### PR TITLE
feat: Add Windows x86 and Linux armv7 Support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release Build
 on:
   workflow_dispatch:
   push:
-    # tags:
-    #   - v**
+    tags:
+      - v**
 
 env:
   CARGO_INCREMENTAL: 0
@@ -30,11 +30,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: armv7-unknown-linux-gnueabihf
+          # - os: ubuntu-latest
+          #   target: armv7-unknown-linux-gnueabihf
 
     runs-on: ${{ matrix.os }}
-    # if: startsWith(github.repository, 'wonfen')
+    if: startsWith(github.repository, 'wonfen')
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release Build
 on:
   workflow_dispatch:
   push:
-    tags:
-      - v**
+    # tags:
+    #   - v**
 
 env:
   CARGO_INCREMENTAL: 0
@@ -18,6 +18,8 @@ jobs:
         include:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+          - os: windows-latest
+            target: i686-pc-windows-msvc
           # - os: windows-latest
           #   target: aarch64-pc-windows-msvc
           - os: macos-latest
@@ -28,9 +30,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
 
     runs-on: ${{ matrix.os }}
-    if: startsWith(github.repository, 'wonfen')
+    # if: startsWith(github.repository, 'wonfen')
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -67,14 +71,26 @@ jobs:
       - name: Install Dependencies (Ubuntu Only)
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.target,'aarch64')
         run: |
-          sed 's/mirror+file:\/etc\/apt\/apt-mirrors.txt/[arch-=amd64,i386] http:\/\/ports.ubuntu.com\/ubuntu-ports\//g' /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/ports.list
-          sudo sed -i 's/mirror+file/[arch=amd64,i386] mirror+file/g' /etc/apt/sources.list
+          sed 's/mirror+file:\/etc\/apt\/apt-mirrors.txt/[arch-=amd64] http:\/\/ports.ubuntu.com\/ubuntu-ports\//g' /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/ports.list
+          sudo sed -i 's/mirror+file/[arch=amd64] mirror+file/g' /etc/apt/sources.list
           cat /etc/apt/sources.list
           cat /etc/apt/sources.list.d/ports.list
           sudo dpkg --add-architecture arm64
           sudo apt-get update
           sudo apt-get install -y libncurses6:arm64 libtinfo6:arm64 linux-libc-dev:arm64 libncursesw6:arm64 libssl3:arm64 libcups2:arm64
           sudo apt-get install -y --no-install-recommends g++-aarch64-linux-gnu libc6-dev-arm64-cross libssl-dev:arm64 libwebkit2gtk-4.0-dev:arm64 libgtk-3-dev:arm64 patchelf:arm64 librsvg2-dev:arm64 libayatana-appindicator3-dev:arm64
+
+      - name: Install Dependencies (Ubuntu Only)
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.target,'armv7')
+        run: |
+          sed 's/mirror+file:\/etc\/apt\/apt-mirrors.txt/[arch-=amd64] http:\/\/ports.ubuntu.com\/ubuntu-ports\//g' /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/ports.list
+          sudo sed -i 's/mirror+file/[arch=amd64] mirror+file/g' /etc/apt/sources.list
+          cat /etc/apt/sources.list
+          cat /etc/apt/sources.list.d/ports.list
+          sudo dpkg --add-architecture armhf
+          sudo apt-get update
+          sudo apt-get install -y libncurses6:armhf libtinfo6:armhf linux-libc-dev:armhf libncursesw6:armhf libssl3:armhf libcups2:armhf
+          sudo apt-get install -y --no-install-recommends g++-arm-linux-gnueabihf libc6-dev-armhf-cross libssl-dev:armhf libwebkit2gtk-4.0-dev:armhf libgtk-3-dev:armhf patchelf:armhf librsvg2-dev:armhf libayatana-appindicator3-dev:armhf
 
       - name: Pnpm install and check
         run: |
@@ -108,6 +124,27 @@ jobs:
           CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
           CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
           PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
+          PKG_CONFIG_ALLOW_CROSS: 1
+        with:
+          tagName: v__VERSION__
+          releaseName: "Clash Verge v__VERSION__"
+          releaseBody: "More new features are now supported."
+          releaseDraft: false
+          prerelease: false
+          tauriScript: pnpm
+          args: -f default-meta --target ${{ matrix.target }} -b deb,updater
+
+      - name: Tauri build (Ubuntu Armv7)
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.target,'armv7')
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
+          CC_armv7_unknown_linux_gnueabihf: arm-linux-gnueabihf-gcc
+          CXX_armv7_unknown_linux_gnueabihf: arm-linux-gnueabihf-g++
+          PKG_CONFIG_PATH: /usr/lib/arm-linux-gnueabihf/pkgconfig
           PKG_CONFIG_ALLOW_CROSS: 1
         with:
           tagName: v__VERSION__

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -40,11 +40,13 @@ let META_VERSION;
 
 const META_MAP = {
   "win32-x64": "mihomo-windows-amd64",
+  "win32-ia32": "mihomo-windows-386",
   "win32-arm64": "mihomo-windows-arm64",
   "darwin-x64": "mihomo-darwin-amd64",
   "darwin-arm64": "mihomo-darwin-arm64",
   "linux-x64": "mihomo-linux-amd64",
   "linux-arm64": "mihomo-linux-arm64",
+  "linux-arm": "mihomo-linux-armv7",
 };
 
 /*
@@ -52,19 +54,23 @@ const META_MAP = {
  */
 const PLATFORM_MAP = {
   "x86_64-pc-windows-msvc": "win32",
+  "i686-pc-windows-msvc": "win32",
   "aarch64-pc-windows-msvc": "win32",
   "x86_64-apple-darwin": "darwin",
   "aarch64-apple-darwin": "darwin",
   "x86_64-unknown-linux-gnu": "linux",
   "aarch64-unknown-linux-gnu": "linux",
+  "armv7-unknown-linux-gnueabihf": "linux",
 };
 const ARCH_MAP = {
   "x86_64-pc-windows-msvc": "x64",
+  "i686-pc-windows-msvc": "ia32",
   "aarch64-pc-windows-msvc": "arm64",
   "x86_64-apple-darwin": "x64",
   "aarch64-apple-darwin": "arm64",
   "x86_64-unknown-linux-gnu": "x64",
   "aarch64-unknown-linux-gnu": "arm64",
+  "armv7-unknown-linux-gnueabihf": "arm",
 };
 
 /**

--- a/scripts/updater.mjs
+++ b/scripts/updater.mjs
@@ -54,15 +54,43 @@ async function resolveUpdater() {
     const { name, browser_download_url } = asset;
 
     // win64 url
-    if (name.endsWith(".msi.zip") && name.includes("en-US")) {
+    if (
+      name.endsWith(".msi.zip") &&
+      name.includes("en-US") &&
+      name.includes("x64")
+    ) {
       updateData.platforms.win64.url = browser_download_url;
       updateData.platforms["windows-x86_64"].url = browser_download_url;
     }
     // win64 signature
-    if (name.endsWith(".msi.zip.sig") && name.includes("en-US")) {
+    if (
+      name.endsWith(".msi.zip.sig") &&
+      name.includes("en-US") &&
+      name.includes("x64")
+    ) {
       const sig = await getSignature(browser_download_url);
       updateData.platforms.win64.signature = sig;
       updateData.platforms["windows-x86_64"].signature = sig;
+    }
+
+    // win32 url
+    if (
+      name.endsWith(".msi.zip") &&
+      name.includes("en-US") &&
+      name.includes("x86")
+    ) {
+      updateData.platforms.win64.url = browser_download_url;
+      updateData.platforms["windows-i686"].url = browser_download_url;
+    }
+    // win32 signature
+    if (
+      name.endsWith(".msi.zip.sig") &&
+      name.includes("en-US") &&
+      name.includes("x86")
+    ) {
+      const sig = await getSignature(browser_download_url);
+      updateData.platforms.win64.signature = sig;
+      updateData.platforms["windows-i686"].signature = sig;
     }
 
     // darwin url (intel)
@@ -95,6 +123,7 @@ async function resolveUpdater() {
       updateData.platforms["linux-x86_64"].url = browser_download_url;
       // 暂时使用x64版本的url和sig，使得可以检查更新，但aarch64版本还不支持构建appimage
       updateData.platforms["linux-aarch64"].url = browser_download_url;
+      // updateData.platforms["linux-armv7"].url = browser_download_url;
     }
     // linux signature
     if (name.endsWith(".AppImage.tar.gz.sig")) {
@@ -102,7 +131,8 @@ async function resolveUpdater() {
       updateData.platforms.linux.signature = sig;
       updateData.platforms["linux-x86_64"].signature = sig;
       // 暂时使用x64版本的url和sig，使得可以检查更新，但aarch64版本还不支持构建appimage
-      updateData.platforms["linux-aarch64"].url = browser_download_url;
+      updateData.platforms["linux-aarch64"].signature = sig;
+      // updateData.platforms["linux-armv7"].signature = sig;
     }
   });
 


### PR DESCRIPTION
添加了Windows 32位和Linux armv7支持，但是由于clash-verge所依赖的 [rquickjs](https://github.com/DelSkayn/rquickjs) 暂时还不支持armv7，所以先将相关脚本注释了。

- #25