### PR TITLE
feat: add auto bindgen for quickjs

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ log4rs = "1"
 nanoid = "0.4"
 chrono = "0.4"
 sysinfo = "0.30"
-rquickjs = "0.3" # 高版本不支持 Linux aarch64
+rquickjs = { version = "0.3", features = ["bindgen"] } # 高版本不支持 Linux aarch64
 serde_json = "1.0"
 serde_yaml = "0.9"
 auto-launch = "0.5"


### PR DESCRIPTION
rquickjs only pre-support a few arch.
for others, may use feature-bindgen to auto generate.
see [here](https://github.com/DelSkayn/rquickjs/issues/36)

tested in loong64 archlinux,  with #246 and this, clash-verge can be built successful