### PR TITLE
feat: use url path's name as the default name fallback for subscription import without Content-Disposition header

### DIFF
--- a/src-tauri/src/config/prfitem.rs
+++ b/src-tauri/src/config/prfitem.rs
@@ -261,7 +261,9 @@ impl PrfItem {
                     },
                 }
             }
-            None => None,
+            None => Some(
+                crate::utils::help::get_last_part_and_decode(url).unwrap_or("Remote File".into()),
+            ),
         };
         let option = match update_interval {
             Some(val) => Some(PrfOption {

--- a/src-tauri/src/utils/help.rs
+++ b/src-tauri/src/utils/help.rs
@@ -80,6 +80,19 @@ pub fn parse_str<T: FromStr>(target: &str, key: &str) -> Option<T> {
     })
 }
 
+/// get the last part of the url, if not found, return empty string
+pub fn get_last_part_and_decode(url: &str) -> Option<String> {
+    let path = url.split('?').next().unwrap_or(""); // Splits URL and takes the path part
+    let segments: Vec<&str> = path.split('/').collect();
+    let last_segment = segments.last()?;
+
+    Some(
+        percent_encoding::percent_decode_str(last_segment)
+            .decode_utf8_lossy()
+            .to_string(),
+    )
+}
+
 /// open file
 /// use vscode by default
 pub fn open_file(app: tauri::AppHandle, path: PathBuf) -> Result<()> {


### PR DESCRIPTION
# Feature
- 下拉订阅配置文件时，在服务端没有指定文件名时，使用URL的最后一段作为名称而非'Remote File'，和CFW行为保持一致。