### PR TITLE
Feat: resolves #438 provide a switch for allowing invalid certificates

### DIFF
--- a/src-tauri/src/config/prfitem.rs
+++ b/src-tauri/src/config/prfitem.rs
@@ -219,15 +219,12 @@ impl PrfItem {
             }
         }
 
-        if accept_invalid_certs {
-            builder = builder.danger_accept_invalid_certs(accept_invalid_certs);
-        }
-
         let version = match VERSION.get() {
             Some(v) => format!("clash-verge/v{}", v),
             None => "clash-verge/unknown".to_string(),
         };
 
+        builder = builder.danger_accept_invalid_certs(accept_invalid_certs);
         builder = builder.user_agent(user_agent.unwrap_or(version));
 
         let resp = builder.build()?.get(url).send().await?;

--- a/src-tauri/src/config/prfitem.rs
+++ b/src-tauri/src/config/prfitem.rs
@@ -84,6 +84,12 @@ pub struct PrfOption {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub update_interval: Option<u64>,
+
+    /// for `remote` profile
+    /// disable certificate validation
+    /// default is `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub danger_accept_invalid_certs: Option<bool>,
 }
 
 impl PrfOption {
@@ -93,6 +99,7 @@ impl PrfOption {
                 a.user_agent = b.user_agent.or(a.user_agent);
                 a.with_proxy = b.with_proxy.or(a.with_proxy);
                 a.self_proxy = b.self_proxy.or(a.self_proxy);
+                a.danger_accept_invalid_certs = b.danger_accept_invalid_certs.or(a.danger_accept_invalid_certs);
                 a.update_interval = b.update_interval.or(a.update_interval);
                 Some(a)
             }
@@ -170,6 +177,7 @@ impl PrfItem {
         let opt_ref = option.as_ref();
         let with_proxy = opt_ref.map_or(false, |o| o.with_proxy.unwrap_or(false));
         let self_proxy = opt_ref.map_or(false, |o| o.self_proxy.unwrap_or(false));
+        let accept_invalid_certs = opt_ref.map_or(false, |o| o.danger_accept_invalid_certs.unwrap_or(false));
         let user_agent = opt_ref.and_then(|o| o.user_agent.clone());
         let update_interval = opt_ref.and_then(|o| o.update_interval);
 
@@ -209,6 +217,10 @@ impl PrfItem {
                     builder = builder.proxy(proxy);
                 }
             }
+        }
+
+        if accept_invalid_certs {
+            builder = builder.danger_accept_invalid_certs(accept_invalid_certs);
         }
 
         let version = match VERSION.get() {

--- a/src-tauri/src/utils/resolve.rs
+++ b/src-tauri/src/utils/resolve.rs
@@ -243,6 +243,7 @@ pub async fn resolve_scheme(param: String) {
         user_agent: None,
         with_proxy: Some(true),
         self_proxy: None,
+        danger_accept_invalid_certs: None,
         update_interval: None,
     };
     if let Ok(item) = PrfItem::from_url(url, None, None, Some(option)).await {

--- a/src/components/profile/profile-viewer.tsx
+++ b/src/components/profile/profile-viewer.tsx
@@ -269,6 +269,17 @@ export const ProfileViewer = forwardRef<ProfileViewerRef, Props>(
                 </StyledBox>
               )}
             />
+
+            <Controller
+              name="option.danger_accept_invalid_certs"
+              control={control}
+              render={({ field }) => (
+                <StyledBox>
+                  <InputLabel>{t("Accept Invalid Certs (Danger)")}</InputLabel>
+                  <Switch checked={field.value} {...field} color="primary" />
+                </StyledBox>
+              )}
+            />
           </>
         )}
       </BaseDialog>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -67,7 +67,7 @@
   "Update Interval": "Update Interval",
   "Use System Proxy": "Use System Proxy",
   "Use Clash Proxy": "Use Clash Proxy",
-  "Accept Invalid Certs (Danger)": "Subscription URL allows invalid certificates (Danger)",
+  "Accept Invalid Certs (Danger)": "Allows Invalid Certificates (Danger)",
 
   "Settings": "Settings",
   "Clash Setting": "Clash Setting",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -67,6 +67,7 @@
   "Update Interval": "Update Interval",
   "Use System Proxy": "Use System Proxy",
   "Use Clash Proxy": "Use Clash Proxy",
+  "Accept Invalid Certs (Danger)": "Subscription URL allows invalid certificates (Danger)",
 
   "Settings": "Settings",
   "Clash Setting": "Clash Setting",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -65,6 +65,9 @@
   "Descriptions": "Описания",
   "Subscription URL": "URL подписки",
   "Update Interval": "Интервал обновления",
+  "Use System Proxy": "Использовать системный прокси для обновления",
+  "Use Clash Proxy": "Использовать прокси Clash для обновления",
+  "Accept Invalid Certs (Danger)": "Принимать недействительные сертификаты (Опасно)",
 
   "Settings": "Настройки",
   "Clash Setting": "Настройки Clash",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -67,6 +67,7 @@
   "Update Interval": "更新间隔",
   "Use System Proxy": "使用系统代理更新",
   "Use Clash Proxy": "使用Clash代理更新",
+  "Accept Invalid Certs (Danger)": "订阅链接允许无效证书 (危险)",
 
   "Settings": "设置",
   "Clash Setting": "Clash 设置",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -67,7 +67,7 @@
   "Update Interval": "更新间隔",
   "Use System Proxy": "使用系统代理更新",
   "Use Clash Proxy": "使用Clash代理更新",
-  "Accept Invalid Certs (Danger)": "订阅链接允许无效证书 (危险)",
+  "Accept Invalid Certs (Danger)": "允许无效证书 (危险)",
 
   "Settings": "设置",
   "Clash Setting": "Clash 设置",

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -173,6 +173,7 @@ interface IProfileOption {
   with_proxy?: boolean;
   self_proxy?: boolean;
   update_interval?: number;
+  danger_accept_invalid_certs?: boolean;
 }
 
 interface IProfilesConfig {


### PR DESCRIPTION
For the remote profile, a new parameter 'danger_accept_invalid_certs' is added to allow invalid/expired certificates.

The parameter will be passed to the reqwest ClientBuilder.

Refer to [Reqwest Docs](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.danger_accept_invalid_certs)

Resol