### PR TITLE
fix: Set `REJECT-DROP` policy the same text color as `REJECT`

### DIFF
--- a/src/components/rule/rule-item.tsx
+++ b/src/components/rule/rule-item.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const parseColor = (text: string) => {
-  if (text === "REJECT" or text === "REJECT-DROP") return "error.main";
+  if (text === "REJECT" || text === "REJECT-DROP") return "error.main";
   if (text === "DIRECT") return "text.primary";
 
   let sum = 0;

--- a/src/components/rule/rule-item.tsx
+++ b/src/components/rule/rule-item.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const parseColor = (text: string) => {
-  if (text === "REJECT") return "error.main";
+  if (text === "REJECT" or text === "REJECT-DROP") return "error.main";
   if (text === "DIRECT") return "text.primary";
 
   let sum = 0;


### PR DESCRIPTION
Clash-meta has 2 reject policy, but only standard `REJECT` policy displayed as red color in the rules page.