### PR TITLE
fix: mac setting theme font-famil not working

### DIFF
--- a/src/pages/_theme.tsx
+++ b/src/pages/_theme.tsx
@@ -12,8 +12,8 @@ export const defaultTheme = {
   warning_color: "#FF9500",
   success_color: "#06943D",
   background_color: "#f5f5f5",
-  font_family: `-apple-system, BlinkMacSystemFont,"Microsoft YaHei UI", "Microsoft YaHei", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", ${
-    OS === "windows" ? "twemoji mozilla" : ""
+  font_family: `-apple-system, BlinkMacSystemFont,"Microsoft YaHei UI", "Microsoft YaHei", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji"${
+    OS === "windows" ? ", twemoji mozilla" : ""
   }`,
 };
 


### PR DESCRIPTION
mac端默认使用safair内核，之前的代码，font-family会以`, `结尾，mac用户设置的字体无效生效，之前的bug如图：
<img width="1217" alt="image" src="https://github.com/clash-verge-rev/clash-verge-rev/assets/26453811/16e1fc47-1d72-4e0b-ad97-9a6f055c00fb">

修复后：

<img width="1217" alt="image" src="https://github.com/clash-verge-rev/clash-verge-rev/assets/26453811/2de75e55-42a6-422e-a003-8b96576f155c">

win端无此问题。