### PR TITLE
Style filter input

### DIFF
--- a/src/components/base/base-styled-text-field.tsx
+++ b/src/components/base/base-styled-text-field.tsx
@@ -1,0 +1,20 @@
+import { TextField, type TextFieldProps, styled } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+export const BaseStyledTextField = styled((props: TextFieldProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <TextField
+      hiddenLabel
+      fullWidth
+      size="small"
+      autoComplete="off"
+      variant="outlined"
+      spellCheck="false"
+      placeholder={t("Filter conditions")}
+      sx={{ input: { py: 0.65, px: 1.25 } }}
+      {...props}
+    />
+  );
+});

--- a/src/components/base/base-styled-text-field.tsx
+++ b/src/components/base/base-styled-text-field.tsx
@@ -17,4 +17,8 @@ export const BaseStyledTextField = styled((props: TextFieldProps) => {
       {...props}
     />
   );
-});
+})(({ theme }) => ({
+  "& .MuiInputBase-root": {
+    background: theme.palette.mode === "light" ? "#fff" : undefined,
+  },
+}));

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -1,14 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useLockFn } from "ahooks";
-import {
-  Box,
-  Button,
-  IconButton,
-  MenuItem,
-  Paper,
-  Select,
-  TextField,
-} from "@mui/material";
+import { Box, Button, IconButton, MenuItem, Select } from "@mui/material";
 import { useRecoilState } from "recoil";
 import { Virtuoso } from "react-virtuoso";
 import { useTranslation } from "react-i18next";
@@ -26,6 +18,7 @@ import {
 } from "@/components/connection/connection-detail";
 import parseTraffic from "@/utils/parse-traffic";
 import { useCustomTheme } from "@/components/layout/use-custom-theme";
+import { BaseStyledTextField } from "@/components/base/base-styled-text-field";
 
 const initConn = { uploadTotal: 0, downloadTotal: 0, connections: [] };
 
@@ -185,17 +178,9 @@ const ConnectionsPage = () => {
           </Select>
         )}
 
-        <TextField
-          hiddenLabel
-          fullWidth
-          size="small"
-          autoComplete="off"
-          spellCheck="false"
-          variant="outlined"
-          placeholder={t("Filter conditions")}
+        <BaseStyledTextField
           value={filterText}
           onChange={(e) => setFilterText(e.target.value)}
-          sx={{ input: { py: 0.65, px: 1.25 } }}
         />
       </Box>
 

--- a/src/pages/logs.tsx
+++ b/src/pages/logs.tsx
@@ -5,9 +5,8 @@ import {
   Button,
   IconButton,
   MenuItem,
-  Paper,
   Select,
-  TextField,
+  SelectProps,
 } from "@mui/material";
 import { Virtuoso } from "react-virtuoso";
 import { useTranslation } from "react-i18next";
@@ -19,6 +18,23 @@ import { atomEnableLog, atomLogData } from "@/services/states";
 import { BaseEmpty, BasePage } from "@/components/base";
 import LogItem from "@/components/log/log-item";
 import { useCustomTheme } from "@/components/layout/use-custom-theme";
+import { BaseStyledTextField } from "@/components/base/base-styled-text-field";
+
+const StyledSelect = (props: SelectProps<string>) => {
+  return (
+    <Select
+      size="small"
+      autoComplete="off"
+      sx={{
+        width: 120,
+        height: 33.375,
+        mr: 1,
+        '[role="button"]': { py: 0.65 },
+      }}
+      {...props}
+    />
+  );
+};
 
 const LogPage = () => {
   const { t } = useTranslation();
@@ -77,35 +93,19 @@ const LogPage = () => {
           alignItems: "center",
         }}
       >
-        <Select
-          size="small"
-          autoComplete="off"
+        <StyledSelect
           value={logState}
           onChange={(e) => setLogState(e.target.value)}
-          sx={{
-            width: 120,
-            height: 33.375,
-            mr: 1,
-            '[role="button"]': { py: 0.65 },
-          }}
         >
           <MenuItem value="all">ALL</MenuItem>
           <MenuItem value="inf">INFO</MenuItem>
           <MenuItem value="warn">WARN</MenuItem>
           <MenuItem value="err">ERROR</MenuItem>
-        </Select>
+        </StyledSelect>
 
-        <TextField
-          hiddenLabel
-          fullWidth
-          size="small"
-          autoComplete="off"
-          spellCheck="false"
-          variant="outlined"
-          placeholder={t("Filter conditions")}
+        <BaseStyledTextField
           value={filterText}
           onChange={(e) => setFilterText(e.target.value)}
-          sx={{ input: { py: 0.65, px: 1.25 } }}
         />
       </Box>
 

--- a/src/pages/logs.tsx
+++ b/src/pages/logs.tsx
@@ -7,6 +7,7 @@ import {
   MenuItem,
   Select,
   SelectProps,
+  styled,
 } from "@mui/material";
 import { Virtuoso } from "react-virtuoso";
 import { useTranslation } from "react-i18next";
@@ -20,7 +21,7 @@ import LogItem from "@/components/log/log-item";
 import { useCustomTheme } from "@/components/layout/use-custom-theme";
 import { BaseStyledTextField } from "@/components/base/base-styled-text-field";
 
-const StyledSelect = (props: SelectProps<string>) => {
+const StyledSelect = styled((props: SelectProps<string>) => {
   return (
     <Select
       size="small"
@@ -34,7 +35,9 @@ const StyledSelect = (props: SelectProps<string>) => {
       {...props}
     />
   );
-};
+})(({ theme }) => ({
+  background: theme.palette.mode === "light" ? "#fff" : undefined,
+}));
 
 const LogPage = () => {
   const { t } = useTranslation();

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -2,15 +2,7 @@ import useSWR, { mutate } from "swr";
 import { useMemo, useRef, useState } from "react";
 import { useLockFn } from "ahooks";
 import { useSetRecoilState } from "recoil";
-import {
-  Box,
-  Button,
-  Grid,
-  IconButton,
-  Stack,
-  TextField,
-  Divider,
-} from "@mui/material";
+import { Box, Button, Grid, IconButton, Stack, Divider } from "@mui/material";
 import {
   DndContext,
   closestCenter,
@@ -56,6 +48,7 @@ import { ConfigViewer } from "@/components/setting/mods/config-viewer";
 import { throttle } from "lodash-es";
 import { useRecoilState } from "recoil";
 import { atomThemeMode } from "@/services/states";
+import { BaseStyledTextField } from "@/components/base/base-styled-text-field";
 
 const ProfilePage = () => {
   const { t } = useTranslation();
@@ -299,16 +292,10 @@ const ProfilePage = () => {
           alignItems: "center",
         }}
       >
-        <TextField
-          hiddenLabel
-          fullWidth
-          size="small"
+        <BaseStyledTextField
           value={url}
           variant="outlined"
-          autoComplete="off"
-          spellCheck="false"
           onChange={(e) => setUrl(e.target.value)}
-          sx={{ input: { py: 0.65, px: 1.25 } }}
           placeholder={t("Profile URL")}
           InputProps={{
             sx: { pr: 1 },

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -2,12 +2,13 @@ import useSWR from "swr";
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Virtuoso } from "react-virtuoso";
-import { Box, TextField } from "@mui/material";
+import { Box } from "@mui/material";
 import { getRules } from "@/services/api";
 import { BaseEmpty, BasePage } from "@/components/base";
 import RuleItem from "@/components/rule/rule-item";
 import { ProviderButton } from "@/components/rule/provider-button";
 import { useCustomTheme } from "@/components/layout/use-custom-theme";
+import { BaseStyledTextField } from "@/components/base/base-styled-text-field";
 
 const RulesPage = () => {
   const { t } = useTranslation();
@@ -41,17 +42,9 @@ const RulesPage = () => {
           alignItems: "center",
         }}
       >
-        <TextField
-          hiddenLabel
-          fullWidth
-          size="small"
-          autoComplete="off"
-          variant="outlined"
-          spellCheck="false"
-          placeholder={t("Filter conditions")}
+        <BaseStyledTextField
           value={filterText}
           onChange={(e) => setFilterText(e.target.value)}
-          sx={{ input: { py: 0.65, px: 1.25 } }}
         />
       </Box>
 


### PR DESCRIPTION
1. 减少重复的代码
2. 过滤输入框在浅色主题时增加白色背景，避免文字太浅不易看清
修改前
<img width="502" alt="image" src="https://github.com/clash-verge-rev/clash-verge-rev/assets/3208016/ca1379fc-6147-44bb-847e-0fe10268ebcc">
修改后
<img width="582" alt="image" src="https://github.com/clash-verge-rev/clash-verge-rev/assets/3208016/7a177c05-a589-4577-94c8-0a4a9f1ad786">
