### PR TITLE
fix:  #730 icon not change when the window is opened maximized

### DIFF
--- a/src/components/layout/layout-control.tsx
+++ b/src/components/layout/layout-control.tsx
@@ -8,18 +8,29 @@ import {
   PushPinOutlined,
   PushPinRounded,
 } from "@mui/icons-material";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export const LayoutControl = () => {
   const minWidth = 40;
 
   const [isMaximized, setIsMaximized] = useState(false);
   const [isPined, setIsPined] = useState(false);
-  appWindow.onResized(() => {
-    appWindow.isMaximized().then((isMaximized) => {
-      setIsMaximized(() => isMaximized);
+
+  useEffect(() => {
+    const unlistenResized = appWindow.onResized(() => {
+      appWindow.isMaximized().then((maximized) => {
+        setIsMaximized(() => maximized);
+      });
     });
-  });
+
+    appWindow.isMaximized().then((maximized) => {
+      setIsMaximized(() => maximized);
+    });
+
+    return () => {
+      unlistenResized.then((fn) => fn());
+    };
+  }, []);
 
   return (
     <ButtonGroup


### PR DESCRIPTION
补充修正 #730中提到的问题，即窗口以最大化状态关闭后，下次打开窗口时窗口为最大化状态，但按钮图标显示不正确的问题。增加了对isMaximized的初始化。