### PR TITLE
fix: disable left click menu on macOS

### DIFF
--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -3,7 +3,8 @@
   "tauri": {
     "systemTray": {
       "iconPath": "icons/mac-tray-icon.png",
-      "iconAsTemplate": true
+      "iconAsTemplate": true,
+      "menuOnLeftClick": false
     },
     "bundle": {
       "identifier": "io.github.clash-verge-rev.clash-verge-rev",


### PR DESCRIPTION
Left-clicking on the system tray icon on macOS would open both the application panel and the menu. 
This PR avoids showing menu on left click.