### PR TITLE
chore: disable WebView keyboard shortcuts

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,11 @@ if (!container) {
   );
 }
 
+document.addEventListener("keydown", (event) => {
+  // Disable WebView keyboard shortcuts
+  event.preventDefault();
+});
+
 createRoot(container).render(
   <React.StrictMode>
     <RecoilRoot>


### PR DESCRIPTION
- 关闭WebView默认的快捷键（例如：F5、CTRL+F搜索、CTRL+H、CTRL+R刷新），防止与编辑器快捷键产生冲突
- CTRL+SHIFT+I不受影响，依旧可以呼出DEV控制台
- 程序热键配置的快捷键不受影响