### PR TITLE
fix: use tauri clipboard

### DIFF
--- a/src-tauri/src/utils/resolve.rs
+++ b/src-tauri/src/utils/resolve.rs
@@ -193,11 +193,11 @@ pub fn create_window(app_handle: &AppHandle) {
                 }
                 Ok(center)
             })();
-
             if center.unwrap_or(true) {
                 trace_err!(win.center(), "set win center");
             }
 
+            #[cfg(not(target_os = "linux"))]
             trace_err!(set_shadow(&win, true), "set win shadow");
             if is_maximized {
                 trace_err!(win.maximize(), "set win maximize");

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -52,6 +52,7 @@ import { atomThemeMode } from "@/services/states";
 import { BaseStyledTextField } from "@/components/base/base-styled-text-field";
 import { listen } from "@tauri-apps/api/event";
 import { readTextFile } from "@tauri-apps/api/fs";
+import { readText } from "@tauri-apps/api/clipboard";
 
 const ProfilePage = () => {
   const { t } = useTranslation();
@@ -267,7 +268,7 @@ const ProfilePage = () => {
   });
 
   const onCopyLink = async () => {
-    const text = await navigator.clipboard.readText();
+    const text = await readText();
     if (text) setUrl(text);
   };
   const [mode] = useRecoilState(atomThemeMode);


### PR DESCRIPTION
- 在我的 Linux (Debian 12, Gnome) 上，无法使用粘贴按钮进行剪贴板的粘贴，使用 tauri 的 clipboard 就没问题

- Linux 上不支持 `set_shadow`  方法