### PR TITLE
refactor: use sortablejs to implement drag and sort

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.1.0",
-    "@dnd-kit/sortable": "^8.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@juggle/resize-observer": "^3.4.0",
@@ -30,6 +27,7 @@
     "@mui/x-data-grid": "^6.19.11",
     "@tauri-apps/api": "^1.5.4",
     "@types/json-schema": "^7.0.15",
+    "@types/sortablejs": "^1.15.8",
     "ahooks": "^3.7.11",
     "axios": "^1.6.8",
     "axios-tauri-api-adapter": "^0.2.1",
@@ -39,7 +37,6 @@
     "meta-json-schema": "1.18.5-alpha",
     "monaco-editor": "^0.48.0",
     "monaco-yaml": "^5.1.1",
-    "types-pac": "^1.0.2",
     "nanoid": "^5.0.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -48,11 +45,14 @@
     "react-i18next": "^13.5.0",
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.23.0",
+    "react-sortablejs": "^6.1.4",
     "react-transition-group": "^4.4.5",
     "react-virtuoso": "^4.7.10",
     "recoil": "^0.7.7",
+    "sortablejs": "^1.15.2",
     "swr": "^1.3.0",
-    "tar": "^6.2.1"
+    "tar": "^6.2.1",
+    "types-pac": "^1.0.2"
   },
   "devDependencies": {
     "@actions/github": "^5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,15 +7,6 @@ settings:
 importers:
   .:
     dependencies:
-      "@dnd-kit/core":
-        specifier: ^6.1.0
-        version: 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@dnd-kit/sortable":
-        specifier: ^8.0.0
-        version: 8.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      "@dnd-kit/utilities":
-        specifier: ^3.2.2
-        version: 3.2.2(react@18.3.1)
       "@emotion/react":
         specifier: ^11.11.4
         version: 11.11.4(@types/react@18.3.1)(react@18.3.1)
@@ -43,6 +34,9 @@ importers:
       "@types/json-schema":
         specifier: ^7.0.15
         version: 7.0.15
+      "@types/sortablejs":
+        specifier: ^1.15.8
+        version: 1.15.8
       ahooks:
         specifier: ^3.7.11
         version: 3.7.11(react@18.3.1)
@@ -94,6 +88,9 @@ importers:
       react-router-dom:
         specifier: ^6.23.0
         version: 6.23.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-sortablejs:
+        specifier: ^6.1.4
+        version: 6.1.4(@types/sortablejs@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sortablejs@1.15.2)
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -103,6 +100,9 @@ importers:
       recoil:
         specifier: ^0.7.7
         version: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sortablejs:
+        specifier: ^1.15.2
+        version: 1.15.2
       swr:
         specifier: ^1.3.0
         version: 1.3.0(react@18.3.1)
@@ -153,8 +153,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       husky:
-        specifier: ^7.0.4
-        version: 7.0.4
+        specifier: ^9.0.11
+        version: 9.0.11
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -381,40 +381,6 @@ packages:
         integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==,
       }
     engines: { node: ">=6.9.0" }
-
-  "@dnd-kit/accessibility@3.1.0":
-    resolution:
-      {
-        integrity: sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==,
-      }
-    peerDependencies:
-      react: ">=16.8.0"
-
-  "@dnd-kit/core@6.1.0":
-    resolution:
-      {
-        integrity: sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==,
-      }
-    peerDependencies:
-      react: ">=16.8.0"
-      react-dom: ">=16.8.0"
-
-  "@dnd-kit/sortable@8.0.0":
-    resolution:
-      {
-        integrity: sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==,
-      }
-    peerDependencies:
-      "@dnd-kit/core": ^6.1.0
-      react: ">=16.8.0"
-
-  "@dnd-kit/utilities@3.2.2":
-    resolution:
-      {
-        integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==,
-      }
-    peerDependencies:
-      react: ">=16.8.0"
 
   "@emotion/babel-plugin@11.11.0":
     resolution:
@@ -1529,6 +1495,12 @@ packages:
         integrity: sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==,
       }
 
+  "@types/sortablejs@1.15.8":
+    resolution:
+      {
+        integrity: sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==,
+      }
+
   "@types/unist@2.0.10":
     resolution:
       {
@@ -1735,6 +1707,12 @@ packages:
         integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==,
       }
     engines: { node: ">=10" }
+
+  classnames@2.3.1:
+    resolution:
+      {
+        integrity: sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==,
+      }
 
   clsx@2.1.1:
     resolution:
@@ -2153,12 +2131,12 @@ packages:
       }
     engines: { node: ">=8.12.0" }
 
-  husky@7.0.4:
+  husky@9.0.11:
     resolution:
       {
-        integrity: sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==,
+        integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==,
       }
-    engines: { node: ">=12" }
+    engines: { node: ">=18" }
     hasBin: true
 
   i18next@23.11.3:
@@ -3014,6 +2992,17 @@ packages:
     peerDependencies:
       react: ">=16.8"
 
+  react-sortablejs@6.1.4:
+    resolution:
+      {
+        integrity: sha512-fc7cBosfhnbh53Mbm6a45W+F735jwZ1UFIYSrIqcO/gRIFoDyZeMtgKlpV4DdyQfbCzdh5LoALLTDRxhMpTyXQ==,
+      }
+    peerDependencies:
+      "@types/sortablejs": "1"
+      react: ">=16.9.0"
+      react-dom: ">=16.9.0"
+      sortablejs: "1"
+
   react-transition-group@4.4.5:
     resolution:
       {
@@ -3174,6 +3163,12 @@ packages:
         integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==,
       }
 
+  sortablejs@1.15.2:
+    resolution:
+      {
+        integrity: sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA==,
+      }
+
   source-map-js@1.2.0:
     resolution:
       {
@@ -3253,6 +3248,12 @@ packages:
         integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==,
       }
     engines: { node: ">=10" }
+
+  tiny-invariant@1.2.0:
+    resolution:
+      {
+        integrity: sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==,
+      }
 
   to-fast-properties@2.0.0:
     resolution:
@@ -3720,31 +3721,6 @@ snapshots:
       "@babel/helper-string-parser": 7.24.1
       "@babel/helper-validator-identifier": 7.24.5
       to-fast-properties: 2.0.0
-
-  "@dnd-kit/accessibility@3.1.0(react@18.3.1)":
-    dependencies:
-      react: 18.3.1
-      tslib: 2.6.2
-
-  "@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)":
-    dependencies:
-      "@dnd-kit/accessibility": 3.1.0(react@18.3.1)
-      "@dnd-kit/utilities": 3.2.2(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.6.2
-
-  "@dnd-kit/sortable@8.0.0(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)":
-    dependencies:
-      "@dnd-kit/core": 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      "@dnd-kit/utilities": 3.2.2(react@18.3.1)
-      react: 18.3.1
-      tslib: 2.6.2
-
-  "@dnd-kit/utilities@3.2.2(react@18.3.1)":
-    dependencies:
-      react: 18.3.1
-      tslib: 2.6.2
 
   "@emotion/babel-plugin@11.11.0":
     dependencies:
@@ -4404,6 +4380,8 @@ snapshots:
       "@types/prop-types": 15.7.12
       csstype: 3.1.3
 
+  "@types/sortablejs@1.15.8": {}
+
   "@types/unist@2.0.10": {}
 
   "@types/unist@3.0.2": {}
@@ -4533,6 +4511,8 @@ snapshots:
       fsevents: 2.3.3
 
   chownr@2.0.0: {}
+
+  classnames@2.3.1: {}
 
   clsx@2.1.1: {}
 
@@ -4785,7 +4765,7 @@ snapshots:
 
   human-signals@1.1.1: {}
 
-  husky@7.0.4: {}
+  husky@9.0.11: {}
 
   i18next@23.11.3:
     dependencies:
@@ -5356,6 +5336,15 @@ snapshots:
       "@remix-run/router": 1.16.0
       react: 18.3.1
 
+  react-sortablejs@6.1.4(@types/sortablejs@1.15.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sortablejs@1.15.2):
+    dependencies:
+      "@types/sortablejs": 1.15.8
+      classnames: 2.3.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      sortablejs: 1.15.2
+      tiny-invariant: 1.2.0
+
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       "@babel/runtime": 7.24.5
@@ -5467,6 +5456,8 @@ snapshots:
       dot-case: 3.0.4
       tslib: 2.6.2
 
+  sortablejs@1.15.2: {}
+
   source-map-js@1.2.0: {}
 
   source-map@0.5.7: {}
@@ -5506,6 +5497,8 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+
+  tiny-invariant@1.2.0: {}
 
   to-fast-properties@2.0.0: {}
 

--- a/src-tauri/src/utils/resolve.rs
+++ b/src-tauri/src/utils/resolve.rs
@@ -12,7 +12,6 @@ use serde_yaml::Mapping;
 use std::net::TcpListener;
 use tauri::api::notification;
 use tauri::{App, AppHandle, Manager};
-use window_shadows::set_shadow;
 
 pub static VERSION: OnceCell<String> = OnceCell::new();
 
@@ -198,7 +197,10 @@ pub fn create_window(app_handle: &AppHandle) {
             }
 
             #[cfg(not(target_os = "linux"))]
-            trace_err!(set_shadow(&win, true), "set win shadow");
+            {
+                use window_shadows::set_shadow;
+                trace_err!(set_shadow(&win, true), "set win shadow");
+            }
             if is_maximized {
                 trace_err!(win.maximize(), "set win maximize");
             }

--- a/src/assets/styles/page.scss
+++ b/src/assets/styles/page.scss
@@ -47,4 +47,12 @@
       }
     }
   }
+
+  // sortablejs drag style
+  .sortable-drag {
+    opacity: 0.8;
+  }
+  .sortable-ghost > .MuiBox-root {
+    background-color: var(--background-color-alpha) !important;
+  }
 }

--- a/src/components/profile/profile-item.tsx
+++ b/src/components/profile/profile-item.tsx
@@ -4,8 +4,6 @@ import { useEffect, useState } from "react";
 import { useLockFn } from "ahooks";
 import { useRecoilState } from "recoil";
 import { useTranslation } from "react-i18next";
-import { useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 import {
   Box,
   Typography,
@@ -41,8 +39,6 @@ interface Props {
 
 export const ProfileItem = (props: Props) => {
   const { selected, activating, itemData, onSelect, onEdit } = props;
-  const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id: props.id });
 
   const { t } = useTranslation();
   const [anchorEl, setAnchorEl] = useState<any>(null);
@@ -213,8 +209,10 @@ export const ProfileItem = (props: Props) => {
   return (
     <Box
       sx={{
-        transform: CSS.Transform.toString(transform),
-        transition,
+        display: "flex",
+        flexGrow: "1",
+        margin: "5px",
+        width: "260px",
       }}
     >
       <ProfileBox
@@ -247,22 +245,6 @@ export const ProfileItem = (props: Props) => {
         )}
         <Box position="relative">
           <Box sx={{ display: "flex", justifyContent: "start" }}>
-            <Box
-              ref={setNodeRef}
-              sx={{ display: "flex", margin: "auto 0" }}
-              {...attributes}
-              {...listeners}
-            >
-              <DragIndicator
-                sx={[
-                  { cursor: "move", marginLeft: "-6px" },
-                  ({ palette: { text } }) => {
-                    return { color: text.primary };
-                  },
-                ]}
-              />
-            </Box>
-
             <Typography
               width="calc(100% - 36px)"
               sx={{ fontSize: "18px", fontWeight: "600", lineHeight: "26px" }}

--- a/src/components/profile/profile-item.tsx
+++ b/src/components/profile/profile-item.tsx
@@ -14,7 +14,7 @@ import {
   Menu,
   CircularProgress,
 } from "@mui/material";
-import { RefreshRounded, DragIndicator } from "@mui/icons-material";
+import { RefreshRounded } from "@mui/icons-material";
 import { atomLoadingCache } from "@/services/states";
 import { updateProfile, deleteProfile, viewProfile } from "@/services/cmds";
 import { Notice } from "@/components/base";
@@ -35,10 +35,12 @@ interface Props {
   itemData: IProfileItem;
   onSelect: (force: boolean) => void;
   onEdit: () => void;
+  onReactivate: () => void;
 }
 
 export const ProfileItem = (props: Props) => {
-  const { selected, activating, itemData, onSelect, onEdit } = props;
+  const { selected, activating, itemData, onSelect, onEdit, onReactivate } =
+    props;
 
   const { t } = useTranslation();
   const [anchorEl, setAnchorEl] = useState<any>(null);
@@ -372,6 +374,11 @@ export const ProfileItem = (props: Props) => {
         language="yaml"
         schema="clash"
         onClose={() => setFileOpen(false)}
+        onChange={() => {
+          if (selected) {
+            onReactivate();
+          }
+        }}
       />
       <ConfirmViewer
         title="Confirm deletion"

--- a/src/components/profile/profile-more.tsx
+++ b/src/components/profile/profile-more.tsx
@@ -24,7 +24,6 @@ interface Props {
   selected: boolean;
   reactivating: boolean;
   itemData: IProfileItem;
-  enableNum: number;
   logInfo?: [string, string][];
   onEnable: () => Promise<void>;
   onDisable: () => Promise<void>;
@@ -39,7 +38,6 @@ export const ProfileMore = (props: Props) => {
     selected,
     reactivating,
     itemData,
-    enableNum,
     logInfo = [],
     onEnable,
     onDisable,

--- a/src/components/test/test-item.tsx
+++ b/src/components/test/test-item.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from "react";
 import { useLockFn } from "ahooks";
 import { useTranslation } from "react-i18next";
-import { useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 import {
   Box,
   Typography,
@@ -32,8 +30,6 @@ let eventListener: UnlistenFn | null = null;
 
 export const TestItem = (props: Props) => {
   const { itemData, onEdit, onDelete: onDeleteItem } = props;
-  const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id: props.id });
 
   const { t } = useTranslation();
   const [anchorEl, setAnchorEl] = useState<any>(null);
@@ -99,8 +95,10 @@ export const TestItem = (props: Props) => {
   return (
     <Box
       sx={{
-        transform: CSS.Transform.toString(transform),
-        transition,
+        display: "flex",
+        flexGrow: "1",
+        margin: "5px",
+        width: "180px",
       }}
     >
       <TestBox
@@ -111,13 +109,7 @@ export const TestItem = (props: Props) => {
           event.preventDefault();
         }}
       >
-        <Box
-          position="relative"
-          sx={{ cursor: "move" }}
-          ref={setNodeRef}
-          {...attributes}
-          {...listeners}
-        >
+        <Box position="relative" sx={{ cursor: "move" }}>
           {icon && icon.trim() !== "" ? (
             <Box sx={{ display: "flex", justifyContent: "center" }}>
               {icon.trim().startsWith("http") && (

--- a/src/components/test/test-viewer.tsx
+++ b/src/components/test/test-viewer.tsx
@@ -39,7 +39,7 @@ export const TestViewer = forwardRef<TestViewerRef, Props>((props, ref) => {
       }
       return x;
     });
-    await patchVerge({ ...verge, test_list: newList });
+    await patchVerge({ test_list: newList });
   };
 
   useImperativeHandle(ref, () => ({
@@ -76,7 +76,6 @@ export const TestViewer = forwardRef<TestViewerRef, Props>((props, ref) => {
         } else {
           if (!form.uid) throw new Error("UID not found");
           uid = form.uid;
-
           await patchTestList(uid, form);
           props.onChange(uid, form);
         }

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -107,7 +107,7 @@ const ProfilePage = () => {
   const configRef = useRef<DialogRef>(null);
 
   // distinguish type
-  const { regularItems, enhanceItems } = useMemo(() => {
+  const { regularItems } = useMemo(() => {
     const items = profiles.items || [];
     const chain = profiles.chain || [];
 
@@ -138,7 +138,7 @@ const ProfilePage = () => {
 
     setSortableProfileList(regularItems);
     setSortableChainList(enhanceItems);
-    return { regularItems, enhanceItems };
+    return { regularItems };
   }, [profiles]);
 
   const onImport = async () => {
@@ -491,7 +491,7 @@ const ProfilePage = () => {
           ))}
         </ReactSortable>
 
-        {enhanceItems.length > 0 && (
+        {sortableChainList.length > 0 && (
           <Divider
             variant="middle"
             flexItem

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -3,19 +3,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useLockFn } from "ahooks";
 import { useSetRecoilState } from "recoil";
 import { Box, Button, Grid, IconButton, Stack, Divider } from "@mui/material";
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  DragEndEvent,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-} from "@dnd-kit/sortable";
 import { LoadingButton } from "@mui/lab";
 import {
   ClearRounded,
@@ -53,6 +40,12 @@ import { BaseStyledTextField } from "@/components/base/base-styled-text-field";
 import { listen } from "@tauri-apps/api/event";
 import { readTextFile } from "@tauri-apps/api/fs";
 import { readText } from "@tauri-apps/api/clipboard";
+import { MoveEvent, ReactSortable, SortableEvent } from "react-sortablejs";
+
+type ISortableItem = {
+  id: string;
+  profileItem: IProfileItem;
+};
 
 const ProfilePage = () => {
   const { t } = useTranslation();
@@ -61,12 +54,13 @@ const ProfilePage = () => {
   const [disabled, setDisabled] = useState(false);
   const [activating, setActivating] = useState("");
   const [loading, setLoading] = useState(false);
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
+  const [sortableProfileList, setSortableProfileList] = useState<
+    ISortableItem[]
+  >([]);
+  const [sortableChainList, setSortableChainList] = useState<ISortableItem[]>(
+    []
   );
+  const [reactivating, setReactivating] = useState(false);
 
   useEffect(() => {
     const unlisten = listen("tauri://file-drop", async (event) => {
@@ -120,14 +114,30 @@ const ProfilePage = () => {
     const type1 = ["local", "remote"];
     const type2 = ["merge", "script"];
 
-    const regularItems = items.filter((i) => i && type1.includes(i.type!));
-    const restItems = items.filter((i) => i && type2.includes(i.type!));
-    const restMap = Object.fromEntries(restItems.map((i) => [i.uid, i]));
+    const regularItems = items
+      .filter((i) => i && type1.includes(i.type!))
+      .map((item) => {
+        return {
+          id: item.uid,
+          profileItem: item,
+        } as ISortableItem;
+      });
+    const restItems = items
+      .filter((i) => i && type2.includes(i.type!))
+      .map((item) => {
+        return {
+          id: item.uid,
+          profileItem: item,
+        } as ISortableItem;
+      });
+    const restMap = Object.fromEntries(restItems.map((i) => [i.id, i]));
     const enhanceItems = chain
       .map((i) => restMap[i]!)
       .filter(Boolean)
-      .concat(restItems.filter((i) => !chain.includes(i.uid)));
+      .concat(restItems.filter((i) => !chain.includes(i.id)));
 
+    setSortableProfileList(regularItems);
+    setSortableChainList(enhanceItems);
     return { regularItems, enhanceItems };
   }, [profiles]);
 
@@ -161,13 +171,22 @@ const ProfilePage = () => {
     }
   };
 
-  const onDragEnd = async (event: DragEndEvent) => {
-    const { active, over } = event;
-    if (over) {
-      if (active.id !== over.id) {
-        await reorderProfile(active.id.toString(), over.id.toString());
-        mutateProfiles();
-      }
+  const handleProfileDragEnd = async (event: SortableEvent) => {
+    const activeId = sortableProfileList[event.oldIndex!].id;
+    const overId = sortableProfileList[event.newIndex!].id;
+    if (activeId !== overId) {
+      await reorderProfile(activeId.toString(), overId.toString());
+      mutateProfiles();
+    }
+  };
+
+  const handleChainDragEnd = async (event: SortableEvent) => {
+    const activeId = sortableChainList[event.oldIndex!].id;
+    if (chain.includes(activeId)) return;
+    const overId = sortableChainList[event.newIndex!].id;
+    if (activeId !== overId) {
+      await reorderProfile(activeId.toString(), overId.toString());
+      mutateProfiles();
     }
   };
 
@@ -189,13 +208,59 @@ const ProfilePage = () => {
     }
   });
 
+  const setChainList = async (newList: ISortableItem[]) => {
+    setSortableChainList(newList);
+    const newChain = newList
+      .filter((item) => chain.includes(item.profileItem.uid))
+      .map((item) => item.profileItem.uid);
+    let needUpdate = false;
+    for (let index = 0; index < chain.length; index++) {
+      const chainId = chain[index];
+      const newChainId = newChain[index];
+      if (chainId !== newChainId) {
+        needUpdate = true;
+        break;
+      }
+    }
+    if (needUpdate && !reactivating) {
+      try {
+        setReactivating(true);
+        await patchProfiles({ chain: newChain });
+        mutateLogs();
+        Notice.success("Refresh clash config", 1000);
+      } catch (err: any) {
+        Notice.error(err.message || err.toString());
+      } finally {
+        setReactivating(false);
+      }
+    }
+  };
+
+  const handleMove = (moveEvt: MoveEvent) => {
+    const { dragged, related } = moveEvt;
+    if (dragged && related) {
+      const draggedType = dragged.classList.contains("enable-enhanced-item");
+      const relatedType = related.classList.contains("enable-enhanced-item");
+      if (draggedType === relatedType) {
+        if (draggedType && reactivating) {
+          return false;
+        }
+        return true;
+      }
+      return false;
+    }
+  };
+
   const onEnhance = useLockFn(async () => {
     try {
+      setReactivating(true);
       await enhanceProfiles();
       mutateLogs();
       Notice.success(t("Profile Reactivated"), 1000);
     } catch (err: any) {
       Notice.error(err.message || err.toString(), 3000);
+    } finally {
+      setReactivating(false);
     }
   });
 
@@ -257,11 +322,11 @@ const ProfilePage = () => {
       setLoadingCache((cache) => {
         // 获取没有正在更新的订阅
         const items = regularItems.filter(
-          (e) => e.type === "remote" && !cache[e.uid]
+          (e) => e.profileItem.type === "remote" && !cache[e.id]
         );
-        const change = Object.fromEntries(items.map((e) => [e.uid, true]));
+        const change = Object.fromEntries(items.map((e) => [e.id, true]));
 
-        Promise.allSettled(items.map((e) => updateOne(e.uid))).then(resolve);
+        Promise.allSettled(items.map((e) => updateOne(e.id))).then(resolve);
         return { ...cache, ...change };
       });
     });
@@ -382,34 +447,49 @@ const ProfilePage = () => {
           overflowY: "auto",
         }}
       >
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={onDragEnd}
+        <ReactSortable
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+          }}
+          animation={150}
+          scrollSensitivity={60}
+          scrollSpeed={10}
+          swapThreshold={0.8}
+          list={sortableProfileList}
+          setList={setSortableProfileList}
+          onEnd={handleProfileDragEnd}
         >
-          <Box sx={{ mb: 1.5 }}>
-            <Grid container spacing={{ xs: 1, lg: 1 }}>
-              <SortableContext
-                items={regularItems.map((x) => {
-                  return x.uid;
-                })}
-              >
-                {regularItems.map((item) => (
-                  <Grid item xs={12} sm={6} md={4} lg={3} key={item.file}>
-                    <ProfileItem
-                      id={item.uid}
-                      selected={profiles.current === item.uid}
-                      activating={activating === item.uid}
-                      itemData={item}
-                      onSelect={(f) => onSelect(item.uid, f)}
-                      onEdit={() => viewerRef.current?.edit(item)}
-                    />
-                  </Grid>
-                ))}
-              </SortableContext>
-            </Grid>
-          </Box>
-        </DndContext>
+          {sortableProfileList.map((item) => (
+            <ProfileItem
+              id={item.profileItem.uid}
+              selected={
+                (activating === "" &&
+                  profiles.current === item.profileItem.uid) ||
+                (activating !== "" && item.profileItem.uid === activating)
+              }
+              activating={
+                activating === item.profileItem.uid ||
+                (profiles.current === item.profileItem.uid && reactivating)
+              }
+              itemData={item.profileItem}
+              onSelect={(f) => onSelect(item.profileItem.uid, f)}
+              onEdit={() => viewerRef.current?.edit(item.profileItem)}
+              // onReactivate={onEnhance}
+            />
+          ))}
+          {[...new Array(20)].map((_) => (
+            <i
+              style={{
+                display: "flex",
+                flexGrow: "1",
+                margin: "0 5px",
+                width: "260px",
+                height: "0",
+              }}
+            ></i>
+          ))}
+        </ReactSortable>
 
         {enhanceItems.length > 0 && (
           <Divider
@@ -419,26 +499,55 @@ const ProfilePage = () => {
           ></Divider>
         )}
 
-        {enhanceItems.length > 0 && (
-          <Box sx={{ mt: 1.5 }}>
-            <Grid container spacing={{ xs: 1, lg: 1 }}>
-              {enhanceItems.map((item) => (
-                <Grid item xs={12} sm={6} md={4} lg={3} key={item.file}>
-                  <ProfileMore
-                    selected={!!chain.includes(item.uid)}
-                    itemData={item}
-                    enableNum={chain.length || 0}
-                    logInfo={chainLogs[item.uid]}
-                    onEnable={() => onEnable(item.uid)}
-                    onDisable={() => onDisable(item.uid)}
-                    onDelete={() => onDelete(item.uid)}
-                    onMoveTop={() => onMoveTop(item.uid)}
-                    onMoveEnd={() => onMoveEnd(item.uid)}
-                    onEdit={() => viewerRef.current?.edit(item)}
-                  />
-                </Grid>
+        {sortableChainList.length > 0 && (
+          <Box>
+            <ReactSortable
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+              }}
+              animation={150}
+              scrollSensitivity={60}
+              scrollSpeed={10}
+              swapThreshold={0.8}
+              list={sortableChainList}
+              setList={setChainList}
+              onMove={handleMove}
+              onEnd={handleChainDragEnd}
+            >
+              {sortableChainList.map((item) => (
+                <ProfileMore
+                  selected={!!chain.includes(item.profileItem.uid)}
+                  reactivating={
+                    !!chain.includes(item.profileItem.uid) &&
+                    (reactivating || activating !== "")
+                  }
+                  itemData={item.profileItem}
+                  enableNum={chain.length || 0}
+                  logInfo={chainLogs[item.profileItem.uid]}
+                  // reactivating={
+                  //   !!chain.includes(item.profileItem.uid) &&
+                  //   (reactivating || activating !== "")
+                  // }
+                  onEnable={() => onEnable(item.profileItem.uid)}
+                  onDisable={() => onDisable(item.profileItem.uid)}
+                  onDelete={() => onDelete(item.profileItem.uid)}
+                  onEdit={() => viewerRef.current?.edit(item.profileItem)}
+                  onActivatedSave={onEnhance}
+                />
               ))}
-            </Grid>
+              {[...new Array(20)].map((_) => (
+                <i
+                  style={{
+                    display: "flex",
+                    flexGrow: "1",
+                    margin: "0 5px",
+                    width: "260px",
+                    height: "0",
+                  }}
+                ></i>
+              ))}
+            </ReactSortable>
           </Box>
         )}
       </Box>

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -211,8 +211,8 @@ const ProfilePage = () => {
   const setChainList = async (newList: ISortableItem[]) => {
     setSortableChainList(newList);
     const newChain = newList
-      .filter((item) => chain.includes(item.profileItem.uid))
-      .map((item) => item.profileItem.uid);
+      .filter((item) => chain.includes(item.id))
+      .map((item) => item.id);
     let needUpdate = false;
     for (let index = 0; index < chain.length; index++) {
       const chainId = chain[index];
@@ -227,7 +227,7 @@ const ProfilePage = () => {
         setReactivating(true);
         await patchProfiles({ chain: newChain });
         mutateLogs();
-        Notice.success("Refresh clash config", 1000);
+        Notice.success(t("Profile Reactivated"), 1000);
       } catch (err: any) {
         Notice.error(err.message || err.toString());
       } finally {
@@ -456,18 +456,17 @@ const ProfilePage = () => {
         >
           {sortableProfileList.map((item) => (
             <ProfileItem
-              id={item.profileItem.uid}
+              id={item.id}
               selected={
-                (activating === "" &&
-                  profiles.current === item.profileItem.uid) ||
-                (activating !== "" && item.profileItem.uid === activating)
+                (activating === "" && profiles.current === item.id) ||
+                activating === item.id
               }
               activating={
-                activating === item.profileItem.uid ||
-                (profiles.current === item.profileItem.uid && reactivating)
+                activating === item.id ||
+                (profiles.current === item.id && reactivating)
               }
               itemData={item.profileItem}
-              onSelect={(f) => onSelect(item.profileItem.uid, f)}
+              onSelect={(f) => onSelect(item.id, f)}
               onEdit={() => viewerRef.current?.edit(item.profileItem)}
               onReactivate={onEnhance}
             />
@@ -489,7 +488,11 @@ const ProfilePage = () => {
           <Divider
             variant="middle"
             flexItem
-            sx={{ width: `calc(100% - 32px)`, borderColor: dividercolor }}
+            sx={{
+              width: `calc(100% - 32px)`,
+              borderColor: dividercolor,
+              my: 1,
+            }}
           ></Divider>
         )}
 
@@ -511,16 +514,16 @@ const ProfilePage = () => {
             >
               {sortableChainList.map((item) => (
                 <ProfileMore
-                  selected={!!chain.includes(item.profileItem.uid)}
+                  selected={!!chain.includes(item.id)}
                   reactivating={
-                    !!chain.includes(item.profileItem.uid) &&
+                    !!chain.includes(item.id) &&
                     (reactivating || activating !== "")
                   }
                   itemData={item.profileItem}
-                  logInfo={chainLogs[item.profileItem.uid]}
-                  onEnable={() => onEnable(item.profileItem.uid)}
-                  onDisable={() => onDisable(item.profileItem.uid)}
-                  onDelete={() => onDelete(item.profileItem.uid)}
+                  logInfo={chainLogs[item.id]}
+                  onEnable={() => onEnable(item.id)}
+                  onDisable={() => onDisable(item.id)}
+                  onDelete={() => onDelete(item.id)}
                   onEdit={() => viewerRef.current?.edit(item.profileItem)}
                   onActivatedSave={onEnhance}
                 />

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -42,10 +42,10 @@ import { readTextFile } from "@tauri-apps/api/fs";
 import { readText } from "@tauri-apps/api/clipboard";
 import { MoveEvent, ReactSortable, SortableEvent } from "react-sortablejs";
 
-type ISortableItem = {
+interface ISortableItem {
   id: string;
   profileItem: IProfileItem;
-};
+}
 
 const ProfilePage = () => {
   const { t } = useTranslation();
@@ -54,12 +54,8 @@ const ProfilePage = () => {
   const [disabled, setDisabled] = useState(false);
   const [activating, setActivating] = useState("");
   const [loading, setLoading] = useState(false);
-  const [sortableProfileList, setSortableProfileList] = useState<
-    ISortableItem[]
-  >([]);
-  const [sortableChainList, setSortableChainList] = useState<ISortableItem[]>(
-    []
-  );
+  const [profileList, setProfileList] = useState<ISortableItem[]>([]);
+  const [chainList, setChainList] = useState<ISortableItem[]>([]);
   const [reactivating, setReactivating] = useState(false);
 
   useEffect(() => {
@@ -136,8 +132,8 @@ const ProfilePage = () => {
       .filter(Boolean)
       .concat(restItems.filter((i) => !chain.includes(i.id)));
 
-    setSortableProfileList(regularItems);
-    setSortableChainList(enhanceItems);
+    setProfileList(regularItems);
+    setChainList(enhanceItems);
     return { regularItems };
   }, [profiles]);
 
@@ -172,8 +168,8 @@ const ProfilePage = () => {
   };
 
   const handleProfileDragEnd = async (event: SortableEvent) => {
-    const activeId = sortableProfileList[event.oldIndex!].id;
-    const overId = sortableProfileList[event.newIndex!].id;
+    const activeId = profileList[event.oldIndex!].id;
+    const overId = profileList[event.newIndex!].id;
     if (activeId !== overId) {
       await reorderProfile(activeId.toString(), overId.toString());
       mutateProfiles();
@@ -181,9 +177,9 @@ const ProfilePage = () => {
   };
 
   const handleChainDragEnd = async (event: SortableEvent) => {
-    const activeId = sortableChainList[event.oldIndex!].id;
+    const activeId = chainList[event.oldIndex!].id;
     if (chain.includes(activeId)) return;
-    const overId = sortableChainList[event.newIndex!].id;
+    const overId = chainList[event.newIndex!].id;
     if (activeId !== overId) {
       await reorderProfile(activeId.toString(), overId.toString());
       mutateProfiles();
@@ -208,8 +204,8 @@ const ProfilePage = () => {
     }
   });
 
-  const setChainList = async (newList: ISortableItem[]) => {
-    setSortableChainList(newList);
+  const setSortableList = async (newList: ISortableItem[]) => {
+    setChainList(newList);
     const newChain = newList
       .filter((item) => chain.includes(item.id))
       .map((item) => item.id);
@@ -450,11 +446,11 @@ const ProfilePage = () => {
           scrollSensitivity={60}
           scrollSpeed={10}
           swapThreshold={0.8}
-          list={sortableProfileList}
-          setList={setSortableProfileList}
+          list={profileList}
+          setList={setProfileList}
           onEnd={handleProfileDragEnd}
         >
-          {sortableProfileList.map((item) => (
+          {profileList.map((item) => (
             <ProfileItem
               id={item.id}
               selected={
@@ -484,7 +480,7 @@ const ProfilePage = () => {
           ))}
         </ReactSortable>
 
-        {sortableChainList.length > 0 && (
+        {chainList.length > 0 && (
           <Divider
             variant="middle"
             flexItem
@@ -496,7 +492,7 @@ const ProfilePage = () => {
           ></Divider>
         )}
 
-        {sortableChainList.length > 0 && (
+        {chainList.length > 0 && (
           <Box>
             <ReactSortable
               style={{
@@ -507,12 +503,12 @@ const ProfilePage = () => {
               scrollSensitivity={60}
               scrollSpeed={10}
               swapThreshold={0.8}
-              list={sortableChainList}
-              setList={setChainList}
+              list={chainList}
+              setList={setSortableList}
               onMove={handleMove}
               onEnd={handleChainDragEnd}
             >
-              {sortableChainList.map((item) => (
+              {chainList.map((item) => (
                 <ProfileMore
                   selected={!!chain.includes(item.id)}
                   reactivating={

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -475,7 +475,7 @@ const ProfilePage = () => {
               itemData={item.profileItem}
               onSelect={(f) => onSelect(item.profileItem.uid, f)}
               onEdit={() => viewerRef.current?.edit(item.profileItem)}
-              // onReactivate={onEnhance}
+              onReactivate={onEnhance}
             />
           ))}
           {[...new Array(20)].map((_) => (

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -113,18 +113,12 @@ const ProfilePage = () => {
     const regularItems = items
       .filter((i) => i && type1.includes(i.type!))
       .map((item) => {
-        return {
-          id: item.uid,
-          profileItem: item,
-        } as ISortableItem;
+        return { id: item.uid, profileItem: item };
       });
     const restItems = items
       .filter((i) => i && type2.includes(i.type!))
       .map((item) => {
-        return {
-          id: item.uid,
-          profileItem: item,
-        } as ISortableItem;
+        return { id: item.uid, profileItem: item };
       });
     const restMap = Object.fromEntries(restItems.map((i) => [i.id, i]));
     const enhanceItems = chain

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -266,16 +266,24 @@ const ProfilePage = () => {
 
   const onEnable = useLockFn(async (uid: string) => {
     if (chain.includes(uid)) return;
-    const newChain = [...chain, uid];
-    await patchProfiles({ chain: newChain });
-    mutateLogs();
+    try {
+      const newChain = [...chain, uid];
+      await patchProfiles({ chain: newChain });
+      mutateLogs();
+    } catch (err: any) {
+      Notice.error(err?.message || err.toString());
+    }
   });
 
   const onDisable = useLockFn(async (uid: string) => {
     if (!chain.includes(uid)) return;
-    const newChain = chain.filter((i) => i !== uid);
-    await patchProfiles({ chain: newChain });
-    mutateLogs();
+    try {
+      const newChain = chain.filter((i) => i !== uid);
+      await patchProfiles({ chain: newChain });
+      mutateLogs();
+    } catch (err: any) {
+      Notice.error(err?.message || err.toString());
+    }
   });
 
   const onDelete = useLockFn(async (uid: string) => {
@@ -287,20 +295,6 @@ const ProfilePage = () => {
     } catch (err: any) {
       Notice.error(err?.message || err.toString());
     }
-  });
-
-  const onMoveTop = useLockFn(async (uid: string) => {
-    if (!chain.includes(uid)) return;
-    const newChain = [uid].concat(chain.filter((i) => i !== uid));
-    await patchProfiles({ chain: newChain });
-    mutateLogs();
-  });
-
-  const onMoveEnd = useLockFn(async (uid: string) => {
-    if (!chain.includes(uid)) return;
-    const newChain = chain.filter((i) => i !== uid).concat([uid]);
-    await patchProfiles({ chain: newChain });
-    mutateLogs();
   });
 
   // 更新所有订阅
@@ -523,12 +517,7 @@ const ProfilePage = () => {
                     (reactivating || activating !== "")
                   }
                   itemData={item.profileItem}
-                  enableNum={chain.length || 0}
                   logInfo={chainLogs[item.profileItem.uid]}
-                  // reactivating={
-                  //   !!chain.includes(item.profileItem.uid) &&
-                  //   (reactivating || activating !== "")
-                  // }
                   onEnable={() => onEnable(item.profileItem.uid)}
                   onDisable={() => onDisable(item.profileItem.uid)}
                   onDelete={() => onDelete(item.profileItem.uid)}

--- a/src/pages/test.tsx
+++ b/src/pages/test.tsx
@@ -41,14 +41,7 @@ const TestPage = () => {
       icon: `<svg enable-background="new 0 0 48 48" height="48" viewBox="0 0 48 48" width="48" xmlns="http://www.w3.org/2000/svg"><path d="m43.611 20.083h-1.611v-.083h-18v8h11.303c-1.649 4.657-6.08 8-11.303 8-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657c-3.572-3.329-8.35-5.382-13.618-5.382-11.045 0-20 8.955-20 20s8.955 20 20 20 20-8.955 20-20c0-1.341-.138-2.65-.389-3.917z" fill="#ffc107"/><path d="m6.306 14.691 6.571 4.819c1.778-4.402 6.084-7.51 11.123-7.51 3.059 0 5.842 1.154 7.961 3.039l5.657-5.657c-3.572-3.329-8.35-5.382-13.618-5.382-7.682 0-14.344 4.337-17.694 10.691z" fill="#ff3d00"/><path d="m24 44c5.166 0 9.86-1.977 13.409-5.192l-6.19-5.238c-2.008 1.521-4.504 2.43-7.219 2.43-5.202 0-9.619-3.317-11.283-7.946l-6.522 5.025c3.31 6.477 10.032 10.921 17.805 10.921z" fill="#4caf50"/><path d="m43.611 20.083h-1.611v-.083h-18v8h11.303c-.792 2.237-2.231 4.166-4.087 5.571.001-.001.002-.001.003-.002l6.19 5.238c-.438.398 6.591-4.807 6.591-14.807 0-1.341-.138-2.65-.389-3.917z" fill="#1976d2"/></svg>`,
     },
   ];
-  const converTestItems = testList.map((x) => {
-    return {
-      id: x.uid,
-      itemData: x,
-    };
-  });
-  const [sortableTestList, setSortableTestList] =
-    useState<ISortableItem[]>(converTestItems);
+  const [sortableTestList, setSortableTestList] = useState<ISortableItem[]>([]);
 
   const onTestListItemChange = (
     uid: string,
@@ -81,6 +74,7 @@ const TestPage = () => {
   };
 
   const handleDragEnd = async (event: SortableEvent) => {
+    if (event.oldIndex === event.newIndex) return;
     let newList = reorder(testList, event.oldIndex!, event.newIndex!);
     await mutateVerge({ ...verge, test_list: newList }, false);
     await patchVerge({ test_list: newList });
@@ -90,16 +84,11 @@ const TestPage = () => {
     if (!verge) return;
     if (!verge?.test_list) {
       patchVerge({ test_list: testList });
-    } else {
-      const converTestItems: ISortableItem[] = verge.test_list.map((x) => {
-        return {
-          id: x.uid,
-          itemData: x,
-          onEdit: () => viewerRef.current?.edit(x),
-        };
-      });
-      setSortableTestList(converTestItems);
     }
+    const converTestItems = (verge.test_list ?? testList).map((x) => {
+      return { id: x.uid, itemData: x };
+    });
+    setSortableTestList(converTestItems);
   }, [verge]);
 
   const viewerRef = useRef<TestViewerRef>(null);
@@ -127,22 +116,12 @@ const TestPage = () => {
         </Box>
       }
     >
-      <Box
-        sx={{
-          pt: 1.25,
-          mb: 0.5,
-          px: "10px",
-        }}
-      >
+      <Box sx={{ pt: 1.25, mb: 0.5, px: "10px" }}>
         <ReactSortable
-          style={{
-            display: "flex",
-            flexWrap: "wrap",
-          }}
+          style={{ display: "flex", flexWrap: "wrap" }}
           animation={150}
-          dragClass="sortable-drag"
           list={sortableTestList}
-          setList={(newList: ISortableItem[]) => setSortableTestList(newList)}
+          setList={setSortableTestList}
           onEnd={handleDragEnd}
         >
           {sortableTestList.map((item) => (


### PR DESCRIPTION
使用简单易上手的 sortablejs 替换 dnd 来实现拖拽排序，并添加以下功能：

- [x] 支持整个 item 鼠标左键拖动排序
- [x] 支持增强文件拖动，仅限同一状态下（已启用/未启用）的增强文件拖动
- [x] 订阅文件保存后，重新激活订阅
- [x] 增强文件保存后，重新激活订阅
- [x] 增强文件启用/禁用/重新激活时，添加动画
- [x] 增强文件启用失败提示错误信息

### Bug 修复
- 测试页面修改 item 信息后导致 clash core 重启

https://github.com/clash-verge-rev/clash-verge-rev/assets/46296997/9e097dec-4990-4362-9bea-1e0f61b9a704
