### PR TITLE
fix: 中文下连接页面的显示问题

### DIFF
--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -7,6 +7,7 @@ import {
   MenuItem,
   Select,
   SelectProps,
+  Typography,
   styled,
 } from "@mui/material";
 import { useRecoilState } from "recoil";
@@ -130,7 +131,7 @@ const ConnectionsPage = () => {
   return (
     <BasePage
       full
-      title={t("Connections")}
+      title={<span style={{ whiteSpace: "nowrap" }}>{t("Connections")}</span>}
       contentStyle={{ height: "100%" }}
       header={
         <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
@@ -159,7 +160,9 @@ const ConnectionsPage = () => {
           </IconButton>
 
           <Button size="small" variant="contained" onClick={onCloseAll}>
-            {t("Close All")}
+            <Typography component="span" style={{ whiteSpace: "nowrap" }}>
+              {t("Close All")}
+            </Typography>
           </Button>
         </Box>
       }


### PR DESCRIPTION
语言使用中文，在宽度小于700px后，连接页面 `连接` 和 `关闭全部`显示如下图，与其他页面不相符：
![image](https://github.com/clash-verge-rev/clash-verge-rev/assets/52861243/b6cdfbc1-0e9f-4d5e-8e76-a9ae53b4ed62)

修改后将 `连接` 和 `关闭全部` 以下图方式显示：
![image](https://github.com/clash-verge-rev/clash-verge-rev/assets/52861243/62b0f61c-33a9-425a-a5a2-c1bb70460998)
