### PR TITLE
refactor: simplify `useConnectionSetting`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ahooks": "^3.8.0",
     "axios": "^1.7.2",
     "dayjs": "1.11.5",
-    "foxact": "^0.2.34",
+    "foxact": "^0.2.35",
     "i18next": "^23.11.5",
     "lodash-es": "^4.17.21",
     "meta-json-schema": "1.18.5-alpha4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: 1.11.5
         version: 1.11.5
       foxact:
-        specifier: ^0.2.34
-        version: 0.2.34(react@18.3.1)
+        specifier: ^0.2.35
+        version: 0.2.35(react@18.3.1)
       i18next:
         specifier: ^23.11.5
         version: 23.11.5
@@ -2842,10 +2842,10 @@ packages:
       }
     engines: { node: ">=12.20.0" }
 
-  foxact@0.2.34:
+  foxact@0.2.35:
     resolution:
       {
-        integrity: sha512-9GrB4NPhTjaJ5pzMkfYFatLGgt5LWq3hhVhYR7zG/PaHhtt3ObOzdRVmmO/whh5E7W8JBykiS6RLtnjeLZLSeg==,
+        integrity: sha512-5e2p34TcBETZTTMhmf4WuljS07lgtv3laimqJer9OGOqYgOpYHgKfR0Cie8Q2IxH1FFhVkm1l0+2W/XL8nBL7Q==,
       }
     peerDependencies:
       react: "*"
@@ -6237,7 +6237,7 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  foxact@0.2.34(react@18.3.1):
+  foxact@0.2.35(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       server-only: 0.0.1

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -5,10 +5,7 @@ import { Virtuoso } from "react-virtuoso";
 import { useTranslation } from "react-i18next";
 import { TableChartRounded, TableRowsRounded } from "@mui/icons-material";
 import { closeAllConnections } from "@/services/api";
-import {
-  defaultConnectionSetting,
-  useConnectionSetting,
-} from "@/services/states";
+import { useConnectionSetting } from "@/services/states";
 import { useClashInfo } from "@/hooks/use-clash";
 import { BaseEmpty, BasePage } from "@/components/base";
 import { useWebsocket } from "@/hooks/use-websocket";
@@ -38,8 +35,7 @@ const ConnectionsPage = () => {
 
   const [setting, setSetting] = useConnectionSetting();
 
-  const isTableLayout =
-    (setting || defaultConnectionSetting).layout === "table";
+  const isTableLayout = setting.layout === "table";
 
   const orderOpts: Record<string, OrderFunc> = {
     Default: (list) =>

--- a/src/services/states.ts
+++ b/src/services/states.ts
@@ -15,7 +15,7 @@ interface IConnectionSetting {
   layout: "table" | "list";
 }
 
-export const defaultConnectionSetting: IConnectionSetting = { layout: "table" };
+const defaultConnectionSetting: IConnectionSetting = { layout: "table" };
 
 export const useConnectionSetting = () =>
   useLocalStorage<IConnectionSetting>(


### PR DESCRIPTION
`useLocalStorage`'s returned state will not be `null` if a default value is provided. The latest version of `foxact` has improved the typescript types to reflect this behavior.