### PR TITLE
perf: replace `Array#map` `Array#filter` chain w/ `Array#reduce`

### DIFF
--- a/src/pages/logs.tsx
+++ b/src/pages/logs.tsx
@@ -24,11 +24,11 @@ const LogPage = () => {
   const [match, setMatch] = useState(() => (_: string) => true);
 
   const filterLogs = useMemo(() => {
-    return logData
-      .filter((data) =>
-        logState === "all" ? true : data.type.includes(logState)
-      )
-      .filter((data) => match(data.payload));
+    return logData.filter(
+      (data) =>
+        (logState === "all" ? true : data.type.includes(logState)) &&
+        match(data.payload)
+    );
   }, [logData, logState, match]);
 
   return (

--- a/src/services/cmds.ts
+++ b/src/services/cmds.ts
@@ -7,23 +7,22 @@ export async function getClashLogs() {
   const newRegex = /(.+?)\s+(.+?)\s+(.+)/;
   const logs = await invoke<string[]>("get_clash_logs");
 
-  return logs
-    .map((log) => {
-      const result = log.match(regex);
-      if (result) {
-        const [_, _time, type, payload] = result;
-        const time = dayjs(_time).format("MM-DD HH:mm:ss");
-        return { time, type, payload };
-      }
+  return logs.reduce<ILogItem[]>((acc, log) => {
+    const result = log.match(regex);
+    if (result) {
+      const [_, _time, type, payload] = result;
+      const time = dayjs(_time).format("MM-DD HH:mm:ss");
+      acc.push({ time, type, payload });
+      return acc;
+    }
 
-      const result2 = log.match(newRegex);
-      if (result2) {
-        const [_, time, type, payload] = result2;
-        return { time, type, payload };
-      }
-      return null;
-    })
-    .filter(Boolean) as ILogItem[];
+    const result2 = log.match(newRegex);
+    if (result2) {
+      const [_, time, type, payload] = result2;
+      acc.push({ time, type, payload });
+    }
+    return acc;
+  }, []);
 }
 
 export async function getProfiles() {


### PR DESCRIPTION
Replace multiple `Array#map` `Array#filter` chains with single `Array#reduce`.

The entire array will be iterated through on every `.map()`, `.filter()`, and `.reduce()` call. By replacing multiple `.map()` and `.filter()` with a single `.reduce()` call, the array will be iterated less frequently, thus improving the performance.

The improvement is most notable on the proxy list and log panel (where arrays' sizes could be huge).