### PR TITLE
fix: hide save button in readonly editor view

### DIFF
--- a/src/components/profile/editor-viewer.tsx
+++ b/src/components/profile/editor-viewer.tsx
@@ -171,12 +171,14 @@ export const EditorViewer = (props: Props) => {
       </DialogContent>
 
       <DialogActions>
-        <Button onClick={onClose} variant="outlined">
+        <Button onClick={onClose} variant={readOnly ? "contained" : "outlined"}>
           {t("Cancel")}
         </Button>
-        <Button onClick={onSave} variant="contained">
-          {t("Save")}
-        </Button>
+        {readOnly ? null : (
+          <Button onClick={onSave} variant="contained">
+            {t("Save")}
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
- Hide the "Save" button when the editor view is read-only
- Make the "Cancel" button the primary color when the editor view is read-only
