### PR TITLE
ci: speed up cargo install by enabling cache (webview2)

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -171,9 +171,15 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          cache-all-crates: true
+          cache-on-failure: true
 
       - name: Install Tauri CLI
-        run: cargo install --git https://github.com/tauri-apps/tauri --branch 1.x tauri-cli
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: tauri-cli
+          git: https://github.com/tauri-apps/tauri
+          branch: 1.x # `branch` and `commit` are also supported
 
       - name: Install Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,11 @@ jobs:
           workspaces: src-tauri
 
       - name: Install Tauri CLI
-        run: cargo install --git https://github.com/tauri-apps/tauri --branch 1.x tauri-cli
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: tauri-cli
+          git: https://github.com/tauri-apps/tauri
+          branch: 1.x # `branch` and `commit` are also supported
 
       - name: Install Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Continues from #1279, enable cache for webview2 as well.