### PR TITLE
style: AddressDisplay padding

### DIFF
--- a/src/components/setting/mods/network-interface-viewer.tsx
+++ b/src/components/setting/mods/network-interface-viewer.tsx
@@ -114,7 +114,7 @@ const AddressDisplay = (props: { label: string; content: string }) => {
       <Box
         sx={({ palette }) => ({
           borderRadius: "8px",
-          padding: "2px",
+          padding: "2px 2px 2px 8px",
           background:
             palette.mode === "dark"
               ? alpha(palette.background.paper, 0.3)


### PR DESCRIPTION
perf AddressDisplay component padding

before
![image](https://github.com/user-attachments/assets/c6ec494d-c6bf-4ce5-9826-2f5e66de44f7)

after
![image](https://github.com/user-attachments/assets/b6ea529d-816f-4e83-84ef-cad0f28a0019)
