### PR TITLE
fix: task bar icon misssing under linux wayland

### DIFF
--- a/src-tauri/template/clash-verge.desktop
+++ b/src-tauri/template/clash-verge.desktop
@@ -2,6 +2,7 @@
 Categories={{{categories}}}
 Comment={{{comment}}}
 Exec={{{exec}}} %u
+StartupWMClass={{{exec}}}
 Icon={{{icon}}}
 Name={{{name}}}
 Terminal=false


### PR DESCRIPTION
Add a "StartupWMClass" field to the .desktop file to fix taskbar icon missing.

![image](https://github.com/user-attachments/assets/38081f2c-bf12-47e3-b7cf-2126d1657490)
