### PR TITLE
fix: macOS tray icon not changed when using system proxy or tun mode

### DIFF
--- a/src-tauri/src/core/tray.rs
+++ b/src-tauri/src/core/tray.rs
@@ -184,12 +184,8 @@ impl Tray {
 
         #[cfg(target_os = "macos")]
         {
-            if use_custom_icon {
-                let _ = tray.set_icon_as_template(false);
-                let _ = tray.set_icon(Some(tauri::image::Image::from_bytes(&indication_icon)?));
-            } else {
-                let _ = tray.set_icon_as_template(true);
-            }
+            let _ = tray.set_icon(Some(tauri::image::Image::from_bytes(&indication_icon)?));
+            let _ = tray.set_icon_as_template(!use_custom_icon);
         }
 
         #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
**修复后：**
<img width="157" alt="image" src="https://github.com/user-attachments/assets/2da6ce97-0b31-4608-b40a-a9609cee63d0">
<img width="157" alt="image" src="https://github.com/user-attachments/assets/b36804b5-5e56-4b56-9f7d-9d15e6eae4a8">
