### PR TITLE
Feat.copy interface specific env var

### DIFF
--- a/src-tauri/src/cmds.rs
+++ b/src-tauri/src/cmds.rs
@@ -15,9 +15,14 @@ use reqwest_dav::list_cmd::ListFile;
 use tauri::Manager;
 
 #[tauri::command]
-pub fn copy_clash_env() -> CmdResult {
-    feat::copy_clash_env();
-    Ok(())
+pub fn copy_clash_env(addr: String) -> CmdResult {
+    if addr.is_empty() {
+        feat::copy_clash_env(None);
+        Ok(())
+    } else {
+        feat::copy_clash_env(Some(addr));
+        Ok(())
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/core/tray.rs
+++ b/src-tauri/src/core/tray.rs
@@ -392,7 +392,7 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
         "open_window" => resolve::create_window(),
         "system_proxy" => feat::toggle_system_proxy(),
         "tun_mode" => feat::toggle_tun_mode(),
-        "copy_env" => feat::copy_clash_env(),
+        "copy_env" => feat::copy_clash_env(None),
         "open_app_dir" => crate::log_err!(cmds::open_app_dir()),
         "open_core_dir" => crate::log_err!(cmds::open_core_dir()),
         "open_logs_dir" => crate::log_err!(cmds::open_logs_dir()),

--- a/src-tauri/src/feat.rs
+++ b/src-tauri/src/feat.rs
@@ -329,11 +329,12 @@ pub async fn update_profile(uid: String, option: Option<PrfOption>) -> Result<()
 }
 
 /// copy env variable
-pub fn copy_clash_env() {
+pub fn copy_clash_env(addr: Option<String>) {
+    let addr = addr.unwrap_or_else(|| "127.0.0.1".to_string());
     let app_handle = handle::Handle::global().app_handle().unwrap();
     let port = { Config::verge().latest().verge_mixed_port.unwrap_or(7897) };
-    let http_proxy = format!("http://127.0.0.1:{}", port);
-    let socks5_proxy = format!("socks5://127.0.0.1:{}", port);
+    let http_proxy = format!("http://{}:{}", addr, port);
+    let socks5_proxy = format!("socks5://{}:{}", addr, port);
 
     let sh =
         format!("export https_proxy={http_proxy} http_proxy={http_proxy} all_proxy={socks5_proxy}");

--- a/src/components/setting/mods/network-interface-viewer.tsx
+++ b/src/components/setting/mods/network-interface-viewer.tsx
@@ -1,9 +1,9 @@
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BaseDialog, DialogRef, Notice } from "@/components/base";
-import { getNetworkInterfacesInfo } from "@/services/cmds";
+import { copyClashEnv, getNetworkInterfacesInfo } from "@/services/cmds";
 import { alpha, Box, Button, Chip, IconButton } from "@mui/material";
-import { ContentCopyRounded } from "@mui/icons-material";
+import { ContentCopyRounded, ContentCopyTwoTone } from "@mui/icons-material";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 
 export const NetworkInterfaceViewer = forwardRef<DialogRef>((props, ref) => {
@@ -66,7 +66,7 @@ export const NetworkInterfaceViewer = forwardRef<DialogRef>((props, ref) => {
                         label={t("Ip Address")}
                         content={address.V4.ip}
                       />
-                    )
+                    ),
                 )}
                 <AddressDisplay
                   label={t("Mac Address")}
@@ -84,7 +84,7 @@ export const NetworkInterfaceViewer = forwardRef<DialogRef>((props, ref) => {
                         label={t("Ip Address")}
                         content={address.V6.ip}
                       />
-                    )
+                    ),
                 )}
                 <AddressDisplay
                   label={t("Mac Address")}
@@ -133,6 +133,22 @@ const AddressDisplay = (props: { label: string; content: string }) => {
         >
           <ContentCopyRounded sx={{ fontSize: "18px" }} />
         </IconButton>
+
+        {props.label === t("Ip Address") && (
+          <>
+            {t("Copy Env")}
+            <IconButton
+              size="small"
+              onClick={() => {
+                copyClashEnv(props.content);
+                // invoke<void>("copy_clash_env", { addr: props.content });
+                Notice.success(t("Copy Success"));
+              }}
+            >
+              <ContentCopyTwoTone sx={{ fontSize: "18px" }} />
+            </IconButton>
+          </>
+        )}
       </Box>
     </Box>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -283,6 +283,7 @@
   "Tray Click Event": "Tray Click Event",
   "Show Main Window": "Show Main Window",
   "Copy Env Type": "Copy Env Type",
+  "Copy Env": "Copy Env",
   "Copy Success": "Copy Success",
   "Start Page": "Start Page",
   "Startup Script": "Startup Script",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -284,6 +284,7 @@
   "Tray Click Event": "رویداد کلیک در سینی سیستم",
   "Show Main Window": "نمایش پنجره اصلی",
   "Copy Env Type": "کپی نوع محیط",
+  "Copy Env": "کپی محیط",
   "Copy Success": "کپی با موفقیت انجام شد",
   "Start Page": "صفحه شروع",
   "Startup Script": "اسکریپت راه‌اندازی",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -284,6 +284,7 @@
   "Tray Click Event": "Событие щелчка в лотке",
   "Show Main Window": "Показать главное окно",
   "Copy Env Type": "Скопировать тип Env",
+  "Copy Env": "Скопировать Env",
   "Copy Success": "Скопировано",
   "Start Page": "Главная страница",
   "Startup Script": "Скрипт запуска",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -284,6 +284,7 @@
   "Tray Click Event": "托盘点击事件",
   "Show Main Window": "显示主窗口",
   "Copy Env Type": "复制环境变量类型",
+  "Copy Env": "复制环境变量",
   "Copy Success": "复制成功",
   "Start Page": "启动页面",
   "Startup Script": "启动脚本",

--- a/src/services/cmds.ts
+++ b/src/services/cmds.ts
@@ -2,8 +2,8 @@ import dayjs from "dayjs";
 import { invoke } from "@tauri-apps/api/core";
 import { Notice } from "@/components/base";
 
-export async function copyClashEnv() {
-  return invoke<void>("copy_clash_env");
+export async function copyClashEnv(addr: string = "127.0.0.1") {
+  return invoke<void>("copy_clash_env", { addr: addr });
 }
 
 export async function getProfiles() {


### PR DESCRIPTION
Adding a button in the interface viewer for each interface, to copy the environment variable for that interface if they have a ip address.

To achieve this, command function copyClashEnv has been changed in both rust and frontend code, added a parameter to accept custom ip address string.

![clash-verge-rev-preview](https://github.com/user-attachments/assets/0e68f60c-5a67-4e78-9c81-1616c2c4534e)
