### PR TITLE
Update doc website link

### DIFF
--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -21,7 +21,7 @@ const SettingPage = () => {
   });
 
   const toGithubDoc = useLockFn(() => {
-    return openWebUrl("https://clash-verge-rev.github.io/index.html");
+    return openWebUrl("https://www.clashverge.dev/index.html");
   });
 
   const toTelegramChannel = useLockFn(() => {


### PR DESCRIPTION
original link  https://clash-verge-rev.github.io/index.html
redirect to  https://www.clashverge.dev/index.html, so lets use the real link