### PR TITLE
fix: check script https-proxy-agent error

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -5,7 +5,7 @@ import { extract } from "tar";
 import path from "path";
 import AdmZip from "adm-zip";
 import fetch from "node-fetch";
-import proxyAgent from "https-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
 import { execSync } from "child_process";
 import { log_info, log_debug, log_error, log_success } from "./utils.mjs";
 import { glob } from "glob";
@@ -85,7 +85,7 @@ async function getLatestAlphaVersion() {
     process.env.https_proxy;
 
   if (httpProxy) {
-    options.agent = proxyAgent(httpProxy);
+    options.agent = new HttpsProxyAgent(httpProxy);
   }
   try {
     const response = await fetch(META_ALPHA_VERSION_URL, {
@@ -132,7 +132,7 @@ async function getLatestReleaseVersion() {
     process.env.https_proxy;
 
   if (httpProxy) {
-    options.agent = proxyAgent(httpProxy);
+    options.agent = new HttpsProxyAgent(httpProxy);
   }
   try {
     const response = await fetch(META_VERSION_URL, {
@@ -332,7 +332,7 @@ async function resolveResource(binInfo) {
     process.env.https_proxy;
 
   if (httpProxy) {
-    options.agent = proxyAgent(httpProxy);
+    options.agent = new HttpsProxyAgent(httpProxy);
   }
 
   const response = await fetch(url, {


### PR DESCRIPTION
After upgrading to a newer version of [https-proxy-agent](https://github.com/TooTallNate/proxy-agents), function calls will no longer be supported. 

```text
PS C:\Users\akioe\Desktop\code\clash-verge-rev> pnpm run check --force

> clash-verge@2.0.2 check C:\Users\akioe\Desktop\code\clash-verge-rev
> node scripts/check.mjs "--force"

task::verge-mihomo-alpha try 0 == proxyAgent is not a function
task::verge-mihomo-alpha try 1 == proxyAgent is not a function
task::verge-mihomo-alpha try 2 == proxyAgent is not a function
task::verge-mihomo-alpha try 3 == proxyAgent is not a function
task::verge-mihomo-alpha try 4 == proxyAgent is not a function
file:///C:/Users/akioe/Desktop/code/clash-verge-rev/scripts/check.mjs:88
    options.agent = proxyAgent(httpProxy);
                    ^

TypeError: proxyAgent is not a function
    at getLatestAlphaVersion (file:///C:/Users/akioe/Desktop/code/clash-verge-rev/scripts/check.mjs:88:21)
    at Object.func (file:///C:/Users/akioe/Desktop/code/clash-verge-rev/scripts/check.mjs:466:7)
    at runTask (file:///C:/Users/akioe/Desktop/code/clash-verge-rev/scripts/check.mjs:524:18)

Node.js v20.13.1
 ELIFECYCLE  Command failed with exit code 1.
```

Since version 6.0.0, function calls have been [removed](https://github.com/TooTallNate/proxy-agents/blob/d0d80cc0482f20495aa8595f802e1a9f3b1b3409/src/index.ts#L8).