### PR TITLE
chore: add nix-shell conf for development

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,27 @@
+let
+  pkgs = import <nixpkgs> { };
+in
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+    gobject-introspection
+    cargo
+    cargo-tauri
+    nodejs
+  ];
+
+  buildInputs = with pkgs;[
+    at-spi2-atk
+    atkmm
+    cairo
+    gdk-pixbuf
+    glib
+    gtk3
+    harfbuzz
+    librsvg
+    libsoup_3
+    pango
+    webkitgtk_4_1
+    openssl
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -23,5 +23,7 @@ pkgs.mkShell {
     pango
     webkitgtk_4_1
     openssl
+    gobject-introspection # gobject-2.0.pc
+    libappindicator-gtk3 # App Indicator
   ];
 }


### PR DESCRIPTION
Nix is a declarative package manager that creates consistent and reproducible dependency environments for the shells. This PR is based on [the `.nix` conf provided by Tauri Docs](https://github.com/tauri-apps/tauri-docs/blob/58bc74c577f2aad6ede8efff024098968b9a252a/src/content/docs/zh-cn/start/prerequisites.mdx?plain=1#L115-143), with one more dependency for building.