### PR TITLE
fix: build front cannot find IvergeConfig.enable_lite_mode and macos port switching causes crash

### DIFF
--- a/src-tauri/src/core/core.rs
+++ b/src-tauri/src/core/core.rs
@@ -98,6 +98,7 @@ impl CoreManager {
 
     /// 启动核心
     pub async fn start_core(&self) -> Result<()> {
+        #[cfg(not(target_os = "macos"))]
         // 检查端口占用
         self.health_checker.check_ports().await?;
 

--- a/src-tauri/src/core/health_check.rs
+++ b/src-tauri/src/core/health_check.rs
@@ -1,7 +1,12 @@
+#[cfg(not(target_os = "macos"))]
 use anyhow::{bail, Result};
+#[cfg(target_os = "macos")]
+use anyhow::Result;
 use sysinfo::{Pid, System};
+#[cfg(not(target_os = "macos"))]
 use crate::config::Config;
 use crate::core::service;
+#[cfg(not(target_os = "macos"))]
 use port_scanner::local_port_available;
 
 #[derive(Debug, Clone)]
@@ -12,6 +17,7 @@ impl HealthChecker {
         Self
     }
 
+    #[cfg(not(target_os = "macos"))]
     pub async fn check_ports(&self) -> Result<()> {
         let verge = Config::verge();
         let verge_config = verge.latest();

--- a/src/services/types.d.ts
+++ b/src/services/types.d.ts
@@ -709,6 +709,7 @@ interface IVergeConfig {
   tun_tray_icon?: boolean;
   enable_tray_speed?: boolean;
   enable_tun_mode?: boolean;
+  enable_lite_mode?: boolean;
   enable_auto_launch?: boolean;
   enable_silent_start?: boolean;
   enable_system_proxy?: boolean;


### PR DESCRIPTION
fix: build time front cannot find IVergeConfig attribute enable_lite_mode

fix: macos switch protocol port or enable protocol port causes crash
