### PR TITLE
feat: 通过添加CLASH_VERGE_REV_IP环境变量的方式，修改复制环境变量按钮的IP

### DIFF
--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -5,7 +5,7 @@ import { extract } from "tar";
 import path from "path";
 import AdmZip from "adm-zip";
 import fetch from "node-fetch";
-import proxyAgent from "https-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
 import { execSync } from "child_process";
 import { log_info, log_debug, log_error, log_success } from "./utils.mjs";
 import { glob } from "glob";
@@ -85,7 +85,7 @@ async function getLatestAlphaVersion() {
     process.env.https_proxy;
 
   if (httpProxy) {
-    options.agent = proxyAgent(httpProxy);
+    options.agent = new HttpsProxyAgent(httpProxy);
   }
   try {
     const response = await fetch(META_ALPHA_VERSION_URL, {
@@ -132,7 +132,7 @@ async function getLatestReleaseVersion() {
     process.env.https_proxy;
 
   if (httpProxy) {
-    options.agent = proxyAgent(httpProxy);
+    options.agent = new HttpsProxyAgent(httpProxy);
   }
   try {
     const response = await fetch(META_VERSION_URL, {
@@ -332,7 +332,7 @@ async function resolveResource(binInfo) {
     process.env.https_proxy;
 
   if (httpProxy) {
-    options.agent = proxyAgent(httpProxy);
+    options.agent = new HttpsProxyAgent(httpProxy);
   }
 
   const response = await fetch(url, {

--- a/src-tauri/src/feat.rs
+++ b/src-tauri/src/feat.rs
@@ -16,6 +16,7 @@ use std::fs;
 use tauri::Manager;
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
+use std::env;
 
 // 打开面板
 pub fn open_or_close_dashboard() {
@@ -359,10 +360,13 @@ pub async fn update_profile(uid: String, option: Option<PrfOption>) -> Result<()
 
 /// copy env variable
 pub fn copy_clash_env() {
+    // 从环境变量获取IP地址，默认127.0.0.1
+    let clash_verge_rev_ip = env::var("CLASH_VERGE_REV_IP").unwrap_or_else(|_| "127.0.0.1".to_string());
+    
     let app_handle = handle::Handle::global().app_handle().unwrap();
     let port = { Config::verge().latest().verge_mixed_port.unwrap_or(7897) };
-    let http_proxy = format!("http://127.0.0.1:{}", port);
-    let socks5_proxy = format!("socks5://127.0.0.1:{}", port);
+    let http_proxy = format!("http://{clash_verge_rev_ip}:{}", port);
+    let socks5_proxy = format!("socks5://{clash_verge_rev_ip}:{}", port);
 
     let sh =
         format!("export https_proxy={http_proxy} http_proxy={http_proxy} all_proxy={socks5_proxy}");


### PR DESCRIPTION
## 1.0 优化点
复制环境变量按钮的IP是`127.0.0.1`固定不变，通过添加环境变量`CLASH_VERGE_REV_IP`来修改复制环境变量按钮的IP。不添加`CLASH_VERGE_REV_IP`环境变量默认为`127.0.0.1`

## 2.0 使用方法
```bash
echo 'export CLASH_VERGE_REV_IP=192.168.1.120' >> ~/.bashrc
source ~/.bashrc
```

## 3.0 重启软件即可