### PR TITLE
feat: auto rename alpha version

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -67,6 +67,9 @@ jobs:
           pnpm i
           pnpm check ${{ matrix.target }}
 
+      - name: Alpha Version update
+        run: pnpm run fix-alpha-version
+
       - name: Tauri build
         uses: tauri-apps/tauri-action@v0
         env:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "updater-fixed-webview2": "node scripts/updater-fixed-webview2.mjs",
     "portable": "node scripts/portable.mjs",
     "portable-fixed-webview2": "node scripts/portable-fixed-webview2.mjs",
+    "fix-alpha-version": "node scripts/alpha_version.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/alpha_version.mjs
+++ b/scripts/alpha_version.mjs
@@ -1,0 +1,55 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+import fs from "fs/promises";
+import path from "path";
+
+/**
+ *  为Alpha版本重命名版本号
+ */
+const execPromise = promisify(exec);
+
+/**
+ * 标准输出HEAD hash
+ */
+async function getLatestCommitHash() {
+  try {
+    const { stdout } = await execPromise("git rev-parse HEAD");
+    const commitHash = stdout.trim();
+    // 格式化，只截取前7位字符
+    const formathash = commitHash.substring(0, 7);
+    console.log(`Found the latest commit hash code: ${commitHash}`);
+    return formathash;
+  } catch (error) {
+    console.error("pnpm run fix-alpha-version ERROR", error);
+  }
+}
+
+/**
+ * @param string 传入格式化后的hash
+ * 将新的版本号写入文件 package.json
+ */
+async function updatePackageVersion(newVersion) {
+  // 获取内容根目录
+  const _dirname = process.cwd();
+  const packageJsonPath = path.join(_dirname, "package.json");
+  // const headhash = await getLatestCommitHash();
+  try {
+    const data = await fs.readFile(packageJsonPath, "utf8");
+    const packageJson = JSON.parse(data);
+    const initversion = packageJson.version;
+    // 将第一个匹配到第一个 "alpha" => 具体的hash
+    const fixversion = initversion.replace("alpha", newVersion);
+    packageJson.version = fixversion;
+    // 写入版本号
+    await fs.writeFile(
+      packageJsonPath,
+      JSON.stringify(packageJson, null, 2),
+      "utf8",
+    );
+    console.log(`Alpha version update to: ${fixversion}`);
+  } catch (error) {
+    console.error("pnpm run fix-alpha-version ERROR", error);
+  }
+}
+const newVersion = await getLatestCommitHash();
+updatePackageVersion(newVersion);


### PR DESCRIPTION
**带来以下影响**
1. 设置页面verge version会显示 v2.0.4-2b01857
2. Alpha发版文件名会被改成类Clash.Verge_2.0.4-2b01857_x64-setup.exe

> 更新assets上传的文件名是匹配`*setup.exe` 或 `*.deb`

不影响上传流程