### PR TITLE
feat: add fast compilation options for development and release

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "2.1.2",
   "license": "GPL-3.0-only",
   "scripts": {
-    "dev": "cross-env RUST_BACKTRACE=1 tauri dev",
+    "dev": "cross-env RUST_BACKTRACE=1 tauri dev -f verge-dev",
+    "dev:fast": "cross-env RUST_BACKTRACE=1 tauri dev",
     "dev:diff": "cross-env RUST_BACKTRACE=1 tauri dev -f verge-dev",
     "build": "cross-env NODE_OPTIONS='--max-old-space-size=4096' tauri build",
+    "build:fast": "cross-env NODE_OPTIONS='--max-old-space-size=4096' tauri build",
     "tauri": "tauri",
     "web:dev": "vite",
     "web:build": "tsc --noEmit && vite build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -100,6 +100,23 @@ strip = true
 [profile.dev]
 incremental = true
 
+[profile.fast-release]
+inherits = "release"  # 继承 release 的配置
+panic = "abort"       # 与 release 相同
+codegen-units = 256    # 增加编译单元，提升编译速度
+lto = false           # 禁用 LTO，提升编译速度
+opt-level = 0         # 禁用优化，大幅提升编译速度
+debug = true          # 保留调试信息
+strip = false         # 不剥离符号，保留调试信息
+
+[profile.fast-dev]
+inherits = "dev"      # 继承 dev 的配置
+codegen-units = 256    # 增加编译单元，提升编译速度
+opt-level = 0         # 禁用优化，进一步提升编译速度
+incremental = true    # 启用增量编译
+debug = true          # 保留调试信息
+strip = false         # 不剥离符号，保留调试信息
+
 [lib]
 name = "app_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]


### PR DESCRIPTION
- Added fast compilation profiles in Cargo.toml
  - fast-dev profile with max codegen units and disabled optimizations
  - fast-release profile with debugging support and faster build time
- Added new npm scripts for quick development iterations
  - dev:fast command for standard development without extra features
  - build:fast command for quick release builds
- Updated default dev command to use verge-dev feature flag
- Both profiles retain debug symbols and disable stripping for better debugging