### PR TITLE
chore: correct typo in src/locales/en.json

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -344,7 +344,7 @@
   "Backup Setting Info": "Support WebDAV backup configuration files",
   "Runtime Config": "Runtime Config",
   "Open Conf Dir": "Open Conf Dir",
-  "Open Conf Dir Info": "If the software runs abnormally, BACKUP and delete all files in this folder than restart the software",
+  "Open Conf Dir Info": "If the software runs abnormally, BACKUP and delete all files in this folder then restart the software",
   "Open Core Dir": "Open Core Dir",
   "Open Logs Dir": "Open Logs Dir",
   "Check for Updates": "Check for Updates",


### PR DESCRIPTION
This pull request corrects a typo in src/locales/en.json by replacing “than” with “then”, gives more accurate instructions.