### PR TITLE
fix: use the http proxy instead of the system proxy in unlock-test

### DIFF
--- a/src-tauri/src/cmd/media_unlock_checker.rs
+++ b/src-tauri/src/cmd/media_unlock_checker.rs
@@ -5,9 +5,11 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tauri::command;
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
+use crate::utils::http;
 
 // 定义解锁测试项目的结构
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1069,11 +1071,15 @@ pub async fn get_unlock_items() -> Result<Vec<UnlockItem>, String> {
     Ok(items)
 }
 
+
 // 开始检测流媒体解锁状态
 #[command]
 pub async fn check_media_unlock() -> Result<Vec<UnlockItem>, String> {
+    let builder = http::http_client_builder_with_verge_mixed_port();
+
     // 创建一个http客户端
-    let client = match Client::builder()
+    let client = match builder
+        .timeout(Duration::from_millis(10000)) // default timeout is 10 seconds
         .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
         .build() {
         Ok(client) => client,

--- a/src-tauri/src/feat/clash.rs
+++ b/src-tauri/src/feat/clash.rs
@@ -4,6 +4,7 @@ use crate::{
     log_err,
     module::mihomo::MihomoManager,
     utils::resolve,
+    utils::http,
 };
 use serde_yaml::{Mapping, Value};
 use tauri::Manager;
@@ -67,27 +68,7 @@ pub fn change_clash_mode(mode: String) {
 /// Test connection delay to a URL
 pub async fn test_delay(url: String) -> anyhow::Result<u32> {
     use tokio::time::{Duration, Instant};
-    let mut builder = reqwest::ClientBuilder::new().use_rustls_tls().no_proxy();
-
-    let port = Config::verge()
-        .latest()
-        .verge_mixed_port
-        .unwrap_or(Config::clash().data().get_mixed_port());
-    let tun_mode = Config::verge().latest().enable_tun_mode.unwrap_or(false);
-
-    let proxy_scheme = format!("http://127.0.0.1:{port}");
-
-    if !tun_mode {
-        if let Ok(proxy) = reqwest::Proxy::http(&proxy_scheme) {
-            builder = builder.proxy(proxy);
-        }
-        if let Ok(proxy) = reqwest::Proxy::https(&proxy_scheme) {
-            builder = builder.proxy(proxy);
-        }
-        if let Ok(proxy) = reqwest::Proxy::all(&proxy_scheme) {
-            builder = builder.proxy(proxy);
-        }
-    }
+    let builder = http::http_client_builder_with_verge_mixed_port();
 
     let request = builder
         .timeout(Duration::from_millis(10000))

--- a/src-tauri/src/utils/http.rs
+++ b/src-tauri/src/utils/http.rs
@@ -1,0 +1,27 @@
+use crate::config::Config;
+pub fn http_client_builder_with_verge_mixed_port() -> reqwest::ClientBuilder {
+    let mut builder = reqwest::Client::builder().use_rustls_tls().no_proxy(); // disable system proxy, use verge(clash) mixed port instead
+    let port = Config::verge()
+        .latest()
+        .verge_mixed_port
+        .unwrap_or(Config::clash().data().get_mixed_port());
+    let tun_mode = Config::verge().latest().enable_tun_mode.unwrap_or(false);
+
+    let proxy_scheme = format!("http://127.0.0.1:{port}");
+
+    if !tun_mode {
+        if let Ok(proxy) = reqwest::Proxy::http(&proxy_scheme) {
+            builder = builder.proxy(proxy);
+        }
+        if let Ok(proxy) = reqwest::Proxy::https(&proxy_scheme) {
+            builder = builder.proxy(proxy);
+        }
+        if let Ok(proxy) = reqwest::Proxy::all(&proxy_scheme) {
+            builder = builder.proxy(proxy);
+        }
+    }
+
+    builder
+}
+
+

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -6,3 +6,4 @@ pub mod init;
 pub mod resolve;
 pub mod server;
 pub mod tmpl;
+pub mod http;


### PR DESCRIPTION
在不开启系统代理时，会使用本地环境进行测试，这并非预期结果。
因此将改成与网页测试相同的处理方式，详见：

https://github.com/clash-verge-rev/clash-verge-rev/blob/e957c10138b3c43d08e4df35cbcef271b12f0425/src-tauri/src/feat/clash.rs#L68

另外，增加代码的可复用性