### PR TITLE
fix: the first function call creates multiple axios instances

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,13 +3,9 @@ import { getClashInfo } from "./cmds";
 import { invoke } from "@tauri-apps/api/core";
 import { useLockFn } from "ahooks";
 
-let axiosIns: AxiosInstance = null!;
+let instancePromise: Promise<AxiosInstance> = null!;
 
-/// initialize some information
-/// enable force update axiosIns
-export const getAxios = async (force: boolean = false) => {
-  if (axiosIns && !force) return axiosIns;
-
+async function getInstancePromise() {
   let server = "";
   let secret = "";
 
@@ -26,13 +22,22 @@ export const getAxios = async (force: boolean = false) => {
     if (info?.secret) secret = info?.secret;
   } catch {}
 
-  axiosIns = axios.create({
+  const axiosIns = axios.create({
     baseURL: `http://${server}`,
     headers: secret ? { Authorization: `Bearer ${secret}` } : {},
     timeout: 15000,
   });
   axiosIns.interceptors.response.use((r) => r.data);
   return axiosIns;
+}
+
+/// initialize some information
+/// enable force update axiosIns
+export const getAxios = async (force: boolean = false) => {
+  if (!instancePromise || force) {
+    instancePromise = getInstancePromise();
+  }
+  return instancePromise;
 };
 
 /// Get Version


### PR DESCRIPTION
Because calling `getClashInfo` requires waiting, `axiosIns` cannot be judged as true in the first place.
It's doesn't lock function.

因为调用 `getClashInfo` 需要等待，因此无法第一时间让 `axiosIns` 判断为 true。
因此没锁函数。