### PR TITLE
feat: integrate RulesEditorViewer into ConnectionDetail for enhanced …

### DIFF
--- a/src/components/profile/rules-editor-viewer.tsx
+++ b/src/components/profile/rules-editor-viewer.tsx
@@ -50,6 +50,7 @@ interface Props {
   open: boolean;
   onClose: () => void;
   onSave?: (prev?: string, curr?: string) => void;
+  initialRule?: string;
 }
 
 const portValidator = (value: string): boolean => {
@@ -234,7 +235,7 @@ const rules: {
 const builtinProxyPolicies = ["DIRECT", "REJECT", "REJECT-DROP", "PASS"];
 
 export const RulesEditorViewer = (props: Props) => {
-  const { groupsUid, mergeUid, profileUid, property, open, onClose, onSave } =
+  const { groupsUid, mergeUid, profileUid, property, open, onClose, onSave, initialRule } =
     props;
   const { t } = useTranslation();
   const themeMode = useThemeMode();
@@ -244,7 +245,7 @@ export const RulesEditorViewer = (props: Props) => {
   const [visualization, setVisualization] = useState(true);
   const [match, setMatch] = useState(() => (_: string) => true);
 
-  const [ruleType, setRuleType] = useState<(typeof rules)[number]>(rules[0]);
+  const [ruleType, setRuleType] = useState<(typeof rules)[number]>(rules.find(r => r.name === "DOMAIN") || rules[0]);
   const [ruleContent, setRuleContent] = useState("");
   const [noResolve, setNoResolve] = useState(false);
   const [proxyPolicy, setProxyPolicy] = useState(builtinProxyPolicies[0]);
@@ -396,6 +397,15 @@ export const RulesEditorViewer = (props: Props) => {
     fetchContent();
     fetchProfile();
   }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    fetchContent();
+    fetchProfile();
+    if (initialRule && open) {
+      setRuleContent(initialRule);
+    }
+  }, [initialRule, open]);
 
   const validateRule = () => {
     if ((ruleType.required ?? true) && !ruleContent) {


### PR DESCRIPTION
背景：使用TUN或者SystemProxy模式时，经常会遇到无法访问，进入Connection列表查看链接情况，很多时候需要跳转到Profiles手动添加规则

代码逻辑：在Connections增加了一个按钮，点击后会弹出规则编辑窗口，用于快速添加规则。如果host字段不存在，就使用source IP。

<img width="329" alt="image" src="https://github.com/user-attachments/assets/57828b63-5863-4191-8010-30ed8bfc8dcb" />
