### PR TITLE
fix: 关闭启动脚本 input 组件下划线

### DIFF
--- a/src/components/setting/setting-verge-basic.tsx
+++ b/src/components/setting/setting-verge-basic.tsx
@@ -182,6 +182,7 @@ const SettingVergeBasic = ({ onError }: Props) => {
           <Input
             value={startup_script}
             disabled
+            disableUnderline
             sx={{ width: 230 }}
             endAdornment={
               <>


### PR DESCRIPTION
before:
<img width="414" alt="image" src="https://github.com/user-attachments/assets/dacb74f7-0c84-4656-b4ad-a5255b28edcf" />

after:
<img width="734" alt="image" src="https://github.com/user-attachments/assets/dcd60122-659b-4078-a7fe-a6539e6a1668" />

