### PR TITLE
feat: clean proxy settings before exit

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -275,6 +275,13 @@ pub fn run() {
                 api.prevent_exit();
             }
         }
+        tauri::RunEvent::Exit => {
+            // avoid duplicate cleanup
+            if core::handle::Handle::global().is_exiting() {
+                return;
+            }
+            feat::clean();
+        }
         tauri::RunEvent::WindowEvent { label, event, .. } => {
             if label == "main" {
                 match event {


### PR DESCRIPTION
当前在macos上通过Dock或者关机的方式关闭应用时不会触发清理代理设置，这会导致无法正常联网。调试发现上述的退出方式会触发 *tauri::RunEvent::Exit** 事件，增加对该事件的处理。  

可能关联的issue: 
https://github.com/clash-verge-rev/clash-verge-rev/issues/3196
