### PR TITLE
feat(config): add new allowed origins for CORS in clash.rs

### DIFF
--- a/src-tauri/src/config/clash.rs
+++ b/src-tauri/src/config/clash.rs
@@ -58,6 +58,9 @@ impl IClashTemp {
                 "tauri://localhost",
                 "http://tauri.localhost",
                 "http://localhost:3000",
+                "https://yacd.metacubex.one",
+                "https://metacubex.github.io",
+                "https://board.zash.run.place",
             ]
             .into(),
         );
@@ -95,6 +98,9 @@ impl IClashTemp {
                 "tauri://localhost",
                 "http://tauri.localhost",
                 "http://localhost:3000",
+                "https://yacd.metacubex.one",
+                "https://metacubex.github.io",
+                "https://board.zash.run.place",
             ]
             .into(),
         );


### PR DESCRIPTION
Include "https://yacd.metacubex.one", "https://metacubex.github.io", and "https://board.zash.run.place" to the list of allowed origins for both HTTP and WebSocket configurations.