### PR TITLE
Revert "fix: update packageManager to pnpm@10.12.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,5 +112,5 @@
     "endOfLine": "lf"
   },
   "type": "module",
-  "packageManager": "pnpm@10.12.1"
+  "packageManager": "pnpm@9.13.2"
 }


### PR DESCRIPTION
修复运行时，启动仪表板不显示。