### PR TITLE
chore (ISSUE_TEMPLATE): 修改问题反馈模板

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,13 +61,12 @@ body:
     attributes:
       label: 日志(勿上传日志文件，请粘贴日志内容) / Log (Do not upload the log file, paste the log content directly)
       description: 请提供完整或相关部分的Debug日志（请在“软件左侧菜单”->“设置”->“日志等级”调整到debug，Verge错误请把“杂项设置”->“app日志等级”调整到debug，并重启Verge生效。日志文件在“软件左侧菜单”->“设置”->“日志目录”下） / Please provide a complete or relevant part of the Debug log (please adjust the "Log level" to debug in "Software left menu" -> "Settings" -> "Log level". If there is a Verge error, please adjust "Miscellaneous settings" -> "app log level" to debug, and restart Verge to take effect. The log file is under "Software left menu" -> "Settings" -> "Log directory")
-      value: |
-        <details><summary>日志内容</summary>
-
+value: |
+        <details><summary>日志内容 / Log Content</summary>
         ```log
-        <!-- 在此处粘贴完整日志 -->
+        <!-- 在此处粘贴完整日志 / Paste the full log here -->
+        
         ```
-
         </details>
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,5 +61,13 @@ body:
     attributes:
       label: 日志(勿上传日志文件，请粘贴日志内容) / Log (Do not upload the log file, paste the log content directly)
       description: 请提供完整或相关部分的Debug日志（请在“软件左侧菜单”->“设置”->“日志等级”调整到debug，Verge错误请把“杂项设置”->“app日志等级”调整到debug，并重启Verge生效。日志文件在“软件左侧菜单”->“设置”->“日志目录”下） / Please provide a complete or relevant part of the Debug log (please adjust the "Log level" to debug in "Software left menu" -> "Settings" -> "Log level". If there is a Verge error, please adjust "Miscellaneous settings" -> "app log level" to debug, and restart Verge to take effect. The log file is under "Software left menu" -> "Settings" -> "Log directory")
+      value: |
+        <details><summary>日志内容</summary>
+
+        ```log
+        <!-- 在此处粘贴完整日志 -->
+        ```
+
+        </details>
     validations:
       required: true


### PR DESCRIPTION
## ❓ 改了啥

- 修改 `bug_report.yml`
- 增加一段预置的格式模板，指引用户将日志粘贴在规范的 Code Block 中以保持日志原有的格式排版
- 使用 `<details />` 块以压缩日志片段，对于非 Contributors / Collaborators 用户友好，规避日志霸屏效果，简化爬楼。

## ❓ 凭什么

- Related #3888 

在浏览 Issues 的过程中，发现项目提供的「问题反馈」模板在最后有要求用户提供日志，但禁止以文件的形式上传日志，必须将日志原文直接粘贴于 Issues Descriptions 中。

由于本项目用途的特殊性，多数提问者对 GitHub Flavored Markdown 了解并不多，且模板并未对此部分内容自动使用 Code Blocks 模式进行格式化，导致日志会被 GitHub 错误排版影响阅读。

对于其他希望参与 Issues 讨论的用户，用 Details 块将日志高度折叠压缩也能避免日志霸屏、方便快速爬楼。同时在内部嵌套预留 Code Block ，指引用户在预留的模板内指定位置粘贴日志文本。