### PR TITLE
refactor: use React in its intended way

### DIFF
--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -1,10 +1,11 @@
 import dayjs from "dayjs";
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState } from "react";
 import { DataGrid, GridColDef, GridColumnResizeParams } from "@mui/x-data-grid";
 import { useThemeMode } from "@/services/states";
 import { truncateStr } from "@/utils/truncate-str";
 import parseTraffic from "@/utils/parse-traffic";
 import { t } from "i18next";
+import { useLocalStorage } from "foxact/use-local-storage";
 
 interface Props {
   connections: IConnectionsItem[];
@@ -21,11 +22,13 @@ export const ConnectionTable = (props: Props) => {
     Partial<Record<keyof IConnectionsItem, boolean>>
   >({});
 
-  const [columnWidths, setColumnWidths] = useState<Record<string, number>>(
-    () => {
-      const saved = localStorage.getItem("connection-table-widths");
-      return saved ? JSON.parse(saved) : {};
-    },
+  const [columnWidths, setColumnWidths] = useLocalStorage<
+    Record<string, number>
+  >(
+    "connection-table-widths",
+    // server-side value, this is the default value used by server-side rendering (if any)
+    // Do not omit (otherwise a Suspense boundary will be triggered)
+    {},
   );
 
   const [columns] = useState<GridColDef[]>([
@@ -115,14 +118,6 @@ export const ConnectionTable = (props: Props) => {
       minWidth: 100,
     },
   ]);
-
-  useEffect(() => {
-    console.log("Saving column widths:", columnWidths);
-    localStorage.setItem(
-      "connection-table-widths",
-      JSON.stringify(columnWidths),
-    );
-  }, [columnWidths]);
 
   const handleColumnResize = (params: GridColumnResizeParams) => {
     const { colDef, width } = params;

--- a/src/components/home/enhanced-traffic-stats.tsx
+++ b/src/components/home/enhanced-traffic-stats.tsx
@@ -29,6 +29,7 @@ import parseTraffic from "@/utils/parse-traffic";
 import { getConnections, isDebugEnabled, gc } from "@/services/api";
 import { ReactNode } from "react";
 import { useAppData } from "@/providers/app-data-provider";
+import useSWR from "swr";
 
 interface MemoryUsage {
   inuse: number;
@@ -161,7 +162,6 @@ export const EnhancedTrafficStats = () => {
   const { verge } = useVerge();
   const trafficRef = useRef<EnhancedTrafficGraphRef>(null);
   const pageVisible = useVisibility();
-  const [isDebug, setIsDebug] = useState(false);
 
   // 使用AppDataProvider
   const { connections, uptime } = useAppData();
@@ -178,19 +178,16 @@ export const EnhancedTrafficStats = () => {
   // 是否显示流量图表
   const trafficGraph = verge?.traffic_graph ?? true;
 
-  // WebSocket引用
-  const socketRefs = useRef<{
-    traffic: ReturnType<typeof createAuthSockette> | null;
-    memory: ReturnType<typeof createAuthSockette> | null;
-  }>({
-    traffic: null,
-    memory: null,
-  });
-
   // 检查是否支持调试
-  useEffect(() => {
-    isDebugEnabled().then((flag) => setIsDebug(flag));
-  }, []);
+  // TODO: merge this hook with layout-traffic.tsx
+  const { data: isDebug } = useSWR(
+    `clash-verge-rev-internal://isDebugEnabled`,
+    () => isDebugEnabled(),
+    {
+      // default value before is fetched
+      fallbackData: false,
+    },
+  );
 
   // 处理流量数据更新 - 使用节流控制更新频率
   const handleTrafficUpdate = useCallback((event: MessageEvent) => {
@@ -260,14 +257,23 @@ export const EnhancedTrafficStats = () => {
     const { server, secret = "" } = clashInfo;
     if (!server) return;
 
+    // WebSocket 引用
+    let sockets: {
+      traffic: ReturnType<typeof createAuthSockette> | null;
+      memory: ReturnType<typeof createAuthSockette> | null;
+    } = {
+      traffic: null,
+      memory: null,
+    };
+
     // 清理现有连接的函数
     const cleanupSockets = () => {
-      Object.values(socketRefs.current).forEach((socket) => {
+      Object.values(sockets).forEach((socket) => {
         if (socket) {
           socket.close();
         }
       });
-      socketRefs.current = { traffic: null, memory: null };
+      sockets = { traffic: null, memory: null };
     };
 
     // 关闭现有连接
@@ -277,44 +283,40 @@ export const EnhancedTrafficStats = () => {
     console.log(
       `[Traffic][${EnhancedTrafficStats.name}] 正在连接: ${server}/traffic`,
     );
-    socketRefs.current.traffic = createAuthSockette(
-      `${server}/traffic`,
-      secret,
-      {
-        onmessage: handleTrafficUpdate,
-        onopen: (event) => {
-          console.log(
-            `[Traffic][${EnhancedTrafficStats.name}] WebSocket 连接已建立`,
-            event,
-          );
-        },
-        onerror: (event) => {
-          console.error(
-            `[Traffic][${EnhancedTrafficStats.name}] WebSocket 连接错误或达到最大重试次数`,
-            event,
+    sockets.traffic = createAuthSockette(`${server}/traffic`, secret, {
+      onmessage: handleTrafficUpdate,
+      onopen: (event) => {
+        console.log(
+          `[Traffic][${EnhancedTrafficStats.name}] WebSocket 连接已建立`,
+          event,
+        );
+      },
+      onerror: (event) => {
+        console.error(
+          `[Traffic][${EnhancedTrafficStats.name}] WebSocket 连接错误或达到最大重试次数`,
+          event,
+        );
+        setStats((prev) => ({ ...prev, traffic: { up: 0, down: 0 } }));
+      },
+      onclose: (event) => {
+        console.log(
+          `[Traffic][${EnhancedTrafficStats.name}] WebSocket 连接关闭`,
+          event.code,
+          event.reason,
+        );
+        if (event.code !== 1000 && event.code !== 1001) {
+          console.warn(
+            `[Traffic][${EnhancedTrafficStats.name}] 连接非正常关闭，重置状态`,
           );
           setStats((prev) => ({ ...prev, traffic: { up: 0, down: 0 } }));
-        },
-        onclose: (event) => {
-          console.log(
-            `[Traffic][${EnhancedTrafficStats.name}] WebSocket 连接关闭`,
-            event.code,
-            event.reason,
-          );
-          if (event.code !== 1000 && event.code !== 1001) {
-            console.warn(
-              `[Traffic][${EnhancedTrafficStats.name}] 连接非正常关闭，重置状态`,
-            );
-            setStats((prev) => ({ ...prev, traffic: { up: 0, down: 0 } }));
-          }
-        },
+        }
       },
-    );
+    });
 
     console.log(
       `[Memory][${EnhancedTrafficStats.name}] 正在连接: ${server}/memory`,
     );
-    socketRefs.current.memory = createAuthSockette(`${server}/memory`, secret, {
+    sockets.memory = createAuthSockette(`${server}/memory`, secret, {
       onmessage: handleMemoryUpdate,
       onopen: (event) => {
         console.log(
@@ -352,18 +354,6 @@ export const EnhancedTrafficStats = () => {
 
     return cleanupSockets;
   }, [clashInfo, pageVisible, handleTrafficUpdate, handleMemoryUpdate]);
-
-  // 组件卸载时清理所有定时器/引用
-  useEffect(() => {
-    return () => {
-      try {
-        Object.values(socketRefs.current).forEach((socket) => {
-          if (socket) socket.close();
-        });
-        socketRefs.current = { traffic: null, memory: null };
-      } catch {}
-    };
-  }, []);
 
   // 执行垃圾回收
   const handleGarbageCollection = useCallback(async () => {

--- a/src/components/layout/layout-traffic.tsx
+++ b/src/components/layout/layout-traffic.tsx
@@ -14,6 +14,7 @@ import useSWRSubscription from "swr/subscription";
 import { createSockette, createAuthSockette } from "@/utils/websocket";
 import { useTranslation } from "react-i18next";
 import { isDebugEnabled, gc } from "@/services/api";
+import useSWR from "swr";
 
 interface MemoryUsage {
   inuse: number;
@@ -31,12 +32,15 @@ export const LayoutTraffic = () => {
 
   const trafficRef = useRef<TrafficRef>(null);
   const pageVisible = useVisibility();
-  const [isDebug, setIsDebug] = useState(false);
 
-  useEffect(() => {
-    isDebugEnabled().then((flag) => setIsDebug(flag));
-    return () => {};
-  }, [isDebug]);
+  const { data: isDebug } = useSWR(
+    "clashh-verge-rev-internal://isDebugEnabled",
+    () => isDebugEnabled(),
+    {
+      // default value before is fetched
+      fallbackData: false,
+    },
+  );
 
   const { data: traffic = { up: 0, down: 0 } } = useSWRSubscription<
     ITrafficItem,

--- a/src/components/layout/layout-traffic.tsx
+++ b/src/components/layout/layout-traffic.tsx
@@ -34,7 +34,7 @@ export const LayoutTraffic = () => {
   const pageVisible = useVisibility();
 
   const { data: isDebug } = useSWR(
-    "clashh-verge-rev-internal://isDebugEnabled",
+    "clash-verge-rev-internal://isDebugEnabled",
     () => isDebugEnabled(),
     {
       // default value before is fetched

--- a/src/components/profile/groups-editor-viewer.tsx
+++ b/src/components/profile/groups-editor-viewer.tsx
@@ -48,6 +48,10 @@ import MonacoEditor from "react-monaco-editor";
 import { useThemeMode } from "@/services/states";
 import { Controller, useForm } from "react-hook-form";
 import { showNotice } from "@/services/noticeService";
+import {
+  requestIdleCallback,
+  cancelIdleCallback,
+} from "foxact/request-idle-callback";
 
 interface Props {
   proxiesUid: string;
@@ -195,11 +199,11 @@ export const GroupsEditorViewer = (props: Props) => {
           // 防止异常导致UI卡死
         }
       };
-      if (window.requestIdleCallback) {
-        window.requestIdleCallback(serialize);
-      } else {
-        setTimeout(serialize, 0);
-      }
+
+      const handle = requestIdleCallback(serialize);
+      return () => {
+        cancelIdleCallback(handle);
+      };
     }
   }, [prependSeq, appendSeq, deleteSeq]);
 

--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -476,31 +476,34 @@ export const ProxyGroups = (props: Props) => {
     }
   }, [handleWheel]);
 
-  // 添加窗口大小变化监听和最大高度计算
-  const updateMaxHeight = useCallback(() => {
-    if (!alphabetSelectorRef.current) return;
-
-    const windowHeight = window.innerHeight;
-    const bottomMargin = 60; // 底部边距
-    const topMargin = bottomMargin * 2; // 顶部边距是底部的2倍
-    const availableHeight = windowHeight - (topMargin + bottomMargin);
-
-    // 调整选择器的位置，使其偏下
-    const offsetPercentage =
-      (((topMargin - bottomMargin) / windowHeight) * 100) / 2;
-    alphabetSelectorRef.current.style.top = `calc(48% + ${offsetPercentage}vh)`;
-
-    setMaxHeight(`${availableHeight}px`);
-  }, []);
-
   // 监听窗口大小变化
+  // layout effect runs before paint
   useEffect(() => {
+    // 添加窗口大小变化监听和最大高度计算
+    const updateMaxHeight = () => {
+      if (!alphabetSelectorRef.current) return;
+
+      const windowHeight = window.innerHeight;
+      const bottomMargin = 60; // 底部边距
+      const topMargin = bottomMargin * 2; // 顶部边距是底部的2倍
+      const availableHeight = windowHeight - (topMargin + bottomMargin);
+
+      // 调整选择器的位置，使其偏下
+      const offsetPercentage =
+        (((topMargin - bottomMargin) / windowHeight) * 100) / 2;
+      alphabetSelectorRef.current.style.top = `calc(48% + ${offsetPercentage}vh)`;
+
+      setMaxHeight(`${availableHeight}px`);
+    };
+
     updateMaxHeight();
+
     window.addEventListener("resize", updateMaxHeight);
+
     return () => {
       window.removeEventListener("resize", updateMaxHeight);
     };
-  }, [updateMaxHeight]);
+  }, []);
 
   if (mode === "direct") {
     return <BaseEmpty text={t("clash_mode_direct")} />;

--- a/src/components/proxy/use-render-list.ts
+++ b/src/components/proxy/use-render-list.ts
@@ -110,7 +110,8 @@ export const useRenderList = (mode: string) => {
       (mode === "rule" && !groups.length) ||
       (mode === "global" && proxies.length < 2)
     ) {
-      setTimeout(() => refreshProxy(), 500);
+      const handle = setTimeout(() => refreshProxy(), 500);
+      return () => clearTimeout(handle);
     }
   }, [proxiesData, mode, refreshProxy]);
 

--- a/src/components/setting/mods/backup-viewer.tsx
+++ b/src/components/setting/mods/backup-viewer.tsx
@@ -3,7 +3,7 @@ import {
   useImperativeHandle,
   useState,
   useCallback,
-  useEffect,
+  useMemo,
 } from "react";
 import { useTranslation } from "react-i18next";
 import { BaseDialog, DialogRef } from "@/components/base";
@@ -30,7 +30,6 @@ export const BackupViewer = forwardRef<DialogRef>((props, ref) => {
 
   const [isLoading, setIsLoading] = useState(false);
   const [backupFiles, setBackupFiles] = useState<BackupFile[]>([]);
-  const [dataSource, setDataSource] = useState<BackupFile[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(0);
 
@@ -91,14 +90,14 @@ export const BackupViewer = forwardRef<DialogRef>((props, ref) => {
       .sort((a, b) => (a.backup_time.isAfter(b.backup_time) ? -1 : 1));
   };
 
-  useEffect(() => {
-    setDataSource(
+  const dataSource = useMemo<BackupFile[]>(
+    () =>
       backupFiles.slice(
         page * DEFAULT_ROWS_PER_PAGE,
         page * DEFAULT_ROWS_PER_PAGE + DEFAULT_ROWS_PER_PAGE,
       ),
-    );
-  }, [page, backupFiles]);
+    [backupFiles, page],
+  );
 
   return (
     <BaseDialog
@@ -116,18 +115,10 @@ export const BackupViewer = forwardRef<DialogRef>((props, ref) => {
         <Paper elevation={2} sx={{ padding: 2 }}>
           <BackupConfigViewer
             setLoading={setIsLoading}
-            onBackupSuccess={async () => {
-              fetchAndSetBackupFiles();
-            }}
-            onSaveSuccess={async () => {
-              fetchAndSetBackupFiles();
-            }}
-            onRefresh={async () => {
-              fetchAndSetBackupFiles();
-            }}
-            onInit={async () => {
-              fetchAndSetBackupFiles();
-            }}
+            onBackupSuccess={fetchAndSetBackupFiles}
+            onSaveSuccess={fetchAndSetBackupFiles}
+            onRefresh={fetchAndSetBackupFiles}
+            onInit={fetchAndSetBackupFiles}
           />
           <Divider sx={{ marginY: 2 }} />
           <BackupTableViewer

--- a/src/components/setting/mods/network-interface-viewer.tsx
+++ b/src/components/setting/mods/network-interface-viewer.tsx
@@ -6,13 +6,11 @@ import { alpha, Box, Button, IconButton } from "@mui/material";
 import { ContentCopyRounded } from "@mui/icons-material";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { showNotice } from "@/services/noticeService";
+import useSWR from "swr";
 
 export const NetworkInterfaceViewer = forwardRef<DialogRef>((props, ref) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const [networkInterfaces, setNetworkInterfaces] = useState<
-    INetworkInterface[]
-  >([]);
   const [isV4, setIsV4] = useState(true);
 
   useImperativeHandle(ref, () => ({
@@ -22,12 +20,13 @@ export const NetworkInterfaceViewer = forwardRef<DialogRef>((props, ref) => {
     close: () => setOpen(false),
   }));
 
-  useEffect(() => {
-    if (!open) return;
-    getNetworkInterfacesInfo().then((res) => {
-      setNetworkInterfaces(res);
-    });
-  }, [open]);
+  const { data: networkInterfaces } = useSWR(
+    "clash-verge-rev-internal://network-interfaces",
+    getNetworkInterfacesInfo,
+    {
+      fallbackData: [], // default data before fetch
+    },
+  );
 
   return (
     <BaseDialog


### PR DESCRIPTION
- Remove unnecessary `useEffect`
  - `useSWR` runs outside of React and syncs its data into React using `useSyncExternalStore`. And it handles async resources and cache properly.
  - It is wrong to set state directly inside `useEffect`. Sometimes it can be replaced with `useMemo`.
  - Handling storage is tricky. Use `foxact/use-local-storage` to simplify the process.
- Remove unnecessary `useCallback`
  - We can store a callback directly inside `useEffect`.
- Clean up some untidy effects.