### PR TITLE
fix: remove unused redir-port and tproxy-port on Windows

### DIFF
--- a/src-tauri/src/enhance/mod.rs
+++ b/src-tauri/src/enhance/mod.rs
@@ -214,6 +214,12 @@ pub async fn enhance() -> (Mapping, Vec<String>, HashMap<String, ResultLog>) {
                 config.remove("port");
                 continue;
             }
+            #[cfg(target_os = "windows")]
+            {
+                if key.as_str() == Some("redir-port") || key.as_str() == Some("tproxy-port") {
+                    continue;
+                }
+            }
             #[cfg(not(target_os = "windows"))]
             {
                 if key.as_str() == Some("redir-port") && !redir_enabled {


### PR DESCRIPTION
Directly remove redir-port and tproxy-port configurations on Windows platform
before：
<img width="310" alt="{9F3F0D3A-6245-4A07-9B2B-C7982185BA29}" src="https://github.com/user-attachments/assets/98b00536-4381-4146-91a8-ff51005d6e19" />

after：

<img width="310" alt="{2EB546EC-4D2F-4436-9796-0778EB50587D}" src="https://github.com/user-attachments/assets/77ab14aa-2cec-4875-a43c-0c796eafd4b7" />
