### PR TITLE
Chore (Renovate): Disable Dependency Dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    ":disableDependencyDashboard"
+  ],
   "baseBranches": ["dev"],
   "enabledManagers": ["cargo", "npm"],
   "labels": ["dependencies"],


### PR DESCRIPTION
## What's this?

I've noticed that there's a special issue in this repository, which acts as a "dependency dashboard" for Renovate. According to manual of renovate, I would recommend this pull request of changing renovate configuration file to disable this dashboard.

- Close #3658

## Additional information

> ## How to disable the dashboard
> 
> To disable the Dependency Dashboard, add the preset `:disableDependencyDashboard` or set `dependencyDashboard` to `false`.
> 
> ```json
> {
>   "extends": ["config:recommended", ":disableDependencyDashboard"]
> }
> ```
> 
> _Originally posted in [documentation](https://docs.renovatebot.com/key-concepts/dashboard/#how-to-disable-the-dashboard) of Renovate_