### PR TITLE
fix: the problem that the DNS override nameserver-policy field cannot correctly recognize multiple writing methods

### DIFF
--- a/UPDATELOG.md
+++ b/UPDATELOG.md
@@ -10,7 +10,8 @@
 - 修复导入订阅时非 http 协议链接被错误尝试导入
 - 修复切换节点后页面长时间 loading 及缓存过期导致的数据不同步问题
 - 修复将快捷键名称更名为 `Clash Verge`之后无法删除图标和无法删除注册表
-- 修复`DNS`覆写服务器支持默认留空
+- 修复`DNS`覆写 `fallback` `proxy server` `nameserver` `direct Nameserver` 字段支持留空
+- 修复`DNS`覆写 `nameserver-policy` 字段无法正确识别 `geo` 库
 
 ### ✨ 新增功能
 

--- a/src/components/setting/mods/dns-viewer.tsx
+++ b/src/components/setting/mods/dns-viewer.tsx
@@ -332,50 +332,50 @@ export const DnsViewer = forwardRef<DialogRef>((props, ref) => {
     }
   };
 
-// 解析nameserver-policy为对象
-const parseNameserverPolicy = (str: string): Record<string, any> => {
-  const result: Record<string, any> = {};
-  if (!str) return result;
+  // 解析nameserver-policy为对象
+  const parseNameserverPolicy = (str: string): Record<string, any> => {
+    const result: Record<string, any> = {};
+    if (!str) return result;
 
-  // 处理geosite:xxx,yyy格式
-  const ruleRegex = /\s*([^=]+?)\s*=\s*([^,]+)(?:,|$)/g;
-  let match;
+    // 处理geosite:xxx,yyy格式
+    const ruleRegex = /\s*([^=]+?)\s*=\s*([^,]+)(?:,|$)/g;
+    let match;
 
-  while ((match = ruleRegex.exec(str)) !== null) {
-    const [, domainsPart, serversPart] = match;
+    while ((match = ruleRegex.exec(str)) !== null) {
+      const [, domainsPart, serversPart] = match;
 
-    // 处理域名部分
-    let domains;
-    if (domainsPart.startsWith('geosite:')) {
-      domains = [domainsPart.trim()];
-    } else {
-      domains = [domainsPart.trim()];
+      // 处理域名部分
+      let domains;
+      if (domainsPart.startsWith("geosite:")) {
+        domains = [domainsPart.trim()];
+      } else {
+        domains = [domainsPart.trim()];
+      }
+
+      // 处理服务器部分
+      const servers = serversPart.split(";").map((s) => s.trim());
+
+      // 为每个域名组分配相同的服务器列表
+      domains.forEach((domain) => {
+        result[domain] = servers;
+      });
     }
 
-    // 处理服务器部分
-    const servers = serversPart.split(';').map(s => s.trim());
+    return result;
+  };
 
-    // 为每个域名组分配相同的服务器列表
-    domains.forEach(domain => {
-      result[domain] = servers;
-    });
-  }
+  // 格式化nameserver-policy为字符串
+  const formatNameserverPolicy = (policy: any): string => {
+    if (!policy || typeof policy !== "object") return "";
 
-  return result;
-};
-
-// 格式化nameserver-policy为字符串
-const formatNameserverPolicy = (policy: any): string => {
-  if (!policy || typeof policy !== 'object') return '';
-
-  // 直接将对象转换为字符串格式
-  return Object.entries(policy)
-    .map(([domain, servers]) => {
-      const serversStr = Array.isArray(servers) ? servers.join(';') : servers;
-      return `${domain}=${serversStr}`;
-    })
-    .join(', ');
-};
+    // 直接将对象转换为字符串格式
+    return Object.entries(policy)
+      .map(([domain, servers]) => {
+        const serversStr = Array.isArray(servers) ? servers.join(";") : servers;
+        return `${domain}=${serversStr}`;
+      })
+      .join(", ");
+  };
 
   // 格式化hosts为字符串
   const formatHosts = (hosts: any): string => {

--- a/src/components/setting/mods/dns-viewer.tsx
+++ b/src/components/setting/mods/dns-viewer.tsx
@@ -332,53 +332,50 @@ export const DnsViewer = forwardRef<DialogRef>((props, ref) => {
     }
   };
 
-  // 格式化nameserver-policy为字符串
-  const formatNameserverPolicy = (policy: any): string => {
-    if (!policy) return "";
+// 解析nameserver-policy为对象
+const parseNameserverPolicy = (str: string): Record<string, any> => {
+  const result: Record<string, any> = {};
+  if (!str) return result;
 
-    let result: string[] = [];
+  // 处理geosite:xxx,yyy格式
+  const ruleRegex = /\s*([^=]+?)\s*=\s*([^,]+)(?:,|$)/g;
+  let match;
 
-    Object.entries(policy).forEach(([domain, servers]) => {
-      if (Array.isArray(servers)) {
-        // 处理数组格式的服务器
-        const serversStr = servers.join(";");
-        result.push(`${domain}=${serversStr}`);
-      } else {
-        // 处理单个服务器
-        result.push(`${domain}=${servers}`);
-      }
+  while ((match = ruleRegex.exec(str)) !== null) {
+    const [, domainsPart, serversPart] = match;
+
+    // 处理域名部分
+    let domains;
+    if (domainsPart.startsWith('geosite:')) {
+      domains = [domainsPart.trim()];
+    } else {
+      domains = [domainsPart.trim()];
+    }
+
+    // 处理服务器部分
+    const servers = serversPart.split(';').map(s => s.trim());
+
+    // 为每个域名组分配相同的服务器列表
+    domains.forEach(domain => {
+      result[domain] = servers;
     });
+  }
 
-    return result.join(", ");
-  };
+  return result;
+};
 
-  // 解析nameserver-policy为对象
-  const parseNameserverPolicy = (str: string): Record<string, any> => {
-    const result: Record<string, any> = {};
-    if (!str) return result;
+// 格式化nameserver-policy为字符串
+const formatNameserverPolicy = (policy: any): string => {
+  if (!policy || typeof policy !== 'object') return '';
 
-    str.split(",").forEach((item) => {
-      const parts = item.trim().split("=");
-      if (parts.length < 2) return;
-
-      const domain = parts[0].trim();
-      const serversStr = parts.slice(1).join("=").trim();
-
-      // 检查是否包含多个分号分隔的服务器
-      if (serversStr.includes(";")) {
-        // 多个服务器，作为数组处理
-        result[domain] = serversStr
-          .split(";")
-          .map((s) => s.trim())
-          .filter(Boolean);
-      } else {
-        // 单个服务器
-        result[domain] = serversStr;
-      }
-    });
-
-    return result;
-  };
+  // 直接将对象转换为字符串格式
+  return Object.entries(policy)
+    .map(([domain, servers]) => {
+      const serversStr = Array.isArray(servers) ? servers.join(';') : servers;
+      return `${domain}=${serversStr}`;
+    })
+    .join(', ');
+};
 
   // 格式化hosts为字符串
   const formatHosts = (hosts: any): string => {


### PR DESCRIPTION
引入 issue #4007 

尝试在 DNS 覆写功能中写入以下配置

```
  nameserver-policy:
    geosite:cn,private:
    - https://doh.pub/dns-query
    - https://dns.alidns.com/dns-query
    geosite:gfw:
    - https://1.1.1.1/dns-query
    - https://dns.google/dns-query
```

当前解析会把 `geosite:cn` 识别为一条单独的规则并丢弃。并识别出 
`private=https://doh.pub/dns-query;https://dns.alidns.com/dns-query`


未修复：

```
  nameserver-policy:
    private:
    - https://doh.pub/dns-query
    - https://dns.alidns.com/dns-query
    geosite:gfw:
    - https://1.1.1.1/dns-query
    - https://dns.google/dns-query
```

修复图：

```
  nameserver-policy:
    geosite:cn,private:
    - https://doh.pub/dns-query
    - https://dns.alidns.com/dns-query
    geosite:gfw:
    - https://1.1.1.1/dns-query
    - https://dns.google/dns-query
```