### PR TITLE
optimization: (fix: the crash when inputting special characters in the search box (#4026))

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -647,5 +647,6 @@
   "Allowed Origins": "Allowed Origins",
   "Please enter a valid url": "Please enter a valid url",
   "Add": "Add",
-  "Development mode: Automatically includes Tauri and localhost origins": "Development mode: Automatically includes Tauri and localhost origins"
+  "Development mode: Automatically includes Tauri and localhost origins": "Development mode: Automatically includes Tauri and localhost origins",
+  "Invalid regular expression": "Invalid regular expression"
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -647,5 +647,6 @@
   "Allowed Origins": "允许的来源",
   "Please enter a valid url": "请输入有效的网址",
   "Add": "添加",
-  "Development mode: Automatically includes Tauri and localhost origins": "开发模式：自动包含 Tauri 和 localhost 来源"
+  "Development mode: Automatically includes Tauri and localhost origins": "开发模式：自动包含 Tauri 和 localhost 来源",
+  "Invalid regular expression": "无效的正则表达式"
 }


### PR DESCRIPTION
# 引入 `issue`#4022 引入 `Commit`  [1d49d79](https://github.com/clash-verge-rev/clash-verge-rev/commit/1d49d79af241b73dec7556d621f5a8d6356d1b09)

## 1d49d79 修复输入特殊字符崩溃，但是进一步导致无法使用正则规则

## 该pr 修复此次问题

### 可以单独输入特殊字符，不会崩溃 只会提示你 

<img width="1329" height="135" alt="image" src="https://github.com/user-attachments/assets/53100e2f-7a8f-4884-9b3d-52ed3cb6efda" />

### 也支持正则匹配
<img width="1322" height="892" alt="image" src="https://github.com/user-attachments/assets/195a8919-5c27-40e2-bb37-d23f801483ea" />
