### PR TITLE
feat (Releases): New assets type - `.snap`

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -268,6 +268,7 @@ jobs:
             target: armv7-unknown-linux-gnueabihf
             arch: armhf
     runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -486,3 +487,60 @@ jobs:
         run: pnpm portable-fixed-webview2 ${{ matrix.target }} --${{ env.TAG_NAME }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  autobuild-all-snap:
+    name: Autobuild All Snaps
+    continue-on-error: true
+    needs:
+      - autobuild-x86-windows-macos-linux
+      - autobuild-arm-linux
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build-for:
+          - amd64
+          - arm64
+          - armhf
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get Version
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq
+          echo "VERSION=$(cat package.json | jq '.version' | tr -d '"')" >> $GITHUB_ENV
+
+      - name: Hijack version and source of Snapcraft
+        shell: python
+        run: |
+          from yaml import safe_load, safe_dump
+
+          with open("./snapcraft.yaml", "r") as conf:
+            snapcraft = safe_load(conf)
+            pass
+          print(f"Original version: {snapcraft['version']}")
+          print(f"Original deb source: {snapcraft['parts']['clash-verge-rev']['source']}")
+          snapcraft['version'] = "${{ env.VERSION }}"
+          snapcraft['parts']['clash-verge-rev']['source'] = "${{ github.server_url }}/${{ github.repository }}/releases/download/${{ env.TAG_NAME }}/Clash.Verge_${{ env.VERSION }}_$CRAFT_ARCH_BUILD_FOR.deb"
+          with open("./snapcraft.yaml", "w") as conf:
+            safe_dump(snapcraft, conf, default_flow_style=False)
+            pass
+          print(f"Hijacked version: {snapcraft['version']}"')
+          print(f"Hijacked deb soursce: {snapcraft['parts']['clash-verge-rev']['source']}")
+          print("Hijacked succeeded!")
+
+      - uses: snapcore/action-build@v1
+        id: build-snap
+        with:
+          snapcraft-args: '-v --build-for ${{ matrix.build-for }}'
+
+      - name: Upload Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG_NAME }}
+          name: "Clash Verge Rev ${{ env.TAG_CHANNEL }}"
+          prerelease: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ steps.build-snap.outputs.snap }}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,138 @@
+# yaml-language-server: $schema=https://github.com/canonical/snapcraft/raw/refs/heads/main/schema/snapcraft.json
+name: clash-verge-rev
+title: Clash Verge Rev
+license: GPL-3.0
+# [NOTE]
+# Will also be hijacked in GitHub Workflows on the fly, to avoid version mismatch with other assets.
+version: "2.4.0"
+type: app
+base: core22
+grade: stable
+confinement: strict
+
+summary: A Clash Meta GUI based on Tauri.
+description: |
+  A modern GUI client based on Tauri, designed to run in Windows, macOS and Linux for tailored proxy experience
+source-code: https://github.com/clash-verge-rev/clash-verge-rev
+contact:
+  # For issues related to this snap.
+  - https://github.com/Dragon1573
+  # For issues related to anything else.
+  - https://github.com/clash-verge-rev
+website: https://www.clashverge.dev/
+# Please also ping @Dragon1573 when reporting bugs specifically related to this Snap.
+issues: https://github.com/clash-verge-rev/clash-verge-rev/issues
+donation: https://github.com/sponsors/clash-verge-rev
+
+icon: src-tauri/icons/128x128.png
+
+layout:
+  ##### Begin: GNOME extension
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgweather-4:
+    symlink: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgweather-4
+  /usr/lib/evolution-data-server:
+    symlink: $SNAP/usr/lib/evolution-data-server
+  /usr/bin/gnome-control-center:
+    symlink: $SNAP/usr/bin/gnome-control-center
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.1:
+    bind: $SNAP/gnome-platform/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/webkit2gtk-4.1
+  /usr/share/xml/iso-codes:
+    bind: $SNAP/gnome-platform/usr/share/xml/iso-codes
+  /usr/share/libdrm:
+    bind: $SNAP/gnome-platform/usr/share/libdrm
+  ##### End: GNOME extension
+
+architectures:
+  # We're currently using amd64 arch of GitHub-hosted Runner.
+  # All other architectures can be cross-built by snapcraft.
+  #
+  # [TODO] Might be able to use arm64 local images for arm64/armhf build?
+  - build-on: amd64
+    # yaml-language-server ignore
+    build-for: amd64
+  - build-on: amd64
+    build-for: arm64
+  - build-on: amd64
+    build-for: armhf
+
+plugs:
+  desktop:
+    mount-host-font-cache: false
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+  gnome-42-2204:
+    interface: content
+    target: $SNAP/gnome-platform
+    default-provider: gnome-42-2204
+  dot-cvr-profiles:
+    interface: personal-files
+    write:
+      - "$HOME/.local/share/io.github.clash-verge-rev.clash-verge-rev"
+  clash-verge-service:
+    interface: system-files
+    read:
+      - "/tmp/clash-verge-service.sock"
+  graphics-core22:
+    interface: content
+    target: $SNAP/graphics
+    default-provider: mesa-core22
+
+apps:
+  clash-verge-rev:
+    command: usr/bin/clash-verge
+    desktop: "usr/share/applications/Clash Verge.desktop"
+    extensions:
+      - gnome
+    plugs:
+      ##### Users specified
+      # Networks
+      - network
+      - network-bind
+      # Profiles
+      - home
+      - dot-cvr-profiles
+      # Unix sockets & BUS
+      - clash-verge-service
+      ##### GNOME extension
+      - desktop
+      - desktop-legacy
+      - gsettings
+      - opengl
+      - wayland
+      - x11
+      - mount-observe
+      - calendar-service
+      - graphics-core22
+
+environment:
+  LIBGL_ALWAYS_SOFTWARE: 1
+  SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
+  GTK_USE_PORTAL: "1"
+
+parts:
+  clash-verge-rev:
+    plugin: dump
+    source-type: deb
+    # [NOTE]
+    # This deb URL is currently hardcoded as a placeholder, convinient for testing on local amd64 machine.
+    # This will be hijacked in GitHub Workflows on the fly.
+    source: https://github.com/clash-verge-rev/clash-verge-rev/releases/download/autobuild/Clash.Verge_2.4.0_amd64.deb
+    build-environment:
+      - PATH: /snap/gnome-42-2204-sdk/current/usr/bin${PATH:+:$PATH}
+      - XDG_DATA_DIRS: $SNAPCRAFT_STAGE/usr/share:/snap/gnome-42-2204-sdk/current/usr/share:/usr/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}
+      - LD_LIBRARY_PATH: /snap/gnome-42-2204-sdk/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:/snap/gnome-42-2204-sdk/current/usr/lib:/snap/gnome-42-2204-sdk/current/usr/lib/vala-current:/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pulseaudio${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+      - PKG_CONFIG_PATH: /snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig:/snap/gnome-42-2204-sdk/current/usr/lib/pkgconfig:/snap/gnome-42-2204-sdk/current/usr/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
+      - GETTEXTDATADIRS: /snap/gnome-42-2204-sdk/current/usr/share/gettext-current${GETTEXTDATADIRS:+:$GETTEXTDATADIRS}
+      - GDK_PIXBUF_MODULE_FILE: /snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-current/loaders.cache
+      - ACLOCAL_PATH: /snap/gnome-42-2204-sdk/current/usr/share/aclocal${ACLOCAL_PATH:+:$ACLOCAL_PATH}
+      - PYTHONPATH: /snap/gnome-42-2204-sdk/current/usr/lib/python3.10:/snap/gnome-42-2204-sdk/current/usr/lib/python3/dist-packages:/snap/gnome-42-2204-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gobject-introspection${PYTHONPATH:+:$PYTHONPATH}


### PR DESCRIPTION
## 啥新玩意儿？

- Related #4105 

本 PR 引入了关于 [SnapCraft](https://snapcraft.io/about) 的全新发行方式，增加 `snapcraft.yaml` 描述文件配置 Snap 构建的必要信息，并在现有 GitHub Workflows 中集成了编译构建流水线。为 Linux 用户提供了 `.snap` 文件用于本地安装。

> [!WARNING]
> 
> 此 Snap 名称尚未在 Snap Store 进行注册，用户安装时需要附加 `--dangerous` 以允许未经 Snap 官方签名许可的程序包。

## 碎碎念

- 当前构建流水线目标仅为 `autobuild` 分支，后续可能会支持其他分支和通道（正式发行版本）
- 当前的 Snap 构建仍处在极为早期的原始原型阶段，可能存在各种奇奇怪怪的 Bug（与 Snap 自身的隔离封闭性有关，和 AppImage 很像），目前在 Windows WSL2 Ubuntu 25.04[^1][^2] 中存在以下已知问题：
  - 必须以 `root` 身份运行 `clash-verge-rev` 主程序以拉起 Mihomo 内核
  - 服务模式不可用[^3]，需使用 `sudo` 手动执行 `/snap` 安装目录下的 `uninstall-service` 提前卸载服务
- 目前的 Snap 使用各自架构的 `.deb` 作为基础源，在 `ubuntu-22.04` 上执行编译构建，尚不确定 `.snap` 是否可以在所有 Linux 发行版通用。

[^1]: WSL `v2.6.0.0` ，内核 `v6.6.87.2-1` ， WSLg `v1.0.66` ， Windows `v10.0.26100.4652`
[^2]: 由 WSLg 提供对图形化应用程序的显示支持，未安装任何桌面环境。
[^3]: 找不到服务模式提供的 `clash-verge-service.sock`