### PR TITLE
CI: Improve Tauri-related commit checking

### DIFF
--- a/.github/workflows/check-commit-needs-build.yml
+++ b/.github/workflows/check-commit-needs-build.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 50
 
       - name: Check if version changed or src changed
         id: check

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -53,7 +53,7 @@ function getGitShortCommit() {
  */
 function getLatestTauriCommit() {
   try {
-    const fullHash = execSync("./scripts-workflow/get_latest_tauri_commit.bash")
+    const fullHash = execSync("bash ./scripts-workflow/get_latest_tauri_commit.bash")
       .toString()
       .trim();
     return execSync(`git rev-parse --short ${fullHash}`).toString().trim();


### PR DESCRIPTION
## ❓ What's changed

- Fix (`check-commit-needs-build.yml`): Increase `fetch-depth` to 50 for more accurate commit history in CI
- Fix (`release-version.mjs`): Use `bash` **explicitly** for improved compatibility
  - Also avoid errors when invoking the script, see [this](https://github.com/clash-verge-rev/clash-verge-rev/actions/runs/17126024477/job/48577810095#step:10:18) for example

## ❓ Why

The step "Check if version changed or src changed" in `check-commit-needs-build.yml` invokes Bash script `scripts-workflow/get_latest_tauri_commit.bash` for inspecting the latest commit that modifies Tauri-related path. When setting `actions/checkout@v4` with `fetch-depth` greater than 0, "shallow clone" will be enabled. For a current value as 2, if the actual last correct commit was 3 or more commits before, we might get a wrong hash because of the shallow clone. Since we update this repository frequently, increase it to 50 is enough for getting the correct hash.

`release-version.mjs` invokes `scripts-workflow/get_latest_tauri_commit.bash` with `execSync()` function provided by `child_process` library. When running this `.mjs` locally in **Git Bash** on Windows or via GitHub-hosted Runner, an error will encounter because of the incorrect parameter. Adding prefix `bash` to explicitly run it as a bash script can solve the problem.

```log
'.' is not recognized as an internal or external command,
operable program or batch file.
[WARN]: Failed to get latest Tauri commit, fallback to current git short commit
```