### PR TITLE
fix: auto-detect KDE/Plasma and switch to X11 as backend to fix titlebar button freeze

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -437,16 +437,17 @@ pub fn run() {
         let desktop_env = std::env::var("XDG_CURRENT_DESKTOP")
             .unwrap_or_default()
             .to_uppercase();
+        let session_env = std::env::var("XDG_SESSION_TYPE").unwrap_or_default();
         let is_kde_desktop = desktop_env.contains("KDE");
-        let is_plasma_desktop = desktop_env.contains("PLASMA");
+        let is_wayland_session = session_env.contains("wayland");
 
-        if is_kde_desktop || is_plasma_desktop {
-            std::env::set_var("GTK_CSD", "0");
+        if is_kde_desktop && is_wayland_session {
+            std::env::set_var("GDK_BACKEND", "x11");
             logging!(
                 info,
                 Type::Setup,
                 true,
-                "KDE detected: Disabled GTK CSD for better titlebar stability."
+                "KDE Wayland detected: Switched to X11 backend for better titlebar stability."
             );
         }
     }


### PR DESCRIPTION
The previous PR #4380  only ran the compiled executable without installing it via the package, and it was found that the GTK_CSD setting did not take effect. The root cause of this issue is that under a Wayland session, the GTK framework automatically enables CSD functionality. However, KDE’s mainline design centers around SSD mode and has relatively poor support for CSD. Therefore, this commit switches the GTK backend to x11 in the KDE Wayland environment to circumvent the impact of this bug. **This change has been thoroughly verified using the RPM installation package.**

However, this straightforward approach is **NOT** the mainstream solution for addressing SSD/CSD issues. Typical Electron/Tauri applications such as VSCode and Obsidian have opted to draw their own buttons (**which may be the primary reason why this project initially avoided using the system window manager**). As #4395 mentioned, I am uncertain about the specific bug that originally led to the changes you were forced to make. 