### PR TITLE
chore(issue template): disable blank issue template in GitHub config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false
 contact_links:
   - name: 讨论交流 / Communication
     url: https://t.me/clash_verge_rev


### PR DESCRIPTION
## For what?

- Prevent users from creating issue without a template
- Always use a template for guiding users to provide necessary information for us

## Example (without template)

- Related #4730 
- Related #4720 
- Related #4541 
- Related #4474 
- Related #4459 