### PR TITLE
stop showing hidden groups in the tray menu

### DIFF
--- a/src-tauri/src/core/tray/mod.rs
+++ b/src-tauri/src/core/tray/mod.rs
@@ -635,7 +635,9 @@ async fn create_tray_menu(
                 let should_show = match mode {
                     "global" => group_name == "GLOBAL",
                     _ => group_name != "GLOBAL",
-                };
+                } &&
+                // Check if the group is hidden
+                !group_data.get("hidden").and_then(|v| v.as_bool( )).unwrap_or(false);
 
                 if !should_show {
                     continue;


### PR DESCRIPTION
托盘菜单不显示隐藏代理组