### PR TITLE
remove incorrect `setupCloseListener` from `_layout.tsx`

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -170,7 +170,7 @@ const Layout = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const routersEles = useRoutes(routers);
-  const { addListener, setupCloseListener } = useListen();
+  const { addListener } = useListen();
   const initRef = useRef(false);
   const [themeReady, setThemeReady] = useState(false);
 
@@ -238,7 +238,6 @@ const Layout = () => {
       };
     };
 
-    setupCloseListener();
     const cleanupWindow = setupWindowListeners();
 
     return () => {


### PR DESCRIPTION
`setupCloseListener` would  remove all listeners when `tauri://close-requested` triggered, so the `verge://refresh-clash-config` listener would be removed.
When the user closed the window and reopened it, the `useEffect` to add listeners would not execute but previous listeners were removed, so UI would not update even if the config was updated.

https://github.com/clash-verge-rev/clash-verge-rev/issues/4718