### PR TITLE
fix: silent start

### DIFF
--- a/src-tauri/src/utils/window_manager.rs
+++ b/src-tauri/src/utils/window_manager.rs
@@ -369,7 +369,7 @@ impl WindowManager {
                 }
             }
 
-            if WindowOperationResult::Failed != Self::show_main_window().await {
+            if WindowOperationResult::Failed == Self::show_main_window().await {
                 return false;
             }
 


### PR DESCRIPTION
调整了窗口创建流程，使成功调用 `show_main_window` 被视为启动成功，从而防止静默启动时错误地停留在轻量模式路径上，而实际上应该加载完整的 WebView。

- `src-tauri/src/utils/window_manager.rs:372` 现在仅在窗口显示真正失败时才会中止，因此 `mark_startup_completed` 依然会执行，并在首次恢复时正常启动 Edge WebView 进程。