### PR TITLE
fix: linux app theme

### DIFF
--- a/UPDATELOG.md
+++ b/UPDATELOG.md
@@ -44,6 +44,7 @@
 - 修复 Windows 深色模式下首次启动客户端标题栏颜色异常
 - 修复静默启动不加载完整 WebView 的问题
 - 修复 Linux WebKit 网络进程的崩溃
+- 修复 Linux GNOME/KDE 桌面下，应用主题颜色选择“系统”后，不随操作系统主题（Dark/Light）切换
 
 ## v2.4.2
 

--- a/src/components/layout/use-custom-theme.ts
+++ b/src/components/layout/use-custom-theme.ts
@@ -53,6 +53,13 @@ export const useCustomTheme = () => {
       return;
     }
 
+    if (
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function"
+    ) {
+      return;
+    }
+
     let isMounted = true;
 
     const timerId = setTimeout(() => {
@@ -89,6 +96,44 @@ export const useCustomTheme = () => {
         });
     };
   }, [theme_mode, appWindow, setMode]);
+
+  useEffect(() => {
+    if (theme_mode !== "system") {
+      return;
+    }
+
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const syncMode = (isDark: boolean) => setMode(isDark ? "dark" : "light");
+    const handleChange = (event: MediaQueryListEvent) =>
+      syncMode(event.matches);
+
+    syncMode(mediaQuery.matches);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    type MediaQueryListLegacy = MediaQueryList & {
+      addListener?: (
+        listener: (this: MediaQueryList, event: MediaQueryListEvent) => void,
+      ) => void;
+      removeListener?: (
+        listener: (this: MediaQueryList, event: MediaQueryListEvent) => void,
+      ) => void;
+    };
+
+    const legacyQuery = mediaQuery as MediaQueryListLegacy;
+    legacyQuery.addListener?.(handleChange);
+    return () => legacyQuery.removeListener?.(handleChange);
+  }, [theme_mode, setMode]);
 
   useEffect(() => {
     if (theme_mode === undefined) {


### PR DESCRIPTION
related https://github.com/clash-verge-rev/clash-verge-rev/issues/4912#issuecomment-3369284485

- 扩展了系统主题效果，使其在可用时优先使用 **matchMedia**，从而让 **GNOME/KDE** 桌面能即时同步深色/浅色模式（`src/components/layout/use-custom-theme.ts:57`）。
    
- 添加了一个兼容旧版 WebView 的 **旧版附件路径**，通过自定义的 `MediaQueryListLegacy` 类型转换，以保持兼容性

