### PR TITLE
fix: linux border render

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -567,7 +567,6 @@ const Layout = () => {
             OS === "linux"
               ? {
                   borderRadius: "8px",
-                  border: "1px solid var(--divider-color)",
                   width: "100vw",
                   height: "100vh",
                 }


### PR DESCRIPTION
在 linux 中，如下代码的 `border` 只会在应用的**左部、顶部**显示，在应用的**右部、底部**并不会显示（见图1-2）：

https://github.com/clash-verge-rev/clash-verge-rev/blob/537a3000b692bac5b7a1d14c884f8a92d3c9bfa9/src/pages/_layout.tsx#L570

<img width="165" height="99" alt="图1" src="https://github.com/user-attachments/assets/ed59a4dc-a3f4-46f5-a32d-3c5045ea64f8" />

*图1：1px border 在应用左、上可见*

<img width="165" height="99" alt="Image" src="https://github.com/user-attachments/assets/e277d713-4616-4801-8f0f-2425da8ecc27" />

*图2：1px border 在应用右、下不可见*

<img width="1983" height="1582" alt="image" src="https://github.com/user-attachments/assets/2e7598ae-51a7-4286-9dc0-f8203235950d" />

*图3：可看到应用的左部、顶部有 1px 的边框*

删除该行后，显示正常：

<img width="1960" height="1582" alt="image" src="https://github.com/user-attachments/assets/388e352d-0212-40f2-8575-d5381eeeeaeb" />

*图4：删除该行后的效果*