### PR TITLE
fix: WindowProvider awful performance

### DIFF
--- a/src/providers/window/index.ts
+++ b/src/providers/window/index.ts
@@ -1,2 +1,3 @@
-export * from "./WindowContext";
-export * from "./WindowProvider";
+export { WindowContext } from "./WindowContext";
+export type { WindowContextType } from "./WindowContext";
+export { WindowProvider } from "./WindowProvider";


### PR DESCRIPTION
启用应用内置标题栏时在 macOS 下表现糟糕性能，前端卡死，托盘无法恢复窗口显示，经过 trace 发现前端短时间内向后端发送大量 tauri 和 wry 命令。

缺陷代码引入

https://github.com/clash-verge-rev/clash-verge-rev/pull/5068/files#diff-63bdb8a20c1561baedb9b151bdd41866738684b142ff5be5f0a8698874d649bdR25-R26


```typescript
updateMaximized();
const unlistenPromise = currentWindow.onResized(updateMaximized);
``` 
删除多余操作后修复性能
```diff
-  updateMaximized();
```

被影响议题：
错误全局 Revert
https://github.com/clash-verge-rev/clash-verge-rev/pull/5105 

对 PR 性能判断产生偏差
https://github.com/clash-verge-rev/clash-verge-rev/pull/5072