### PR TITLE
feat: add tracing support to logger initialization

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -127,6 +127,7 @@ verge-dev = ["clash_verge_logger/color"]
 tauri-dev = []
 tokio-trace = ["console-subscriber"]
 clippy = ["tauri/test"]
+tracing = []
 
 [[bench]]
 name = "draft_benchmark"


### PR DESCRIPTION
提供可选特性 `tracing`，在开发情景中对 tauri 以及 wry 等模块 debug 追溯。

在 https://github.com/clash-verge-rev/clash-verge-rev/pull/5119 中帮助很多。