### PR TITLE
fix: notification not work

### DIFF
--- a/src-tauri/src/core/notification.rs
+++ b/src-tauri/src/core/notification.rs
@@ -96,10 +96,17 @@ impl NotificationSystem {
         let handle = Handle::global();
 
         while !handle.is_exiting() {
-            match rx.recv_timeout(std::time::Duration::from_millis(100)) {
+            match rx.recv() {
                 Ok(event) => Self::process_event(handle, event),
-                Err(mpsc::RecvTimeoutError::Disconnected) => break,
-                Err(mpsc::RecvTimeoutError::Timeout) => break,
+                Err(e) => {
+                    logging!(
+                        error,
+                        Type::System,
+                        "receive event error, stop notification worker: {}",
+                        e
+                    );
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
可能导致的相关 issuse: https://github.com/clash-verge-rev/clash-verge-rev/issues/5229 https://github.com/clash-verge-rev/clash-verge-rev/issues/5187

应用初始化时，recv_timeout 方法超时处理导致 notification 系统退出工作状态，导致 rust 侧向前端窗口发送事件失败