### PR TITLE
fix: linux theme sync

### DIFF
--- a/src/components/layout/use-custom-theme.ts
+++ b/src/components/layout/use-custom-theme.ts
@@ -53,10 +53,13 @@ export const useCustomTheme = () => {
       return;
     }
 
-    if (
+    const preferBrowserMatchMedia =
       typeof window !== "undefined" &&
-      typeof window.matchMedia === "function"
-    ) {
+      typeof window.matchMedia === "function" &&
+      // Skip Tauri flow when running purely in browser.
+      !("__TAURI__" in window);
+
+    if (preferBrowserMatchMedia) {
       return;
     }
 


### PR DESCRIPTION
### Closes #5227.

强制桌面端走 Tauri 的 API，保证一开始就取系统主题并监听变化，而不是只依赖 WebView 自己的 matchMedia。