### PR TITLE
docs(release): Assets URL correction

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -578,7 +578,7 @@ jobs:
           - [64位](${{ env.DOWNLOAD_URL }}/Clash.Verge_${{ env.VERSION }}_amd64_linux.deb) | [ARM64](${{ env.DOWNLOAD_URL }}/Clash.Verge_${{ env.VERSION }}_arm64.deb) | [ARMv7](${{ env.DOWNLOAD_URL }}/Clash.Verge_${{ env.VERSION }}_armhf.deb)
 
           #### RPM包(Redhat系) 使用 dnf ./路径 安装
-          - [64位](${{ env.DOWNLOAD_URL }}/Clash.Verge_${{ env.VERSION }}-1.x86_64_linux.rpm) | [ARM64](${{ env.DOWNLOAD_URL }}/Clash.Verge_${{ env.VERSION }}-1.aarch64.rpm) | [ARMv7](${{ env.DOWNLOAD_URL }}/Clash.Verge_${{ env.VERSION }}-1.armhfp.rpm)
+          - [64位](${{ env.DOWNLOAD_URL }}/Clash.Verge-${{ env.VERSION }}-1.x86_64_linux.rpm) | [ARM64](${{ env.DOWNLOAD_URL }}/Clash.Verge-${{ env.VERSION }}-1.aarch64.rpm) | [ARMv7](${{ env.DOWNLOAD_URL }}/Clash.Verge-${{ env.VERSION }}-1.armhfp.rpm)
 
           ### FAQ
           - [常见问题](https://clash-verge-rev.github.io/faq/windows.html)


### PR DESCRIPTION
## 改了啥？

- 修复 [Release Notes](https://github.com/clash-verge-rev/clash-verge-rev/releases/tag/autobuild) 中指向 Linux RPM 安装包链接的拼写错误

> [!NOTE]
> 
> 不是很清楚当前 Tauri 编译构建生成 Assets 的文件命名规则，`.deb` 包用的命名规则是 `Clash.Verge_2.4.3` (下划线) 而 `.rpm` 用的是 `Clash.Verge-2.4.3` (连字符) 。
> 
> 或许会有更好的 Releases Notes 模板格式？

- Resolve #5293 