### PR TITLE
chore(i18n): add and refine Korean translations using the new i18n system

### DIFF
--- a/src-tauri/locales/ko.yml
+++ b/src-tauri/locales/ko.yml
@@ -1,52 +1,52 @@
 _version: 1
 notifications:
   dashboardToggled:
-    title: Dashboard
-    body: Dashboard visibility has been updated.
+    title: 대시보드
+    body: 대시보드 표시 상태가 업데이트되었습니다.
   clashModeChanged:
-    title: Mode Switch
-    body: Switched to {mode}.
+    title: 모드 전환
+    body: "{mode}(으)로 전환되었습니다."
   systemProxyToggled:
-    title: System Proxy
-    body: System proxy status has been updated.
+    title: 시스템 프록시
+    body: 시스템 프록시 상태가 업데이트되었습니다.
   tunModeToggled:
-    title: TUN Mode
-    body: TUN mode status has been updated.
+    title: TUN 모드
+    body: TUN 모드 상태가 업데이트되었습니다.
   lightweightModeEntered:
-    title: Lightweight Mode
-    body: Entered lightweight mode.
+    title: 경량 모드
+    body: 경량 모드에 진입했습니다.
   appQuit:
-    title: About to Exit
-    body: Clash Verge is about to exit.
+    title: 곧 종료
+    body: Clash Verge가 곧 종료됩니다.
   appHidden:
-    title: Application Hidden
-    body: Clash Verge is running in the background.
+    title: 앱이 숨겨짐
+    body: Clash Verge가 백그라운드에서 실행 중입니다.
 service:
-  adminPrompt: Installing the service requires administrator privileges.
+  adminPrompt: 서비스를 설치하려면 관리자 권한이 필요합니다.
 tray:
-  dashboard: Dashboard
-  ruleMode: Rule Mode
-  globalMode: Global Mode
-  directMode: Direct Mode
-  profiles: Profiles
-  proxies: Proxies
-  systemProxy: System Proxy
-  tunMode: TUN Mode
-  closeAllConnections: Close All Connections
-  lightweightMode: Lightweight Mode
-  copyEnv: Copy Environment Variables
-  confDir: Configuration Directory
-  coreDir: Core Directory
-  logsDir: Log Directory
-  openDir: Open Directory
-  appLog: Application Log
-  coreLog: Core Log
-  restartClash: Restart Clash Core
-  restartApp: Restart Application
-  vergeVersion: Verge Version
-  more: More
-  exit: Exit
+  dashboard: 대시보드
+  ruleMode: 규칙 모드
+  globalMode: 전역 모드
+  directMode: 직접 모드
+  profiles: 프로필
+  proxies: 프록시
+  systemProxy: 시스템 프록시
+  tunMode: TUN 모드
+  closeAllConnections: 모든 연결 닫기
+  lightweightMode: 경량 모드
+  copyEnv: 환경 변수 복사
+  confDir: 구성 디렉터리
+  coreDir: 코어 디렉터리
+  logsDir: 로그 디렉터리
+  openDir: 디렉터리 열기
+  appLog: 애플리케이션 로그
+  coreLog: 코어 로그
+  restartClash: Clash 코어 재시작
+  restartApp: 애플리케이션 재시작
+  vergeVersion: Verge 버전
+  more: 더 보기
+  exit: 종료
   tooltip:
-    systemProxy: System Proxy
+    systemProxy: 시스템 프록시
     tun: TUN
-    profile: Profile
+    profile: 프로필

--- a/src/locales/ko/connections.json
+++ b/src/locales/ko/connections.json
@@ -17,7 +17,7 @@
       "type": "유형"
     },
     "order": {
-      "default": "Default",
+      "default": "기본",
       "uploadSpeed": "업로드 속도",
       "downloadSpeed": "다운로드 속도"
     },

--- a/src/locales/ko/home.json
+++ b/src/locales/ko/home.json
@@ -1,137 +1,137 @@
 {
   "page": {
     "tooltips": {
-      "lightweightMode": "Lightweight Mode",
-      "manual": "Manual",
-      "settings": "Home Settings"
+      "lightweightMode": "경량 모드",
+      "manual": "사용 설명서",
+      "settings": "홈 설정"
     },
     "cards": {
-      "trafficStats": "Traffic Stats",
-      "networkSettings": "Network Settings",
-      "proxyMode": "Proxy Mode"
+      "trafficStats": "트래픽 통계",
+      "networkSettings": "네트워크 설정",
+      "proxyMode": "프록시 모드"
     },
     "settings": {
       "cards": {
-        "profile": "Profile Card",
-        "currentProxy": "Current Proxy Card",
-        "network": "Network Settings Card",
-        "proxyMode": "Proxy Mode Card",
-        "traffic": "Traffic Stats Card",
-        "tests": "Website Tests Card",
-        "ip": "IP Information Card",
-        "clashInfo": "Clash Info Cards",
-        "systemInfo": "System Info Cards"
+        "profile": "프로필 카드",
+        "currentProxy": "현재 프록시 카드",
+        "network": "네트워크 설정 카드",
+        "proxyMode": "프록시 모드 카드",
+        "traffic": "트래픽 통계 카드",
+        "tests": "웹사이트 테스트 카드",
+        "ip": "IP 정보 카드",
+        "clashInfo": "Clash 정보 카드",
+        "systemInfo": "시스템 정보 카드"
       },
-      "title": "Home Settings"
+      "title": "홈 설정"
     },
     "title": "홈"
   },
   "components": {
     "proxyTun": {
       "status": {
-        "systemProxyEnabled": "System proxy is enabled, your applications will access the network through the proxy",
-        "systemProxyDisabled": "System proxy is disabled, it is recommended for most users to turn on this option",
-        "tunModeServiceRequired": "TUN mode requires service mode, please install the service first",
-        "tunModeEnabled": "TUN mode is enabled, applications will access the network through the virtual network card",
-        "tunModeDisabled": "TUN mode is disabled, suitable for special applications"
+        "systemProxyEnabled": "시스템 프록시가 활성화되었습니다. 애플리케이션이 프록시를 통해 네트워크에 접근합니다",
+        "systemProxyDisabled": "시스템 프록시가 비활성화되었습니다. 대부분의 사용자에게 이 옵션을 켜는 것을 권장합니다",
+        "tunModeServiceRequired": "TUN 모드는 서비스 모드가 필요합니다. 먼저 서비스를 설치하세요",
+        "tunModeEnabled": "TUN 모드가 활성화되었습니다. 애플리케이션이 가상 네트워크 카드를 통해 네트워크에 접근합니다",
+        "tunModeDisabled": "TUN 모드가 비활성화되었습니다. 특수 애플리케이션에 적합합니다"
       },
       "tooltips": {
-        "systemProxy": "Enable to modify the operating system's proxy settings. If enabling fails, modify the operating system's proxy settings manually",
-        "tunMode": "TUN mode can take over all application traffic, suitable for special applications that do not follow the system proxy settings"
+        "systemProxy": "운영 체제의 프록시 설정을 수정합니다. 활성화에 실패하면 운영 체제의 프록시 설정을 수동으로 수정하세요",
+        "tunMode": "TUN 모드는 모든 애플리케이션 트래픽을 인수할 수 있으며 시스템 프록시를 따르지 않는 특수 앱에 적합합니다"
       }
     },
     "clashInfo": {
-      "title": "Clash Info",
+      "title": "Clash 정보",
       "fields": {
-        "coreVersion": "Core Version",
-        "systemProxyAddress": "System Proxy Address",
-        "mixedPort": "Mixed Port",
-        "uptime": "Uptime",
-        "rulesCount": "Rules Count"
+        "coreVersion": "코어 버전",
+        "systemProxyAddress": "시스템 프록시 주소",
+        "mixedPort": "혼합 포트",
+        "uptime": "업타임",
+        "rulesCount": "규칙 개수"
       }
     },
     "systemInfo": {
-      "title": "System Info",
+      "title": "시스템 정보",
       "fields": {
-        "osInfo": "OS Info",
-        "autoLaunch": "Auto Launch",
-        "runningMode": "Running Mode",
-        "lastCheckUpdate": "Last Check Update",
-        "vergeVersion": "Verge Version"
+        "osInfo": "OS 정보",
+        "autoLaunch": "자동 실행",
+        "runningMode": "실행 모드",
+        "lastCheckUpdate": "마지막 업데이트 확인",
+        "vergeVersion": "Verge 버전"
       },
       "actions": {
         "settings": "설정"
       },
       "tooltips": {
-        "autoLaunchAdmin": "Administrator mode may not support auto launch"
+        "autoLaunchAdmin": "관리자 모드에서는 자동 실행이 지원되지 않을 수 있습니다"
       },
       "badges": {
-        "adminMode": "Administrator Mode",
+        "adminMode": "관리자 모드",
         "serviceMode": "서비스 모드",
-        "sidecarMode": "User Mode",
-        "adminServiceMode": "Admin + Service Mode"
+        "sidecarMode": "사용자 모드",
+        "adminServiceMode": "관리자 + 서비스 모드"
       }
     },
     "ipInfo": {
-      "title": "IP Information",
+      "title": "IP 정보",
       "labels": {
         "ip": "IP",
         "asn": "ASN",
         "isp": "ISP",
         "org": "ORG",
-        "location": "Location",
-        "timezone": "Timezone",
-        "autoRefresh": "Auto refresh",
-        "unknown": "Unknown"
+        "location": "위치",
+        "timezone": "시간대",
+        "autoRefresh": "자동 새로고침",
+        "unknown": "알 수 없음"
       },
       "errors": {
         "load": "IP 정보를 가져오지 못했습니다"
       }
     },
     "currentProxy": {
-      "title": "Current Node",
+      "title": "현재 노드",
       "actions": {
         "refreshDelay": "지연 확인"
       },
       "labels": {
-        "globalMode": "Global Mode",
-        "directMode": "Direct Mode",
-        "group": "Group",
-        "proxy": "Proxy",
-        "noActiveNode": "No active proxy node"
+        "globalMode": "전역 모드",
+        "directMode": "직접 모드",
+        "group": "그룹",
+        "proxy": "프록시",
+        "noActiveNode": "활성 프록시 노드 없음"
       }
     },
     "tests": {
-      "title": "Website Tests"
+      "title": "웹사이트 테스트"
     },
     "traffic": {
       "metrics": {
         "uploadSpeed": "업로드 속도",
         "downloadSpeed": "다운로드 속도",
         "activeConnections": "활성 연결",
-        "memoryUsage": "메모리 사용량"
+        "memoryUsage": "코어 사용량"
       },
       "legends": {
         "upload": "업로드",
         "download": "다운로드"
       },
       "patterns": {
-        "minutes": "{{time}} Minutes"
+        "minutes": "{{time}}분"
       }
     },
     "clashMode": {
       "errors": {
-        "communication": "Core communication error"
+        "communication": "코어 통신 오류"
       },
       "labels": {
-        "rule": "Rule Mode",
-        "global": "Global Mode",
-        "direct": "Direct Mode"
+        "rule": "규칙",
+        "global": "전역",
+        "direct": "직접"
       },
       "descriptions": {
-        "rule": "Automatically choose proxies according to the rule set.",
-        "global": "Forward all network requests through the selected proxy.",
-        "direct": "Bypass the proxy and connect to the internet directly."
+        "rule": "규칙 세트에 따라 자동으로 프록시를 선택합니다.",
+        "global": "모든 네트워크 요청을 선택한 프록시를 통해 전달합니다.",
+        "direct": "프록시를 우회하여 직접 인터넷에 연결합니다."
       }
     }
   }

--- a/src/locales/ko/layout.json
+++ b/src/locales/ko/layout.json
@@ -12,9 +12,9 @@
         "settings": "설정"
       },
       "menu": {
-        "reorderMode": "Menu reorder mode",
-        "unlock": "Unlock menu order",
-        "lock": "Lock menu order"
+        "reorderMode": "메뉴 재정렬 모드",
+        "unlock": "메뉴 순서 잠금 해제",
+        "lock": "메뉴 순서 잠금"
       }
     }
   }

--- a/src/locales/ko/profiles.json
+++ b/src/locales/ko/profiles.json
@@ -8,16 +8,16 @@
     },
     "batch": {
       "actions": {
-        "delete": "Delete Selected Profiles",
-        "selectAll": "Select All",
-        "deselectAll": "Deselect All",
-        "done": "Done"
+        "delete": "선택한 프로필 삭제",
+        "selectAll": "모두 선택",
+        "deselectAll": "모두 선택 해제",
+        "done": "완료"
       },
       "summary": {
-        "selected": "Selected",
-        "items": "items"
+        "selected": "선택됨",
+        "items": "항목"
       },
-      "title": "Batch Operations"
+      "title": "일괄 작업"
     },
     "importForm": {
       "placeholder": "프로필 URL",
@@ -27,22 +27,22 @@
     },
     "feedback": {
       "errors": {
-        "invalidUrl": "Invalid profile URL. Please enter a URL starting with http:// or https://",
-        "onlyYaml": "Only YAML Files Supported"
+        "invalidUrl": "잘못된 프로필 URL입니다. http:// 또는 https://로 시작하는 URL을 입력하세요",
+        "onlyYaml": "YAML 파일만 지원됩니다"
       },
       "notifications": {
-        "importRetry": "Import failed, retrying with Clash proxy...",
-        "importFail": "Import failed even with Clash proxy",
-        "importNeedsRefresh": "Profile imported but may need manual refresh",
-        "importSuccess": "Profile imported successfully, please restart if not visible",
-        "profileSwitched": "Profile Switched",
-        "profileReactivated": "Profile Reactivated",
-        "switchInterrupted": "Profile switch interrupted by new selection",
-        "batchDeleted": "Selected profiles deleted successfully"
+        "importRetry": "가져오기에 실패했습니다. Clash 프록시로 다시 시도 중...",
+        "importFail": "Clash 프록시로도 가져오기에 실패했습니다",
+        "importNeedsRefresh": "프로필을 가져왔지만 수동 새로고침이 필요할 수 있습니다",
+        "importSuccess": "프로필을 성공적으로 가져왔습니다. 보이지 않으면 재시작하세요",
+        "profileSwitched": "프로필 전환됨",
+        "profileReactivated": "프로필 재활성화됨",
+        "switchInterrupted": "새 선택으로 인해 프로필 전환이 중단되었습니다",
+        "batchDeleted": "선택한 프로필이 삭제되었습니다"
       },
       "notices": {
-        "forceRefreshCompleted": "Force refresh completed",
-        "emergencyRefreshFailed": "Emergency refresh failed: {{message}}"
+        "forceRefreshCompleted": "강제 새로고침 완료",
+        "emergencyRefreshFailed": "긴급 새로고침 실패: {{message}}"
       }
     },
     "title": "프로필"
@@ -50,7 +50,7 @@
   "components": {
     "card": {
       "labels": {
-        "clickToImport": "Click to import subscription"
+        "clickToImport": "클릭하여 구독 가져오기"
       }
     },
     "fileInput": {
@@ -68,29 +68,29 @@
       "extendScript": "스크립트 확장",
       "openFile": "파일 열기",
       "update": "업데이트",
-      "updateViaProxy": "Update via proxy"
+      "updateViaProxy": "프록시를 통해 업데이트"
     },
     "more": {
       "global": {
-        "merge": "Global Merge",
-        "script": "Global Script"
+        "merge": "전역 확장 구성",
+        "script": "전역 확장 스크립트"
       },
       "chips": {
-        "merge": "Merge",
-        "script": "Script"
+        "merge": "병합",
+        "script": "스크립트"
       }
     },
     "profileItem": {
       "tooltips": {
-        "showLast": "Click to show last update time",
-        "showNext": "Click to show next update"
+        "showLast": "클릭하여 마지막 업데이트 시간 표시",
+        "showNext": "클릭하여 다음 업데이트 표시"
       },
       "status": {
-        "lastUpdateFailed": "Last Update failed",
-        "nextUp": "Next Up",
-        "noSchedule": "No schedule",
-        "unknown": "Unknown",
-        "autoUpdateDisabled": "Auto update disabled"
+        "lastUpdateFailed": "마지막 업데이트 실패",
+        "nextUp": "다음 예정",
+        "noSchedule": "예약 없음",
+        "unknown": "알 수 없음",
+        "autoUpdateDisabled": "자동 업데이트 비활성화됨"
       }
     }
   },
@@ -104,17 +104,17 @@
         "type": "유형",
         "description": "설명",
         "subscriptionUrl": "구독 URL",
-        "httpTimeout": "HTTP Request Timeout",
+        "httpTimeout": "HTTP 요청 시간 초과",
         "updateInterval": "업데이트 간격",
         "useSystemProxy": "시스템 프록시 사용",
         "useClashProxy": "Clash 프록시 사용",
         "acceptInvalidCerts": "잘못된 인증서 허용(위험)",
-        "allowAutoUpdate": "Allow Auto Update"
+        "allowAutoUpdate": "자동 업데이트 허용"
       },
       "feedback": {
         "notifications": {
-          "creationRetry": "Profile creation failed, retrying with Clash proxy...",
-          "creationSuccess": "Profile creation succeeded with Clash proxy"
+          "creationRetry": "프로필 생성 실패, Clash 프록시로 다시 시도 중...",
+          "creationSuccess": "Clash 프록시로 프로필 생성 성공"
         }
       }
     },
@@ -137,7 +137,7 @@
       "fields": {
         "type": "그룹 유형",
         "name": "그룹 이름",
-        "icon": "Proxy Group Icon",
+        "icon": "프록시 그룹 아이콘",
         "proxies": "프록시 사용",
         "provider": "제공자 사용",
         "healthCheckUrl": "상태 확인 URL",
@@ -168,7 +168,7 @@
         "format": "문서 포맷"
       },
       "messages": {
-        "readOnly": "Cannot edit in read-only editor"
+        "readOnly": "읽기 전용 편집기에서는 편집할 수 없습니다"
       }
     },
     "confirmDelete": {

--- a/src/locales/ko/proxies.json
+++ b/src/locales/ko/proxies.json
@@ -1,16 +1,16 @@
 {
   "page": {
     "modes": {
-      "rule": "Rule",
-      "global": "Global",
-      "direct": "Direct"
+      "rule": "규칙",
+      "global": "전역",
+      "direct": "직접"
     },
     "actions": {
       "toggleChain": "🔗 체인 프록시",
-      "connect": "Connect",
-      "disconnect": "Disconnect",
-      "connecting": "Connecting...",
-      "clearChainConfig": "Delete Chain Config"
+      "connect": "연결",
+      "disconnect": "연결 해제",
+      "connecting": "연결 중...",
+      "clearChainConfig": "체인 구성 삭제"
     },
     "provider": {
       "title": "프록시 제공자",
@@ -20,18 +20,18 @@
       }
     },
     "rules": {
-      "title": "Proxy Rules",
-      "select": "Select Rules"
+      "title": "프록시 규칙",
+      "select": "규칙 선택"
     },
     "labels": {
       "proxyCount": "프록시 개수",
       "delayCheckReset": "고정 취소를 위한 지연 확인"
     },
     "tooltips": {
-      "locate": "로케이트",
+      "locate": "위치 찾기",
       "delayCheck": "지연 확인",
-      "sortDefault": "기본값으로 정렬",
-      "sortDelay": "지연시간으로 정렬",
+      "sortDefault": "기본 정렬",
+      "sortDelay": "지연으로 정렬",
       "sortName": "이름으로 정렬",
       "delayCheckUrl": "지연 확인 URL",
       "showBasic": "프록시 기본",
@@ -42,31 +42,31 @@
       "delayCheckUrl": "지연 확인 URL"
     },
     "chain": {
-      "header": "Chain Proxy Config",
-      "empty": "No proxy chain configured",
-      "instruction": "Click nodes in order to add to proxy chain",
-      "minimumNodes": "Chain proxy requires at least 2 nodes",
-      "minimumNodesHint": "Chain proxy requires at least 2 nodes. Please add one more node.",
-      "connectFailed": "Failed to connect to proxy chain",
-      "disconnectFailed": "Failed to disconnect from proxy chain",
-      "duplicateNode": "Proxy node already exists in chain"
+      "header": "체인 프록시 구성",
+      "empty": "구성된 프록시 체인이 없습니다",
+      "instruction": "프록시 체인에 추가하려면 순서대로 노드를 클릭하세요",
+      "minimumNodes": "체인 프록시는 최소 2개의 노드가 필요합니다",
+      "minimumNodesHint": "체인 프록시는 최소 2개의 노드가 필요합니다. 하나 더 추가하세요.",
+      "connectFailed": "프록시 체인 연결 실패",
+      "disconnectFailed": "프록시 체인 연결 해제 실패",
+      "duplicateNode": "프록시 노드가 체인에 이미 존재합니다"
     },
     "messages": {
-      "directMode": "Direct Mode"
+      "directMode": "직접 모드"
     },
     "title": {
       "default": "프록시 그룹",
-      "chainMode": "Proxy Chain Mode"
+      "chainMode": "프록시 체인 모드"
     }
   },
   "feedback": {
     "notifications": {
       "provider": {
-        "updateSuccess": "{{name}} updated successfully",
-        "updateFailed": "Failed to update {{name}}: {{message}}",
-        "genericError": "Update failed: {{message}}",
-        "none": "No providers available to update",
-        "allUpdated": "All providers updated successfully"
+        "updateSuccess": "{{name}} 업데이트 성공",
+        "updateFailed": "{{name}} 업데이트 실패: {{message}}",
+        "genericError": "업데이트 실패: {{message}}",
+        "none": "업데이트할 제공자가 없습니다",
+        "allUpdated": "모든 제공자가 업데이트되었습니다"
       }
     }
   },

--- a/src/locales/ko/rules.json
+++ b/src/locales/ko/rules.json
@@ -13,11 +13,11 @@
   "feedback": {
     "notifications": {
       "provider": {
-        "updateSuccess": "{{name}} updated successfully",
-        "updateFailed": "Failed to update {{name}}: {{message}}",
-        "genericError": "Update failed: {{message}}",
-        "none": "No providers available to update",
-        "allUpdated": "All providers updated successfully"
+        "updateSuccess": "{{name}} 업데이트 성공",
+        "updateFailed": "{{name}} 업데이트 실패: {{message}}",
+        "genericError": "업데이트 실패: {{message}}",
+        "none": "업데이트할 제공자가 없습니다",
+        "allUpdated": "모든 제공자가 업데이트되었습니다"
       }
     }
   },

--- a/src/locales/ko/shared.json
+++ b/src/locales/ko/shared.json
@@ -8,14 +8,14 @@
     "edit": "편집",
     "new": "새로 만들기",
     "enable": "활성화",
-    "upgrade": "Upgrade",
-    "restart": "Restart",
-    "resetToDefault": "Reset to Default",
+    "upgrade": "업그레이드",
+    "restart": "재시작",
+    "resetToDefault": "기본값으로 재설정",
     "refresh": "새로고침",
-    "retry": "Retry",
-    "refreshPage": "Refresh Page",
-    "showDetails": "Show Details",
-    "hideDetails": "Hide Details",
+    "retry": "재시도",
+    "refreshPage": "페이지 새로고침",
+    "showDetails": "세부정보 보기",
+    "hideDetails": "세부정보 숨기기",
     "listView": "목록 보기",
     "tableView": "테이블 보기",
     "pause": "일시 정지",
@@ -25,23 +25,23 @@
   },
   "labels": {
     "updateAt": "업데이트 시간",
-    "timeout": "Timeout",
+    "timeout": "시간 초과",
     "icon": "아이콘",
     "name": "이름",
-    "readOnly": "ReadOnly",
+    "readOnly": "읽기 전용",
     "expireTime": "만료 시간",
     "updateTime": "업데이트 시간",
     "usedTotal": "사용됨 / 전체",
     "from": "출처",
     "password": "비밀번호",
-    "retryAttempts": "Retry attempts",
+    "retryAttempts": "재시도 횟수",
     "downloaded": "다운로드됨",
     "uploaded": "업로드됨"
   },
   "statuses": {
-    "enabled": "Enabled",
-    "disabled": "Disabled",
-    "saving": "Saving...",
+    "enabled": "사용",
+    "disabled": "비활성화",
+    "saving": "저장 중...",
     "empty": "비어있음"
   },
   "units": {
@@ -49,16 +49,16 @@
     "seconds": "초",
     "minutes": "분",
     "kilobytes": "KB",
-    "files": "Files"
+    "files": "파일"
   },
   "placeholders": {
-    "filter": "Filter conditions",
-    "matchCase": "Match Case",
-    "matchWholeWord": "Match Whole Word",
-    "useRegex": "Use Regular Expression"
+    "filter": "필터 조건",
+    "matchCase": "대/소문자 구분",
+    "matchWholeWord": "단어 전체 일치",
+    "useRegex": "정규식 사용"
   },
   "validation": {
-    "invalidRegex": "Invalid regular expression"
+    "invalidRegex": "잘못된 정규식"
   },
   "window": {
     "maximize": "최대화",
@@ -70,23 +70,23 @@
   },
   "feedback": {
     "errors": {
-      "trafficStats": "Traffic Statistics Error",
-      "trafficStatsDescription": "The traffic statistics component encountered an error and has been disabled to prevent crashes."
+      "trafficStats": "트래픽 통계 오류",
+      "trafficStatsDescription": "트래픽 통계 구성 요소에서 오류가 발생하여 충돌을 방지하기 위해 비활성화되었습니다."
     },
     "notices": {
       "raw": "{{message}}",
       "prefixedRaw": "{{prefix}} {{message}}"
     },
     "notifications": {
-      "importSuccess": "Profile Imported Successfully",
+      "importSuccess": "프로필 가져오기 성공",
       "importSubscriptionSuccess": "구독 가져오기 성공",
-      "importWithClashProxy": "Profile Imported with Clash proxy",
-      "updateAvailable": "Update Available",
-      "saved": "Saved successfully",
+      "importWithClashProxy": "Clash 프록시로 프로필 가져오기",
+      "updateAvailable": "업데이트 가능",
+      "saved": "저장되었습니다",
       "common": {
         "copySuccess": "복사 성공",
-        "saveSuccess": "Configuration saved successfully",
-        "saveFailed": "Failed to save configuration"
+        "saveSuccess": "설정이 저장되었습니다",
+        "saveFailed": "설정 저장 실패"
       }
     },
     "validation": {

--- a/src/locales/ko/tests.json
+++ b/src/locales/ko/tests.json
@@ -25,16 +25,16 @@
   },
   "statuses": {
     "test": {
-      "pending": "Pending",
-      "yes": "Yes",
-      "no": "No",
+      "pending": "대기 중",
+      "yes": "예",
+      "no": "아니오",
       "failed": "실패",
-      "completed": "Completed",
-      "disallowedIsp": "Disallowed ISP",
-      "originalsOnly": "Originals Only",
-      "noDisney": "No (IP Banned By Disney+)",
-      "unsupportedRegion": "Unsupported Country/Region",
-      "failedNetwork": "Failed (Network Connection)"
+      "completed": "완료",
+      "disallowedIsp": "허용되지 않는 ISP",
+      "originalsOnly": "오리지널만",
+      "noDisney": "아니오 (Disney+에 의해 IP 차단)",
+      "unsupportedRegion": "지원되지 않는 국가/지역",
+      "failedNetwork": "실패 (네트워크 연결)"
     }
   },
   "unlock": {
@@ -42,12 +42,12 @@
       "actions": {
         "testing": "테스트 중..."
       },
-      "empty": "No unlock test items",
+      "empty": "잠금 해제 테스트 항목이 없습니다",
       "messages": {
         "detectionFailedWithName": "{{name}} 감지에 실패했습니다",
-        "detectionTimeout": "Detection timeout or failed"
+        "detectionTimeout": "감지 시간 초과 또는 실패"
       },
-      "title": "Unlock Test"
+      "title": "잠금 해제 테스트"
     }
   }
 }


### PR DESCRIPTION
Summary
- Introduces and refines full Korean (ko) translations across the frontend scopes and the Rust backend, following the new i18n architecture introduced in #5276.

What changed
- Frontend: Updated ko translations in:
  - connections
  - home
  - layout
  - profiles
  - proxies
  - rules
  - shared
  - tests
- Backend: Translated src-tauri/locales/ko.yml (notifications, tray entries)
- No i18n keys were changed; only translation values. Placeholders are preserved.
- Notice keys used by the unified showNotice API (e.g., shared.feedback.notices.raw/prefixedRaw) are kept intact.

Checklist
- [x] Conforms to the new per-scope i18n structure
- [x] Preserves all keys and placeholders (values only)
- [x] Aligns with rust_i18n YAML format for backend
- [x] Keeps showNotice integration unaffected