### PR TITLE
refactor: use smol for system signal handle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock 3.4.1",
+ "blocking",
+ "futures-lite 2.6.1",
+]
+
+[[package]]
 name = "async-io"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +330,17 @@ dependencies = [
  "async-io 1.13.0",
  "blocking",
  "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io 2.6.0",
+ "blocking",
+ "futures-lite 2.6.1",
 ]
 
 [[package]]
@@ -1202,6 +1224,7 @@ dependencies = [
  "clash-verge-logging",
  "log",
  "signal-hook 0.3.18",
+ "smol 2.0.2",
  "tauri",
  "windows-sys 0.61.2",
 ]
@@ -1281,7 +1304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1785,7 +1808,7 @@ dependencies = [
  "once_cell",
  "rs-snowflake",
  "rustc_version 0.2.3",
- "smol",
+ "smol 1.3.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -3383,7 +3406,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4987,7 +5010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5763,7 +5786,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5800,7 +5823,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6952,13 +6975,30 @@ checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
 dependencies = [
  "async-channel 1.9.0",
  "async-executor",
- "async-fs",
+ "async-fs 1.6.0",
  "async-io 1.13.0",
  "async-lock 2.8.0",
- "async-net",
+ "async-net 1.8.0",
  "async-process 1.8.1",
  "blocking",
  "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-fs 2.2.0",
+ "async-io 2.6.0",
+ "async-lock 3.4.1",
+ "async-net 2.0.0",
+ "async-process 2.5.0",
+ "blocking",
+ "futures-lite 2.6.1",
 ]
 
 [[package]]
@@ -9246,7 +9286,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/clash-verge-signal/Cargo.toml
+++ b/crates/clash-verge-signal/Cargo.toml
@@ -5,14 +5,15 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-tauri = { workspace = true }
 clash-verge-logging = { workspace = true }
 log = { workspace = true }
+smol = "2.0.2"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3.18"
 
 [target.'cfg(windows)'.dependencies]
+tauri = { workspace = true }
 windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",

--- a/crates/clash-verge-signal/src/unix.rs
+++ b/crates/clash-verge-signal/src/unix.rs
@@ -11,7 +11,7 @@ where
     F: Fn() -> Fut + Send + Sync + 'static,
     Fut: Future + Send + 'static,
 {
-    tauri::async_runtime::spawn(async move {
+    smol::spawn(async move {
         let signals = [SIGTERM, SIGINT, SIGHUP];
 
         let mut sigs = match Signals::new(signals) {
@@ -40,5 +40,6 @@ where
                 low_level::emulate_default_handler(signal)
             );
         }
-    });
+    })
+    .detach();
 }

--- a/crates/clash-verge-signal/src/windows.rs
+++ b/crates/clash-verge-signal/src/windows.rs
@@ -56,7 +56,7 @@ unsafe extern "system" fn shutdown_proc(
         }
         WM_ENDSESSION => {
             if let Some(handler) = SHUTDOWN_HANDLER.get() {
-                tauri::async_runtime::block_on(async {
+                smol::block_on(async {
                     logging!(info, Type::System, "Session ended, system shutting down.");
                     handler().await;
                     logging!(info, Type::System, "resolved reset finished");


### PR DESCRIPTION
The tauri::async_runtime is GUI related async runtime, we do not want the GUI and related data hanlding to block signal listen.
