### PR TITLE
refactor: profiles use IndexMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,7 @@ dependencies = [
  "boa_interner",
  "boa_macros",
  "boa_string",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "num-bigint",
  "rustc-hash",
 ]
@@ -706,9 +706,9 @@ dependencies = [
  "futures-channel",
  "futures-concurrency",
  "futures-lite 2.6.1",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "icu_normalizer",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "intrusive-collections",
  "itertools 0.14.0",
  "num-bigint",
@@ -741,7 +741,7 @@ checksum = "f1179f690cbfcbe5364cceee5f1cb577265bb6f07b0be6f210aabe270adcf9da"
 dependencies = [
  "boa_macros",
  "boa_string",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "thin-vec",
 ]
 
@@ -753,8 +753,8 @@ checksum = "9626505d33dc63d349662437297df1d3afd9d5fc4a2b3ad34e5e1ce879a78848"
 dependencies = [
  "boa_gc",
  "boa_macros",
- "hashbrown 0.16.0",
- "indexmap 2.12.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.12.1",
  "once_cell",
  "phf 0.13.1",
  "rustc-hash",
@@ -1131,6 +1131,7 @@ dependencies = [
  "futures",
  "gethostname",
  "getrandom 0.3.4",
+ "indexmap 2.12.1",
  "log",
  "nanoid",
  "network-interface",
@@ -3002,7 +3003,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -3021,7 +3022,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -3078,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3594,12 +3595,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -3904,7 +3905,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser",
  "html5ever",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "selectors",
 ]
 
@@ -5166,7 +5167,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
 ]
 
 [[package]]
@@ -5401,7 +5402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "quick-xml 0.38.4",
  "serde",
  "time",
@@ -6067,7 +6068,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "memchr",
 ]
 
@@ -6713,7 +6714,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "schemars 0.9.0",
  "schemars 1.1.0",
  "serde_core",
@@ -6740,7 +6741,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itoa",
  "ryu",
  "serde",
@@ -6753,7 +6754,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itoa",
  "ryu",
  "serde",
@@ -8209,7 +8210,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "serde_core",
  "serde_spanned 1.0.3",
  "toml_datetime 0.7.3",
@@ -8242,7 +8243,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -8253,7 +8254,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -8264,7 +8265,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -8278,7 +8279,7 @@ version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "toml_datetime 0.7.3",
  "toml_parser",
  "winnow 0.7.13",
@@ -8433,7 +8434,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",
@@ -10166,7 +10167,7 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "memchr",
 ]
 
@@ -10185,7 +10186,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "hmac",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ log = "0.4.28"
 
 smartstring = { version = "1.0.1" }
 compact_str = { version = "0.9.0", features = ["serde"] }
+indexmap = { version = "2.12.1" }
 
 serde = { version = "1.0.228" }
 serde_json = { version = "1.0.145" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 smartstring = { workspace = true, features = ["serde"] }
+indexmap = { workspace = true, features = ["serde"] } #TODO 迁移完成后移除
 warp = { version = "0.4.2", features = ["server"] }
 open = "5.3.3"
 dunce = "1.0.5"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,7 +52,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 smartstring = { workspace = true, features = ["serde"] }
-indexmap = { workspace = true, features = ["serde"] } #TODO 迁移完成后移除
+indexmap = { workspace = true, features = ["serde"] }
 warp = { version = "0.4.2", features = ["server"] }
 open = "5.3.3"
 dunce = "1.0.5"

--- a/src-tauri/src/config/profiles.rs
+++ b/src-tauri/src/config/profiles.rs
@@ -209,8 +209,10 @@ impl IProfiles {
             _ => return Ok(()),
         };
 
-        if let Some(item) = items.swap_remove(&old_key) {
-            items.insert(new_key, item);
+        let old_index = items.get_index_of(&old_key);
+        let new_index = items.get_index_of(&new_key);
+        if let (Some(old_idx), Some(new_idx)) = (old_index, new_index) {
+            items.move_index(old_idx, new_idx);
         }
 
         self.items = Some(items);

--- a/src/hooks/use-profiles.ts
+++ b/src/hooks/use-profiles.ts
@@ -2,11 +2,11 @@ import useSWR, { mutate } from "swr";
 import { selectNodeForGroup } from "tauri-plugin-mihomo-api";
 
 import {
+  calcuProxies,
   getProfiles,
   patchProfile,
   patchProfilesConfig,
 } from "@/services/cmds";
-import { calcuProxies } from "@/services/cmds";
 
 export const useProfiles = () => {
   const {
@@ -83,9 +83,10 @@ export const useProfiles = () => {
         return;
       }
 
-      const current = profileData.items?.find(
-        (e) => e && e.uid === profileData.current,
-      );
+      const current =
+        profileData.current && profileData.items
+          ? profileData.items[profileData.current]
+          : undefined;
 
       if (!current) {
         console.log("[ActivateSelected] 未找到当前profile配置");
@@ -197,7 +198,7 @@ export const useProfiles = () => {
 
   return {
     profiles,
-    current: profiles?.items?.find((p) => p && p.uid === profiles.current),
+    current: profiles?.items?.[profiles.current || ""],
     activateSelected,
     patchProfiles,
     patchCurrent,

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -263,11 +263,11 @@ const ProfilePage = () => {
 
   // distinguish type
   const profileItems = useMemo(() => {
-    const items = profiles.items || [];
+    const items = profiles.items || {};
 
     const type1 = ["local", "remote"];
 
-    return items.filter((i) => i && type1.includes(i.type!));
+    return Object.values(items).filter((i) => i && type1.includes(i.type!));
   }, [profiles]);
 
   const currentActivatings = () => {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -280,7 +280,7 @@ interface IProfileOption {
 
 interface IProfilesConfig {
   current?: string;
-  items?: IProfileItem[];
+  items?: Record<string, IProfileItem>;
 }
 
 interface IVergeTestItem {


### PR DESCRIPTION
在 https://github.com/clash-verge-rev/clash-verge-rev/commit/97769cf93a874cc2d6e55a2cc14cd1ea4251d42c 中迁移了 Prfitem 内部数据查找方式，避免多次 On 查找。但核心配置结构 Vec<Prfitem> 仍然是 On。本次 PR 引入 indexmap 在保持排序特性下实现 O1 核心配置查找。兼容读取 Vec<Prfitem> 数据格式，保存时会覆盖为新的 IndexMap<String, Prfitem>，因此无法重新安装旧版本读取配置数据。