### PR TITLE
feat: imporve the layout of proxies page

### DIFF
--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -597,7 +597,7 @@ export const ProxyGroups = (props: Props) => {
         initialScrollTop={scrollPositionRef.current[mode]}
         computeItemKey={(index) => renderList[index].key}
         itemContent={(index) => (
-          <div style={{ paddingRight: 14, paddingLeft: 14 }}>
+          <div style={{ paddingRight: 14 }}>
             <ProxyRender
               key={renderList[index].key}
               item={renderList[index]}


### PR DESCRIPTION
Closes: https://github.com/clash-verge-rev/clash-verge-rev/issues/5556
列表两侧添加少量的空间，避免右侧导航栏和列表项check按钮重叠造成误触
<img width="1410" height="1050" alt="image" src="https://github.com/user-attachments/assets/6ed59060-5a9f-4f20-92c3-b9cadc15159a" />
