### PR TITLE
Add monitor validation for window state restoration with multi-monitor support close #5712

### DIFF
--- a/src-tauri/src/utils/resolve/window.rs
+++ b/src-tauri/src/utils/resolve/window.rs
@@ -1,13 +1,14 @@
 use dark_light::{Mode as SystemTheme, detect as detect_system_theme};
 use tauri::utils::config::Color;
-use tauri::{Theme, WebviewWindow};
+use tauri::{Theme, WebviewWindow, Monitor};
+use std::path::PathBuf;
 
 use crate::{
     config::Config,
     core::handle,
-    utils::resolve::window_script::{INITIAL_LOADING_OVERLAY, build_window_initial_script},
+    utils::{dirs, resolve::window_script::{INITIAL_LOADING_OVERLAY, build_window_initial_script}},
 };
-use clash_verge_logging::{Type, logging_error};
+use clash_verge_logging::{Type, logging, logging_error};
 
 const DARK_BACKGROUND_COLOR: Color = Color(46, 48, 61, 255); // #2E303D
 const LIGHT_BACKGROUND_COLOR: Color = Color(245, 245, 245, 255); // #F5F5F5
@@ -20,6 +21,126 @@ const DEFAULT_HEIGHT: f64 = 700.0;
 
 const MINIMAL_WIDTH: f64 = 520.0;
 const MINIMAL_HEIGHT: f64 = 520.0;
+
+/// 窗口状态信息（从 window_state.json 读取）
+#[derive(Debug, Clone, serde::Deserialize)]
+struct WindowState {
+    #[serde(default)]
+    x: Option<i32>,
+    #[serde(default)]
+    y: Option<i32>,
+    #[serde(default)]
+    width: Option<f64>,
+    #[serde(default)]
+    height: Option<f64>,
+}
+
+/// 检查窗口状态文件是否存在，并读取保存的窗口状态
+fn get_saved_window_state() -> Option<WindowState> {
+    let app_dir = dirs::app_home_dir().ok()?;
+    let state_path: PathBuf = app_dir.join(crate::constants::files::WINDOW_STATE);
+    
+    if !state_path.exists() {
+        logging!(info, Type::Window, "窗口状态文件不存在: {:?}", state_path);
+        return None;
+    }
+    
+    match std::fs::read_to_string(&state_path) {
+        Ok(content) => {
+            match serde_json::from_str::<serde_json::Value>(&content) {
+                Ok(json) => {
+                    // 尝试从 JSON 中提取 main 窗口的状态
+                    if let Some(main_state) = json.get("main") {
+                        match serde_json::from_value::<WindowState>(main_state.to_owned()) {
+                            Ok(state) => {
+                                logging!(
+                                    info,
+                                    Type::Window,
+                                    "读取到保存的窗口状态: x={:?}, y={:?}, width={:?}, height={:?}",
+                                    state.x,
+                                    state.y,
+                                    state.width,
+                                    state.height
+                                );
+                                Some(state)
+                            }
+                            Err(e) => {
+                                logging!(
+                                    warn,
+                                    Type::Window,
+                                    "解析窗口状态失败: {}",
+                                    e
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        logging!(info, Type::Window, "窗口状态文件中没有 main 窗口的记录");
+                        None
+                    }
+                }
+                Err(e) => {
+                    logging!(warn, Type::Window, "解析窗口状态 JSON 失败: {}", e);
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            logging!(warn, Type::Window, "读取窗口状态文件失败: {}", e);
+            None
+        }
+    }
+}
+
+/// 验证窗口位置是否在有效的监视器范围内
+/// 如果位置无效（例如监视器已断开），返回 false
+fn validate_window_position(x: i32, y: i32, width: f64, height: f64, monitors: &[Monitor]) -> bool {
+    if monitors.is_empty() {
+        logging!(warn, Type::Window, "没有检测到任何监视器");
+        return false;
+    }
+    
+    // 计算窗口中心点
+    let window_center_x = x + (width / 2.0) as i32;
+    let window_center_y = y + (height / 2.0) as i32;
+    
+    // 检查窗口中心点是否在任何监视器范围内
+    for monitor in monitors {
+        let monitor_pos = monitor.position();
+        let monitor_size = monitor.size();
+        
+        let monitor_x = monitor_pos.x;
+        let monitor_y = monitor_pos.y;
+        let monitor_width = monitor_size.width as i32;
+        let monitor_height = monitor_size.height as i32;
+        
+        // 检查窗口中心是否在监视器范围内
+        if window_center_x >= monitor_x
+            && window_center_x < monitor_x + monitor_width
+            && window_center_y >= monitor_y
+            && window_center_y < monitor_y + monitor_height
+        {
+            logging!(
+                info,
+                Type::Window,
+                "窗口位置有效: 中心点({}, {}) 在监视器 {} 范围内",
+                window_center_x,
+                window_center_y,
+                monitor.name().unwrap_or("Unknown".to_string())
+            );
+            return true;
+        }
+    }
+    
+    logging!(
+        warn,
+        Type::Window,
+        "窗口位置无效: 中心点({}, {}) 不在任何监视器范围内",
+        window_center_x,
+        window_center_y
+    );
+    false
+}
 
 /// 构建新的 WebView 窗口
 pub async fn build_new_window() -> Result<WebviewWindow, String> {
@@ -58,20 +179,58 @@ pub async fn build_new_window() -> Result<WebviewWindow, String> {
         LIGHT_BACKGROUND_HEX,
     );
 
+    // 检查是否存在保存的窗口状态
+    let saved_state = get_saved_window_state();
+    let (should_center, window_width, window_height) = if let Some(ref state) = saved_state {
+        // 如果有保存的状态，检查位置是否有效
+        if let (Some(x), Some(y), Some(width), Some(height)) = (state.x, state.y, state.width, state.height) {
+            // 获取所有监视器
+            let monitors = app_handle.available_monitors().map_err(|e| {
+                logging!(warn, Type::Window, "获取监视器列表失败: {}", e);
+                e.to_string()
+            })?;
+            
+            // 验证保存的位置是否有效
+            let is_valid = validate_window_position(x, y, width, height, &monitors);
+            
+            if is_valid {
+                logging!(info, Type::Window, "使用保存的窗口位置和大小");
+                (false, width, height) // 不需要居中，让插件恢复保存的位置和大小
+            } else {
+                logging!(
+                    info,
+                    Type::Window,
+                    "保存的窗口位置无效（监视器可能已断开），将使用保存的大小在主监视器居中"
+                );
+                (true, width, height) // 需要居中，但保留保存的大小
+            }
+        } else {
+            logging!(info, Type::Window, "保存的窗口状态不完整，将使用默认大小并居中显示");
+            (true, DEFAULT_WIDTH, DEFAULT_HEIGHT)
+        }
+    } else {
+        logging!(info, Type::Window, "没有保存的窗口状态，将使用默认大小并居中显示");
+        (true, DEFAULT_WIDTH, DEFAULT_HEIGHT)
+    };
+
     let mut builder = tauri::WebviewWindowBuilder::new(
         app_handle,
         "main", /* the unique window label */
         tauri::WebviewUrl::App(start_page.into()),
     )
     .title("Clash Verge")
-    .center()
     // Using WindowManager::prefer_system_titlebar to control if show system built-in titlebar
     // .decorations(true)
     .fullscreen(false)
-    .inner_size(DEFAULT_WIDTH, DEFAULT_HEIGHT)
+    .inner_size(window_width, window_height)
     .min_inner_size(MINIMAL_WIDTH, MINIMAL_HEIGHT)
     .visible(false) // 等待主题色准备好后再展示，避免启动色差
     .initialization_script(&initial_script);
+    
+    // 只在需要时才居中（首次启动或监视器配置变化导致保存的位置无效）
+    if should_center {
+        builder = builder.center();
+    }
 
     if let Some(theme) = resolved_theme {
         builder = builder.theme(Some(theme));


### PR DESCRIPTION
The window always centered on creation, ignoring saved position/size. When monitors were disconnected, windows could restore to off-screen positions.

## Changes

**Window state validation** (`src-tauri/src/utils/resolve/window.rs`)
- Added `WindowState` struct to parse saved state from `window_state.json`
- Added `get_saved_window_state()` to read persisted window configuration
- Added `validate_window_position()` to verify saved position is within current monitor bounds

**Conditional centering logic**
- `.center()` now only called when:
  - No saved state exists (first launch)
  - Saved position invalid (monitor disconnected)
  - Saved state incomplete
- Otherwise, `tauri-plugin-window-state` restores saved position

**Size preservation**
- Saved window dimensions used even when position invalid
- Falls back to centered position on primary monitor with preserved size

```rust
// Before: always centered, ignored saved state
let builder = tauri::WebviewWindowBuilder::new(...)
    .center()
    .inner_size(DEFAULT_WIDTH, DEFAULT_HEIGHT)

// After: conditional centering, preserves saved size
let (should_center, width, height) = validate_saved_state();
let mut builder = tauri::WebviewWindowBuilder::new(...)
    .inner_size(width, height);
if should_center {
    builder = builder.center();
}
```

Works with existing `tauri-plugin-window-state` v2.4.1 for automatic state persistence.