### PR TITLE
fix: failed to restart core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3547,12 +3547,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry",
 ]
 
 [[package]]
@@ -5165,7 +5165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5955,7 +5955,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5992,7 +5992,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7720,7 +7720,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "url",
- "windows-registry 0.5.3",
+ "windows-registry",
  "windows-result 0.3.4",
 ]
 
@@ -7833,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-mihomo"
 version = "0.1.1"
-source = "git+https://github.com/clash-verge-rev/tauri-plugin-mihomo?rev=153f16f7b3f979aa130a2d3d7c39a52a39987288#153f16f7b3f979aa130a2d3d7c39a52a39987288"
+source = "git+https://github.com/clash-verge-rev/tauri-plugin-mihomo#153f16f7b3f979aa130a2d3d7c39a52a39987288"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -9474,7 +9474,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9652,17 +9652,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-router": "^7.10.0",
     "react-virtuoso": "^4.16.1",
     "swr": "^2.3.7",
-    "tauri-plugin-mihomo-api": "git+https://github.com/clash-verge-rev/tauri-plugin-mihomo#153f16f7b3f979aa130a2d3d7c39a52a39987288",
+    "tauri-plugin-mihomo-api": "git+https://github.com/clash-verge-rev/tauri-plugin-mihomo#main",
     "types-pac": "^1.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,7 +126,7 @@ importers:
         specifier: ^2.3.7
         version: 2.3.7(react@19.2.1)
       tauri-plugin-mihomo-api:
-        specifier: git+https://github.com/clash-verge-rev/tauri-plugin-mihomo#153f16f7b3f979aa130a2d3d7c39a52a39987288
+        specifier: git+https://github.com/clash-verge-rev/tauri-plugin-mihomo#main
         version: https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/153f16f7b3f979aa130a2d3d7c39a52a39987288
       types-pac:
         specifier: ^1.0.3

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -90,7 +90,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 tauri-plugin-http = "2.5.4"
 console-subscriber = { version = "0.5.0", optional = true }
 tauri-plugin-devtools = { version = "2.0.1" }
-tauri-plugin-mihomo = { git = "https://github.com/clash-verge-rev/tauri-plugin-mihomo", rev = "153f16f7b3f979aa130a2d3d7c39a52a39987288" }
+tauri-plugin-mihomo = { git = "https://github.com/clash-verge-rev/tauri-plugin-mihomo" }
 clash_verge_logger = { git = "https://github.com/clash-verge-rev/clash-verge-logger" }
 async-trait = "0.1.89"
 clash_verge_service_ipc = { version = "2.0.24", features = [


### PR DESCRIPTION
Closes: https://github.com/clash-verge-rev/clash-verge-rev/issues/5749

主要原因是：更新系统托盘菜单时，因为内核停止，导致 mihomo 请求阻塞，且请求的超时机制未起作用（需要排查），一直卡在更新系统托盘菜单的步骤上，以至于无法重启内核

https://github.com/clash-verge-rev/clash-verge-rev/blob/b5da9c962937ad0626e24ce27f3da9497d695fe1/src-tauri/src/core/service.rs#L423-L433


mihomo 请求阻塞，超时机制未起作用日志（大量并发获取连接），下个版本再排查吧
<img width="1239" height="499" alt="Snipaste_2025-12-07_00-41-04" src="https://github.com/user-attachments/assets/e460b05c-bfdb-4fbb-9fe7-6e9e4deea8e4" />
