### PR TITLE
fix(window): hover effect of the minimize and close button does not disappear

### DIFF
--- a/src/providers/window-provider.tsx
+++ b/src/providers/window-provider.tsx
@@ -81,6 +81,7 @@ export const WindowProvider = ({ children }: PropsWithChildren) => {
 
     return {
       minimize: async () => {
+        // Delay one frame so the UI can clear :hover before the window hides.
         await new Promise((resolve) => setTimeout(resolve, 10));
         await currentWindow.minimize();
       },


### PR DESCRIPTION
解决最小化按钮和关闭按钮动画不消失的问题
![525147847-30269aca-2795-4071-859f-9d9002d39978](https://github.com/user-attachments/assets/7d46595d-b850-4743-bc34-fc4047c9e7f0)
