### PR TITLE
fix: head state not updated when using config.yaml as current profile

### DIFF
--- a/src/components/proxy/use-head-state.ts
+++ b/src/components/proxy/use-head-state.ts
@@ -55,11 +55,6 @@ export function useHeadStateNew() {
   const [state, dispatch] = useReducer(headStateReducer, {});
 
   useEffect(() => {
-    if (!current) {
-      dispatch({ type: "reset" });
-      return;
-    }
-
     try {
       const data = JSON.parse(
         localStorage.getItem(HEAD_STATE_KEY)!,
@@ -78,8 +73,6 @@ export function useHeadStateNew() {
   }, [current]);
 
   useEffect(() => {
-    if (!current) return;
-
     const timer = setTimeout(() => {
       try {
         const item = localStorage.getItem(HEAD_STATE_KEY);
@@ -99,10 +92,9 @@ export function useHeadStateNew() {
 
   const setHeadState = useCallback(
     (groupName: string, obj: Partial<HeadState>) => {
-      if (!current) return;
       dispatch({ type: "update", groupName, patch: obj });
     },
-    [current],
+    [],
   );
 
   return [state, setHeadState] as const;


### PR DESCRIPTION
更新2.4.3后同样遇到了 https://github.com/clash-verge-rev/clash-verge-rev/issues/5393 代理组无法展开的问题，因为我们都是直接覆盖config.yaml来作为配置使用的，profile.current为空，更新后直接return了导致没有办法展开代理组，我也是今天才注意到正确用法是导入本地配置 😊 
