### PR TITLE
Remove tun mode public DNS setting in macOS async handler

### DIFF
--- a/src-tauri/src/enhance/tun.rs
+++ b/src-tauri/src/enhance/tun.rs
@@ -61,7 +61,6 @@ pub fn use_tun(mut config: Mapping, enable: bool) -> Mapping {
             {
                 AsyncHandler::spawn(move || async move {
                     crate::utils::resolve::dns::restore_public_dns().await;
-                    crate::utils::resolve::dns::set_public_dns("223.6.6.6".to_string()).await;
                 });
             }
         }


### PR DESCRIPTION
Removed setting public DNS to '223.6.6.6' in macOS handler.
Tun mode modification of default dns destroys local dns configuration.