### PR TITLE
fix(tauri): reduce Tokio task stack usage for embedded Warp server

### DIFF
--- a/src-tauri/src/utils/server.rs
+++ b/src-tauri/src/utils/server.rs
@@ -101,6 +101,17 @@ pub fn embed_server() {
 
     let commands = visible.or(scheme).or(pac);
 
+    #[cfg(target_os = "linux")]
+    {
+        // On Linux, spawing through a new tokio runtime cause to create a new app instance
+        // So we have to spawn through AsyncHandler(tauri::async_runtime) to avoid that
+        // See relate comments in https://github.com/clash-verge-rev/clash-verge-rev/pull/5908#issuecomment-3678727040
+        AsyncHandler::spawn(move || async move {
+            run(commands, port, shutdown_rx).await;
+        });
+    }
+
+    #[cfg(not(target_os = "linux"))]
     if let Ok(rt) = tokio::runtime::Builder::new_current_thread()
         .thread_name("clash-verge-rev-embed-server")
         .worker_threads(1)


### PR DESCRIPTION
主线中 Warp server 运行在 tauri asyncruntime 中，可能会阻塞 UI，且产生过多 tokio task size。PR 对 Warp server 独立到 tokio runtime 中以避免和主进程竞争

主线 tokio-console 观察大量 location 来自 warp server
```
⚠ 1 tasks have lost their wakers                                                                                                                                                                                                                                                                      
│⚠ 3 tasks have been boxed by the runtime due to their size                                                                                                                                                                                                                                            
│⚠ 13 tasks are 1024 bytes or larger
```

PR 实现后 tokio-console 观察到显著减少过大 task 数量
```
⚠ 1 tasks have lost their wakers                                                                                                                                                                                                                                                                      │
│⚠ 4 tasks have been boxed by the runtime due to their size                                                                                                                                                                                                                                            │
│⚠ 1 tasks are 1024 bytes or larger
```

对于性能差异的观测由于没有很好的方法，统一按照最小操作后等待 3 分钟左右趋于稳定记录

主线
```
静默启动
内存 29.6MB CPU 0.1 线程 38

UI 显示
内存 CPU 线程
内存 47.9MB CPU 1.6% 线程 41
```

PR
```
静默启动
内存 29.8MB CPU 0.1% 线程 38

UI显示
内存 47.2MB CPU 1.5% 线程 41
```

受影响功能测试均未破坏行为
- Scheme  导入订阅
- 重启 Verge
- 重启 Verge 时重启内置服务

仅在 macOS 中测试，合并需要 Windows 和 Linux 再进行功能测试，以防止平台差异