### PR TITLE
chore(windows): remove redundant 3s delay from autostart task

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,6 @@
 - 修复 Monaco 编辑器初始化卡 Loading
 - 修复恢复备份时 `config.yaml` / `profiles.yaml` 文件内字段未正确恢复
 - 修复 Windows 下系统主题同步问题
-- 修复 Windows 自动启动系统托盘未显示问题
 
 <details>
 <summary><strong> ✨ 新增功能 </strong></summary>

--- a/src-tauri/src/core/tray/mod.rs
+++ b/src-tauri/src/core/tray/mod.rs
@@ -162,34 +162,8 @@ impl Tray {
                     Type::Tray,
                     "System tray creation failed: {e}, Application will continue running without tray icon",
                 );
-
-                // retray
-                #[cfg(target_os = "windows")]
-                tokio::spawn(async move {
-                    // backoff：3s / 10s / 30s
-                    let delays = [3, 10, 30];
-
-                    for delay in delays {
-                        tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
-
-                        if handle::Handle::global().is_exiting() {
-                            logging!(debug, Type::Tray, "应用正在退出，停止托盘重试");
-                            return;
-                        }
-
-                        logging!(debug, Type::Tray, "Retrying system tray creation after {delay}s");
-
-                        if Self::global().create_tray_from_handle(app_handle).await.is_ok() {
-                            logging!(info, Type::Tray, "System tray created successfully on retry");
-                            return;
-                        }
-                    }
-
-                    logging!(warn, Type::Tray, "System tray retry attempts exhausted, giving up");
-                });
             }
         }
-
         Ok(())
     }
 


### PR DESCRIPTION
Windows 启动早期系统托盘创建可能失败。
当首次创建失败时，后台延时重试，不阻塞应用启动。
相关issue https://github.com/clash-verge-rev/clash-verge-rev/issues/5984