### PR TITLE
build(tauri): add libayatana-appindicator3 dependency for linux packages

### DIFF
--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -5,7 +5,7 @@
     "targets": ["deb", "rpm"],
     "linux": {
       "deb": {
-        "depends": ["openssl"],
+        "depends": ["openssl", "libayatana-appindicator3-1"],
         "desktopTemplate": "./packages/linux/clash-verge.desktop",
         "provides": ["clash-verge"],
         "conflicts": ["clash-verge"],
@@ -14,7 +14,7 @@
         "preRemoveScript": "./packages/linux/pre-remove.sh"
       },
       "rpm": {
-        "depends": ["openssl"],
+        "depends": ["openssl", "libayatana-appindicator-gtk3"],
         "desktopTemplate": "./packages/linux/clash-verge.desktop",
         "provides": ["clash-verge"],
         "conflicts": ["clash-verge"],


### PR DESCRIPTION
这个 commit 主要是为了修复打包缺少 `libayatana-appindicator3` 依赖的问题。

主要修改如下：
- 在 deb 打包中加入 `libayatana-appindicator3-1`，在 rpm 打包中加入 `libayatana-appindicator-gtk3`

动机：
tauri build 在打包时不会将 `libappindicator` 需要的依赖自动加入 `tauri.linux.conf.json` 中，导致系统在安装 clash-verge 时不会自动安装对应的依赖包。并且由于该依赖在部分系统（例如 Debian sid）中不是默认被安装的，clash-verge 在启动时就会提示缺少动态库。因此需要在打包配置文件中手动添加相应的依赖以解决此问题。

影响范围：
Linux 的 deb 与 rpm 打包