### PR TITLE
perf: reduce various timeout and retry intervals for improved responsiveness to fetch proxy infomation

### DIFF
--- a/src/components/home/current-proxy-card.tsx
+++ b/src/components/home/current-proxy-card.tsx
@@ -27,8 +27,13 @@ import {
   useTheme,
 } from "@mui/material";
 import { useLockFn } from "ahooks";
-import React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { delayGroup, healthcheckProxyProvider } from "tauri-plugin-mihomo-api";
@@ -46,8 +51,8 @@ const STORAGE_KEY_GROUP = "clash-verge-selected-proxy-group";
 const STORAGE_KEY_PROXY = "clash-verge-selected-proxy";
 const STORAGE_KEY_SORT_TYPE = "clash-verge-proxy-sort-type";
 
-const AUTO_CHECK_INITIAL_DELAY_MS = 1500;
 const AUTO_CHECK_DEFAULT_INTERVAL_MINUTES = 5;
+const AUTO_CHECK_INITIAL_DELAY_MS = 100;
 
 // 代理节点信息接口
 interface ProxyOption {

--- a/src/hooks/use-mihomo-ws-subscription.ts
+++ b/src/hooks/use-mihomo-ws-subscription.ts
@@ -4,7 +4,7 @@ import { mutate, type MutatorCallback } from "swr";
 import useSWRSubscription from "swr/subscription";
 import { type Message, type MihomoWebSocket } from "tauri-plugin-mihomo-api";
 
-export const RECONNECT_DELAY_MS = 500;
+export const RECONNECT_DELAY_MS = 100;
 
 type NextFn<T> = (error?: any, data?: T | MutatorCallback<T>) => void;
 

--- a/src/hooks/use-traffic-monitor.ts
+++ b/src/hooks/use-traffic-monitor.ts
@@ -48,7 +48,7 @@ const WORKER_CONFIG = {
   rawDataMinutes: 10,
   compressedDataMinutes: 60,
   compressionRatio: 5,
-  snapshotIntervalMs: 250,
+  snapshotIntervalMs: 100,
   defaultRangeMinutes: 10,
 };
 


### PR DESCRIPTION
修复缺陷
- 首次启动，Mihomo 代理信息会明显延迟显示

修改行为
- 减少获取 Mihomo 操作重试延迟

预期改进
- 首次启动会更快加载 Mihomo 代理信息

暂未发现 CPU / 内存有回归

CC @Tychristine, @Slinetrac