### PR TITLE
fix: update service to 2.1.0 and improve service installation for Unix systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1243,8 +1243,8 @@ dependencies = [
 
 [[package]]
 name = "clash_verge_service_ipc"
-version = "2.0.30"
-source = "git+https://github.com/clash-verge-rev/clash-verge-service-ipc#3d8d51937b2fa133221f36c990e93da606e59221"
+version = "2.1.0"
+source = "git+https://github.com/clash-verge-rev/clash-verge-service-ipc#dab73f0f6c69fb72408f84beebf4d042137950c8"
 dependencies = [
  "anyhow",
  "compact_str",
@@ -1312,7 +1312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2022,7 +2022,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2286,7 +2286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3807,7 +3807,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4565,7 +4565,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5862,7 +5862,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6485,7 +6485,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6543,7 +6543,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8071,7 +8071,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,25 +1,5 @@
 ## v2.4.5
 
-> [!WARNING]
-> 此版本 macOS 和 Linux 对服务 IPC 权限进一步限制引入了破坏性变更，需要先在旧版本**卸载 TUN 服务**后再安装新版本。
->
-> **已经安装的用户**可在终端卸载服务再安装。
->
-> 对于 macOS：
->
-> ```bash
-> APP="/Applications/Clash Verge.app"
-> sudo "$APP/Contents/Resources/resources/clash-verge-service-uninstall"
-> sudo "$APP/Contents/Resources/resources/clash-verge-service-install"
-> ```
->
-> 对于 Linux：
->
-> ```bash
-> sudo clash-verge-service-uninstall
-> sudo clash-verge-service-install
-> ```
-
 - **Mihomo(Meta) 内核升级至 v1.19.19**
 
 ### 🐞 修复问题

--- a/crates/tauri-plugin-clash-verge-sysinfo/src/lib.rs
+++ b/crates/tauri-plugin-clash-verge-sysinfo/src/lib.rs
@@ -121,6 +121,12 @@ fn is_binary_admin() -> bool {
 }
 
 #[inline]
+#[cfg(unix)]
+pub fn current_gid() -> u32 {
+    unsafe { libc::getgid() }
+}
+
+#[inline]
 pub fn list_network_interfaces() -> Vec<String> {
     let mut networks = Networks::new();
     networks.refresh(false);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -99,7 +99,7 @@ tauri-plugin-devtools = { version = "2.0.1" }
 tauri-plugin-mihomo = { git = "https://github.com/clash-verge-rev/tauri-plugin-mihomo" }
 clash_verge_logger = { git = "https://github.com/clash-verge-rev/clash-verge-logger" }
 async-trait = "0.1.89"
-clash_verge_service_ipc = { version = "2.0.30", features = [
+clash_verge_service_ipc = { version = "2.1.0", features = [
   "client",
 ], git = "https://github.com/clash-verge-rev/clash-verge-service-ipc" }
 arc-swap = "1.8.0"

--- a/src-tauri/src/core/service.rs
+++ b/src-tauri/src/core/service.rs
@@ -158,16 +158,12 @@ fn install_service() -> Result<()> {
     }
 
     let install_shell: String = install_path.to_string_lossy().replace(" ", "\\ ");
-    let gid = tauri_plugin_clash_verge_sysinfo::current_gid();
 
     let elevator = crate::utils::help::linux_elevator();
     let status = if linux_running_as_root() {
-        StdCommand::new(&install_path)
-            .env("CLASH_VERGE_SERVICE_GID", gid.to_string())
-            .status()?
+        StdCommand::new(&install_path).status()?
     } else {
         let result = StdCommand::new(&elevator)
-            .env("CLASH_VERGE_SERVICE_GID", gid.to_string())
             .arg("sh")
             .arg("-c")
             .arg(&install_shell)

--- a/src-tauri/src/core/service.rs
+++ b/src-tauri/src/core/service.rs
@@ -158,12 +158,16 @@ fn install_service() -> Result<()> {
     }
 
     let install_shell: String = install_path.to_string_lossy().replace(" ", "\\ ");
+    let gid = tauri_plugin_clash_verge_sysinfo::current_gid();
 
     let elevator = crate::utils::help::linux_elevator();
     let status = if linux_running_as_root() {
-        StdCommand::new(&install_path).status()?
+        StdCommand::new(&install_path)
+            .env("CLASH_VERGE_SERVICE_GID", gid.to_string())
+            .status()?
     } else {
         let result = StdCommand::new(&elevator)
+            .env("CLASH_VERGE_SERVICE_GID", gid.to_string())
             .arg("sh")
             .arg("-c")
             .arg(&install_shell)

--- a/src-tauri/src/core/service.rs
+++ b/src-tauri/src/core/service.rs
@@ -256,9 +256,11 @@ fn install_service() -> Result<()> {
 
     // clash_verge_i18n::sync_locale(Config::verge().await.latest_arc().language.as_deref());
 
+    let gid = tauri_plugin_clash_verge_sysinfo::current_gid();
     let prompt = clash_verge_i18n::t!("service.adminInstallPrompt");
-    let command =
-        format!(r#"do shell script "sudo '{install_shell}'" with administrator privileges with prompt "{prompt}""#);
+    let command = format!(
+        r#"do shell script "sudo CLASH_VERGE_SERVICE_GID={gid} '{install_shell}'" with administrator privileges with prompt "{prompt}""#
+    );
 
     let status = StdCommand::new("osascript").args(vec!["-e", &command]).status()?;
 


### PR DESCRIPTION
可能相关 Unix Issues: #6034, #6017, #5982, #5323, #5960

新增 Unix IPC 安装时优先以环境环境变量 CLASH_VERGE_SERVICE_GID 继承 GID

背景（以 macOS 为例）：
IPC socket 强约束，同 GID 时才能进行通信。
```bash
> id
gid=20(staff)
> sudo id
gid=0(wheel)
```

通过终端 `sudo clash-verge-service-install`，得到符合预期权限
```bash
srw-rw----@  1 root      staff     0 Jan 18 09:36 clash-verge-service.sock=
```

通过 GUI (Rust侧)，普通用户 -> 提权 Command -> install 得到不符合预期权限
```bash
srw-rw----   1 root      wheel     0 Jan 18 09:30 clash-verge-service.sock=
```

其中 staff 不包含 0，导致通过 GUI 安装的服务无法通信。且典型 GUI 安装错误
```
Install Service failed: Failed
to connect to IPC server:
Custom error: Operation 'GET
/ magic' failed after retries:
Timeout error: operation timed
out after 100ms
```
