### PR TITLE
fix: prevent Linux system freeze caused by blocking operations

### DIFF
--- a/src-tauri/src/core/tray/mod.rs
+++ b/src-tauri/src/core/tray/mod.rs
@@ -205,8 +205,8 @@ impl Tray {
         let verge = Config::verge().await.latest_arc();
         let system_proxy = verge.enable_system_proxy.as_ref().unwrap_or(&false);
         let tun_mode = verge.enable_tun_mode.as_ref().unwrap_or(&false);
-        let tun_mode_available =
-            is_current_app_handle_admin(app_handle) || service::is_service_available().await.is_ok();
+        // 使用缓存的服务状态检查，避免每次都进行 IPC 连接导致阻塞
+        let tun_mode_available = is_current_app_handle_admin(app_handle) || service::is_service_available_cached();
         let mode = {
             Config::clash()
                 .await


### PR DESCRIPTION
This commit addresses multiple issues that can cause the entire Linux system to freeze when using Clash Verge Rev, particularly during TUN mode startup and GUI operations.

Key fixes:

1. **Exit event handling (lib.rs)**
   - Replace blocking `block_on` with background thread + timeout
   - Prevent deadlock in Tauri event loop during application exit
   - Add 5-second timeout for cleanup operations

2. **Service availability check (tray/mod.rs, service.rs)**
   - Add cached service status check to avoid repeated IPC connections
   - Cache TTL of 5 seconds reduces blocking during tray menu updates
   - Add 500ms timeout for IPC connection checks

3. **IPC configuration optimization (service.rs)**
   - Reduce max retries from 20 to 5 (max blocking: 1s instead of 5s)
   - Add per-connection timeout protection (300ms)

4. **Linux privilege elevation (service.rs)**
   - Add display environment detection before using pkexec
   - Add 60-second timeout for install/uninstall commands
   - Prevent infinite blocking when pkexec waits for user input

5. **System proxy operations (sysopt.rs)**
   - Minimize lock holding duration
   - Perform I/O operations outside of locks
   - Clone configurations before releasing locks

6. **Core operations timeout (feat/config.rs)**
   - Add 10-second timeout for restart_core and update_config
   - Prevent TUN mode toggle from blocking indefinitely

7. **Window creation (utils/resolve/window.rs)**
   - Add 500ms timeout for system theme detection
   - Prevent DBUS calls from blocking window creation

https://claude.ai/code/session_01WRpzkH8TjniyEjCsQ9JvtH