### PR TITLE
fix: displays rule lineNo instead of index in rule page (#6230)

### DIFF
--- a/src/components/rule/rule-item.tsx
+++ b/src/components/rule/rule-item.tsx
@@ -15,7 +15,6 @@ const COLOR = [
 ];
 
 interface Props {
-  index: number;
   value: IRuleItem;
 }
 
@@ -31,7 +30,7 @@ const parseColor = (text: string) => {
 };
 
 const RuleItem = (props: Props) => {
-  const { index, value } = props;
+  const { value } = props;
 
   return (
     <Item sx={{ borderBottom: "1px solid var(--divider-color)" }}>
@@ -40,7 +39,7 @@ const RuleItem = (props: Props) => {
         variant="body2"
         sx={{ lineHeight: 2, minWidth: 30, mr: 2.25, textAlign: "center" }}
       >
-        {index}
+        {value.lineNo}
       </Typography>
 
       <Box sx={{ userSelect: "text" }}>

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -30,6 +30,7 @@ const RulesPage = () => {
   }, [refreshRules, refreshRuleProviders, pageVisible]);
 
   const filteredRules = useMemo(() => {
+    rules.forEach((item, index) => (item.lineNo = index + 1)); // 循环出每一条规则的行号lineNo，用于展示在规则页面里的每一行（主要是过滤的时候展示行号用）
     return rules.filter((item) => match(item.payload));
   }, [rules, match]);
 
@@ -81,9 +82,7 @@ const RulesPage = () => {
             style={{
               flex: 1,
             }}
-            itemContent={(index, item) => (
-              <RuleItem index={index + 1} value={item} />
-            )}
+            itemContent={(_index, item) => <RuleItem value={item} />}
             followOutput={"smooth"}
             scrollerRef={(ref) => {
               if (ref) ref.addEventListener("scroll", handleScroll);

--- a/src/providers/app-data-context.ts
+++ b/src/providers/app-data-context.ts
@@ -9,7 +9,7 @@ import {
 export interface AppDataContextType {
   proxies: any;
   clashConfig: BaseConfig;
-  rules: Rule[];
+  rules: Array<Rule & { lineNo: number }>;
   sysproxy: any;
   runningMode?: string;
   uptime: number;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -86,6 +86,7 @@ interface IRuleItem {
   type: string;
   payload: string;
   proxy: string;
+  lineNo: number;
 }
 
 interface IProxyItem {


### PR DESCRIPTION
## Description

Displays rule lineNo instead of index in rule page

## References
Feature & Issue: #6230