### PR TITLE
fix: add margin and border radius to group svg image

### DIFF
--- a/src/components/profile/group-item.tsx
+++ b/src/components/profile/group-item.tsx
@@ -86,6 +86,10 @@ export const GroupItem = (props: Props) => {
         <img
           src={`data:image/svg+xml;base64,${btoa(group.icon ?? "")}`}
           width="32px"
+          style={{
+            marginRight: "12px",
+            borderRadius: "6px",
+          }}
         />
       )}
       <ListItemText


### PR DESCRIPTION
## Add margin and border radius to group svg image.

<img width="2519" height="1605" alt="image" src="https://github.com/user-attachments/assets/2272d7b5-37af-4a8f-840c-c1c2772238b6" />

## Clash Group

  - {name: Duolingo, type: select, proxies: [手动选择, 直连], icon: "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 120 120\"><path fill=\"#50C800\" fill-rule=\"evenodd\" d=\"M22.84 0h74.332C109.78 0 120 10.219 120 22.84v74.332c0 12.609-10.219 22.84-22.84 22.84H22.84C10.219 120 0 109.781 0 97.16V22.84C0 10.219 10.219 0 22.84 0\" clip-rule=\"evenodd\"/><path fill=\"#8EE000\" fill-rule=\"evenodd\" d=\"M120.004 77.52V42.809a27.2 27.2 0 0 0-5.848-8.813c.223-3.726-.609-7.5-2.543-10.863-1.265-2.203-4.324-2.52-6.035-.621l-3.879 4.3c-.023-.01-.047-.01-.07-.023.504-3.925-.164-7.98-2.086-11.601-1.195-2.25-3.785-2.649-5.567-.82L75.345 33.246c-.211.2-.434.41-.645.621-.011.012-.035.024-.047.036-8.097 7.336-20.718 7.64-28.43.902a26 26 0 0 0-1.511-1.523L26.043 14.379c-1.781-1.828-4.371-1.43-5.566.82a19.44 19.44 0 0 0-2.098 11.544c-.035.011-.07.011-.106.023l-3.832-4.254c-1.71-1.898-4.77-1.582-6.046.621a19.4 19.4 0 0 0-2.555 10.64A27.4 27.4 0 0 0-.008 42.27v35.8C4.2 87.669 13.785 94.384 24.93 94.384h1.195c11.05 0 20.566-6.598 24.82-16.066q6.135-.035 8.895-.035c3.984-.012 7.09-.012 9.316-.012C73.398 87.762 82.937 94.383 94 94.383h.844c11.355 0 21.082-6.972 25.16-16.863\" clip-rule=\"evenodd\"/><path fill=\"#fff\" fill-rule=\"evenodd\" d=\"M26.617 35.625c10.453 0 18.938 8.473 18.938 18.938v11.214c0 10.454-8.473 18.938-18.938 18.938-10.453 0-18.937-8.473-18.937-18.938V54.562c0-10.464 8.484-18.937 18.937-18.937M93.145 35.625c10.453 0 18.937 8.473 18.937 18.938v11.214c0 10.454-8.473 18.938-18.937 18.938-10.454 0-18.938-8.473-18.938-18.938V54.562c0-10.464 8.473-18.937 18.938-18.937\" clip-rule=\"evenodd\"/><path fill=\"#4B4B4B\" fill-rule=\"evenodd\" d=\"M29.535 46.5c4.957 0 8.988 4.02 8.988 8.989v9.597c0 4.957-4.02 8.989-8.988 8.989-4.957 0-8.988-4.02-8.988-8.989V55.49c0-4.969 4.031-8.988 8.988-8.988\" clip-rule=\"evenodd\"/><path fill=\"#F48000\" fill-rule=\"evenodd\" d=\"M60.005 68.288c5.683 0 10.289 4.606 10.289 10.29v3.573c0 5.684-4.606 10.29-10.29 10.29s-10.288-4.606-10.288-10.29v-3.574c0-5.683 4.605-10.289 10.289-10.289\" clip-rule=\"evenodd\"/><path fill=\"#FFC200\" d=\"M45.802 79.562c1.23-6.563 7.312-11.297 14.59-11.297 6.62 0 12.609 4.851 13.816 11.296v.528c0 .41-.14.574-.516.527l-13.289 2.367h-.785l-13.3-2.379c-.376.047-.517-.117-.517-.527z\"/><path fill=\"#FFE747\" fill-rule=\"evenodd\" d=\"M57.825 70.538a9.2 9.2 0 0 1 2.121-.258 9 9 0 0 1 2.297.293 3.5 3.5 0 0 1 2.625 3.387 2.32 2.32 0 0 1-2.32 2.32h-5.086a2.32 2.32 0 0 1-2.32-2.32 3.51 3.51 0 0 1 2.683-3.422\" clip-rule=\"evenodd\"/><path fill=\"#4B4B4B\" fill-rule=\"evenodd\" d=\"M90.227 46.5c4.957 0 8.988 4.02 8.988 8.989v9.597c0 4.957-4.02 8.989-8.988 8.989-4.958 0-8.989-4.02-8.989-8.989V55.49c.012-4.969 4.031-8.988 8.989-8.988\" clip-rule=\"evenodd\"/><path fill=\"#fff\" d=\"M21.941 57.399c3.204 0 5.801-2.587 5.801-5.777s-2.597-5.778-5.8-5.778c-3.204 0-5.801 2.587-5.801 5.778s2.597 5.777 5.8 5.777M81.754 57.399c3.203 0 5.8-2.587 5.8-5.777s-2.597-5.778-5.8-5.778c-3.204 0-5.801 2.587-5.801 5.778s2.597 5.777 5.8 5.777\"/></svg>"}

