### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -49,7 +49,7 @@ jobs:
   #       uses: dtolnay/rust-toolchain@stable
 
   #     - name: install taplo-cli
-  #       uses: taiki-e/install-action@v2
+  #       uses: taiki-e/install-action@v2.68.8
   #       with:
   #         tool: taplo-cli
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `taiki-e/install-action` | [`v2`](https://github.com/taiki-e/install-action/releases/tag/v2) | [`v2.68.8`](https://github.com/taiki-e/install-action/releases/tag/v2.68.8) | [Release](https://github.com/taiki-e/install-action/releases/tag/v2.68.8) | rustfmt.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
