### PR TITLE
fix: apply config timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ scripts/_env.sh
 .changelog_backups
 target
 CLAUDE.md
+.vfox.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3398,12 +3398,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4834,7 +4834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5605,7 +5605,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5643,7 +5643,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7461,7 +7461,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
- "windows-registry 0.5.3",
+ "windows-registry",
  "windows-result 0.3.4",
 ]
 
@@ -7574,7 +7574,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-mihomo"
 version = "0.1.7"
-source = "git+https://github.com/clash-verge-rev/tauri-plugin-mihomo#96025cd790e8738de2d2c268a1ba84d6271d7834"
+source = "git+https://github.com/clash-verge-rev/tauri-plugin-mihomo#5979c6169b3def4782f4cabe9099703943279108"
 dependencies = [
  "futures-util",
  "http 1.4.0",
@@ -9256,7 +9256,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9434,17 +9434,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - 修复 Windows 管理员身份运行时开关 TUN 模式异常
 - 修复静默启动与自动轻量模式存在冲突
 - 修复进入轻量模式后无法返回主界面
+- 切换配置文件偶尔失败的问题
 
 <details>
 <summary><strong> ✨ 新增功能 </strong></summary>

--- a/src-tauri/src/core/manager/config.rs
+++ b/src-tauri/src/core/manager/config.rs
@@ -90,7 +90,7 @@ impl CoreManager {
             }
             Err(err) => {
                 logging!(
-                    info,
+                    warn,
                     Type::Core,
                     "Failed to apply configuration by mihomo api, restart core to apply it, error msg: {err}"
                 );

--- a/src-tauri/src/core/manager/config.rs
+++ b/src-tauri/src/core/manager/config.rs
@@ -89,8 +89,23 @@ impl CoreManager {
                 Ok(())
             }
             Err(err) => {
-                Config::runtime().await.discard();
-                Err(anyhow!("Failed to apply config: {}", err))
+                logging!(
+                    info,
+                    Type::Core,
+                    "Failed to apply configuration by mihomo api, restart core to apply it, error msg: {err}"
+                );
+                match self.restart_core().await {
+                    Ok(_) => {
+                        Config::runtime().await.apply();
+                        logging!(info, Type::Core, "Configuration applied after restart");
+                        Ok(())
+                    }
+                    Err(err) => {
+                        logging!(error, Type::Core, "Failed to restart core: {}", err);
+                        Config::runtime().await.discard();
+                        Err(anyhow!("Failed to apply config: {}", err))
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Related：https://github.com/clash-verge-rev/clash-verge-rev/issues/6028

mihomo 重载配置的 API 的逻辑中，需要将配置文件中的外部资源下载完成才能继续执行重载配置的后续操作

在之前的 `reload_config` 方法中，默认设置了 60 秒超时用来下载外部资源，但是这可能会导致切换配置时间过长，对用户不友好
在最近的一次提交中 [5979c6169b3def4782f4cabe9099703943279108](https://github.com/clash-verge-rev/tauri-plugin-mihomo/commit/5979c6169b3def4782f4cabe9099703943279108) 我移除了 60 秒超时时间，使用设置的请求超时时间

该 PR 实现的目的是优先通过 API 切换配置文件，超时后直接重新启动内核加载该配置文件，避免由于各种网络或其他问题导致外部资源下载超时失败而无法应用配置文件的情况