### PR TITLE
refactor(core): move autostart logic out of sysopt and clean up naming

### DIFF
--- a/src-tauri/src/cmd/app.rs
+++ b/src-tauri/src/cmd/app.rs
@@ -1,6 +1,5 @@
 use super::CmdResult;
-use crate::core::handle;
-use crate::core::sysopt::Sysopt;
+use crate::core::{autostart, handle};
 use crate::utils::resolve::ui::{self, UiReadyStage};
 use crate::{cmd::StringifyErr as _, feat, utils::dirs};
 use clash_verge_logging::{Type, logging};
@@ -96,7 +95,7 @@ pub fn get_app_dir() -> CmdResult<String> {
 /// 获取当前自启动状态
 #[tauri::command]
 pub fn get_auto_launch_status() -> CmdResult<bool> {
-    Sysopt::global().get_launch_status().stringify_err()
+    autostart::get_launch_status().stringify_err()
 }
 
 /// 下载图标缓存

--- a/src-tauri/src/core/autostart.rs
+++ b/src-tauri/src/core/autostart.rs
@@ -1,0 +1,63 @@
+#[cfg(target_os = "windows")]
+use crate::utils::schtasks;
+use crate::{config::Config, core::handle::Handle};
+use anyhow::Result;
+#[cfg(not(target_os = "windows"))]
+use clash_verge_logging::logging_error;
+use clash_verge_logging::{Type, logging};
+#[cfg(not(target_os = "windows"))]
+use tauri_plugin_autostart::ManagerExt as _;
+#[cfg(target_os = "windows")]
+use tauri_plugin_clash_verge_sysinfo::is_current_app_handle_admin;
+
+pub async fn update_launch() -> Result<()> {
+    let enable_auto_launch = { Config::verge().await.latest_arc().enable_auto_launch };
+    let is_enable = enable_auto_launch.unwrap_or(false);
+    logging!(info, Type::System, "Setting auto-launch enabled state to: {is_enable}");
+
+    #[cfg(target_os = "windows")]
+    {
+        let is_admin = is_current_app_handle_admin(Handle::app_handle());
+        schtasks::set_auto_launch(is_enable, is_admin).await?;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let app_handle = Handle::app_handle();
+        let autostart_manager = app_handle.autolaunch();
+        if is_enable {
+            logging_error!(Type::System, "{:?}", autostart_manager.enable());
+        } else {
+            logging_error!(Type::System, "{:?}", autostart_manager.disable());
+        }
+    }
+
+    Ok(())
+}
+
+pub fn get_launch_status() -> Result<bool> {
+    #[cfg(target_os = "windows")]
+    {
+        let enabled = schtasks::is_auto_launch_enabled();
+        if let Ok(status) = enabled {
+            logging!(info, Type::System, "Auto-launch status (scheduled task): {status}");
+        }
+        enabled
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let app_handle = Handle::app_handle();
+        let autostart_manager = app_handle.autolaunch();
+        match autostart_manager.is_enabled() {
+            Ok(status) => {
+                logging!(info, Type::System, "Auto-launch status: {status}");
+                Ok(status)
+            }
+            Err(e) => {
+                logging!(error, Type::System, "Failed to get auto-launch status: {e}");
+                Err(anyhow::anyhow!("Failed to get auto-launch status: {}", e))
+            }
+        }
+    }
+}

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod autostart;
 pub mod backup;
 pub mod handle;
 pub mod hotkey;

--- a/src-tauri/src/core/sysopt.rs
+++ b/src-tauri/src/core/sysopt.rs
@@ -1,13 +1,8 @@
-#[cfg(target_os = "windows")]
-use crate::utils::schtasks as startup_task;
 use crate::{
     config::{Config, IVerge},
-    core::handle::Handle,
     singleton,
 };
 use anyhow::Result;
-#[cfg(not(target_os = "windows"))]
-use clash_verge_logging::logging_error;
 use clash_verge_logging::{Type, logging};
 use parking_lot::RwLock;
 use scopeguard::defer;
@@ -20,10 +15,6 @@ use std::{
     time::Duration,
 };
 use sysproxy::{Autoproxy, GuardMonitor, GuardType, Sysproxy};
-#[cfg(not(target_os = "windows"))]
-use tauri_plugin_autostart::ManagerExt as _;
-#[cfg(target_os = "windows")]
-use tauri_plugin_clash_verge_sysinfo::is_current_app_handle_admin;
 
 pub struct Sysopt {
     update_sysproxy: AtomicBool,
@@ -227,65 +218,5 @@ impl Sysopt {
         auto.set_auto_proxy()?;
 
         Ok(())
-    }
-
-    /// update the startup
-    pub async fn update_launch(&self) -> Result<()> {
-        let enable_auto_launch = { Config::verge().await.latest_arc().enable_auto_launch };
-        let is_enable = enable_auto_launch.unwrap_or(false);
-        logging!(info, Type::System, "Setting auto-launch state to: {:?}", is_enable);
-
-        #[cfg(target_os = "windows")]
-        {
-            let is_admin = is_current_app_handle_admin(Handle::app_handle());
-            startup_task::set_auto_launch(is_enable, is_admin).await
-        }
-
-        #[cfg(not(target_os = "windows"))]
-        {
-            self.try_original_autostart_method(is_enable);
-            Ok(())
-        }
-    }
-
-    /// 尝试使用原来的自启动方法
-    #[cfg(not(target_os = "windows"))]
-    fn try_original_autostart_method(&self, is_enable: bool) {
-        let app_handle = Handle::app_handle();
-        let autostart_manager = app_handle.autolaunch();
-
-        if is_enable {
-            logging_error!(Type::System, "{:?}", autostart_manager.enable());
-        } else {
-            logging_error!(Type::System, "{:?}", autostart_manager.disable());
-        }
-    }
-
-    /// 获取当前自启动的实际状态
-    pub fn get_launch_status(&self) -> Result<bool> {
-        #[cfg(target_os = "windows")]
-        {
-            let enabled = startup_task::is_auto_launch_enabled();
-            if let Ok(status) = enabled {
-                logging!(info, Type::System, "Auto launch status (scheduled task): {status}");
-            }
-            enabled
-        }
-
-        #[cfg(not(target_os = "windows"))]
-        {
-            let app_handle = Handle::app_handle();
-            let autostart_manager = app_handle.autolaunch();
-            match autostart_manager.is_enabled() {
-                Ok(status) => {
-                    logging!(info, Type::System, "Auto launch status: {status}");
-                    Ok(status)
-                }
-                Err(e) => {
-                    logging!(error, Type::System, "Failed to get auto launch status: {e}");
-                    Err(anyhow::anyhow!("Failed to get auto launch status: {}", e))
-                }
-            }
-        }
     }
 }

--- a/src-tauri/src/feat/config.rs
+++ b/src-tauri/src/feat/config.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{Config, IVerge},
-    core::{CoreManager, handle, hotkey, logger::Logger, sysopt, tray},
+    core::{CoreManager, autostart, handle, hotkey, logger::Logger, sysopt, tray},
     module::{auto_backup::AutoBackupManager, lightweight},
 };
 use anyhow::Result;
@@ -218,7 +218,7 @@ async fn process_terminated_flags(update_flags: UpdateFlags, patch: &IVerge) -> 
         handle::Handle::refresh_verge();
     }
     if update_flags.contains(UpdateFlags::LAUNCH) {
-        sysopt::Sysopt::global().update_launch().await?;
+        autostart::update_launch().await?;
     }
     if update_flags.contains(UpdateFlags::LANGUAGE)
         && let Some(language) = &patch.language


### PR DESCRIPTION
把开机自启相关逻辑从 `sysopt` 里抽了出来。目前是无状态的，暂时用不着 `global()` 单例。
算是给 Windows 开机自启实现加 fallback 做结构性准备（？）
