### PR TITLE
fix(mode-switch): make rule/global/direct switching resilient to UI and IPC races  

### DIFF
--- a/src-tauri/src/cmd/clash.rs
+++ b/src-tauri/src/cmd/clash.rs
@@ -35,8 +35,7 @@ pub async fn patch_clash_config(payload: Mapping) -> CmdResult {
 /// 修改Clash模式
 #[tauri::command]
 pub async fn patch_clash_mode(payload: String) -> CmdResult {
-    feat::change_clash_mode(payload).await;
-    Ok(())
+    feat::change_clash_mode(payload).await.stringify_err()
 }
 
 /// 切换Clash核心

--- a/src-tauri/src/core/hotkey.rs
+++ b/src-tauri/src/core/hotkey.rs
@@ -117,19 +117,28 @@ impl Hotkey {
             }
             HotkeyFunction::ClashModeRule => {
                 AsyncHandler::spawn(async move || {
-                    feat::change_clash_mode("rule".into()).await;
+                    if let Err(err) = feat::change_clash_mode("rule".into()).await {
+                        logging!(error, Type::Hotkey, "Failed to switch clash mode to rule: {}", err);
+                        return;
+                    }
                     notify_event(NotificationEvent::ClashModeChanged { mode: "Rule" }).await;
                 });
             }
             HotkeyFunction::ClashModeGlobal => {
                 AsyncHandler::spawn(async move || {
-                    feat::change_clash_mode("global".into()).await;
+                    if let Err(err) = feat::change_clash_mode("global".into()).await {
+                        logging!(error, Type::Hotkey, "Failed to switch clash mode to global: {}", err);
+                        return;
+                    }
                     notify_event(NotificationEvent::ClashModeChanged { mode: "Global" }).await;
                 });
             }
             HotkeyFunction::ClashModeDirect => {
                 AsyncHandler::spawn(async move || {
-                    feat::change_clash_mode("direct".into()).await;
+                    if let Err(err) = feat::change_clash_mode("direct".into()).await {
+                        logging!(error, Type::Hotkey, "Failed to switch clash mode to direct: {}", err);
+                        return;
+                    }
                     notify_event(NotificationEvent::ClashModeChanged { mode: "Direct" }).await;
                 });
             }

--- a/src-tauri/src/core/tray/mod.rs
+++ b/src-tauri/src/core/tray/mod.rs
@@ -945,7 +945,9 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
                     && let Some(final_mode) = stripped.strip_suffix("_mode")
                 {
                     logging!(info, Type::ProxyMode, "Switch Proxy Mode To: {}", final_mode);
-                    feat::change_clash_mode(final_mode.into()).await;
+                    if let Err(err) = feat::change_clash_mode(final_mode.into()).await {
+                        logging!(error, Type::Tray, "Failed to switch proxy mode from tray: {err}");
+                    }
                 }
             }
             MenuIds::DASHBOARD => {

--- a/src-tauri/src/feat/clash.rs
+++ b/src-tauri/src/feat/clash.rs
@@ -9,6 +9,10 @@ use anyhow::Result;
 use clash_verge_logging::{Type, logging, logging_error};
 use serde_yaml_ng::{Mapping, Value};
 use smartstring::alias::String;
+use tauri_plugin_mihomo::Error as MihomoError;
+use tokio::time::{Duration, sleep};
+
+const MODE_SWITCH_RETRY_DELAYS_MS: [u64; 4] = [125, 250, 500, 1000];
 
 /// Restart the Clash core
 pub async fn restart_clash_core() {
@@ -67,6 +71,51 @@ fn after_change_clash_mode() {
     });
 }
 
+fn is_transient_mode_switch_error(err: &MihomoError) -> bool {
+    match err {
+        MihomoError::Io(io_err) => matches!(
+            io_err.kind(),
+            std::io::ErrorKind::ConnectionAborted
+                | std::io::ErrorKind::ConnectionRefused
+                | std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::NotFound
+                | std::io::ErrorKind::TimedOut
+        ),
+        MihomoError::Reqwest(req_err) => req_err.is_connect() || req_err.is_timeout() || req_err.is_request(),
+        MihomoError::FailedResponse(msg) => {
+            let msg = msg.to_ascii_lowercase();
+            ["connection", "pipe", "timed out", "timeout", "localhost"]
+                .iter()
+                .any(|pattern| msg.contains(pattern))
+        }
+        _ => false,
+    }
+}
+
+async fn patch_base_config_with_retry(json_value: &serde_json::Value) -> Result<(), MihomoError> {
+    let total_attempts = MODE_SWITCH_RETRY_DELAYS_MS.len() + 1;
+
+    for (attempt_idx, retry_delay_ms) in MODE_SWITCH_RETRY_DELAYS_MS.iter().copied().enumerate() {
+        let attempt = attempt_idx + 1;
+        let result = handle::Handle::mihomo().await.patch_base_config(json_value).await;
+
+        match result {
+            Ok(()) => return Ok(()),
+            Err(err) if is_transient_mode_switch_error(&err) => {
+                logging!(
+                    warn,
+                    Type::Core,
+                    "change clash mode request failed on attempt {attempt}/{total_attempts}: {err}; retrying in {retry_delay_ms}ms"
+                );
+                sleep(Duration::from_millis(retry_delay_ms)).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    handle::Handle::mihomo().await.patch_base_config(json_value).await
+}
+
 /// Change Clash mode (rule/global/direct/script)
 pub async fn change_clash_mode(mode: String) -> Result<()> {
     let mut mapping = Mapping::new();
@@ -76,10 +125,7 @@ pub async fn change_clash_mode(mode: String) -> Result<()> {
         "mode": mode
     });
     logging!(debug, Type::Core, "change clash mode to {mode}");
-    handle::Handle::mihomo()
-        .await
-        .patch_base_config(&json_value)
-        .await?;
+    patch_base_config_with_retry(&json_value).await?;
 
     // 更新订阅
     Config::clash().await.edit_draft(|d| d.patch_config(&mapping));

--- a/src-tauri/src/feat/clash.rs
+++ b/src-tauri/src/feat/clash.rs
@@ -5,6 +5,7 @@ use crate::{
     process::AsyncHandler,
     utils::{self, resolve::reset_resolve_done},
 };
+use anyhow::Result;
 use clash_verge_logging::{Type, logging, logging_error};
 use serde_yaml_ng::{Mapping, Value};
 use smartstring::alias::String;
@@ -67,7 +68,7 @@ fn after_change_clash_mode() {
 }
 
 /// Change Clash mode (rule/global/direct/script)
-pub async fn change_clash_mode(mode: String) {
+pub async fn change_clash_mode(mode: String) -> Result<()> {
     let mut mapping = Mapping::new();
     mapping.insert(Value::from("mode"), Value::from(mode.as_str()));
     // Convert YAML mapping to JSON Value
@@ -75,31 +76,33 @@ pub async fn change_clash_mode(mode: String) {
         "mode": mode
     });
     logging!(debug, Type::Core, "change clash mode to {mode}");
-    match handle::Handle::mihomo().await.patch_base_config(&json_value).await {
-        Ok(_) => {
-            // 更新订阅
-            Config::clash().await.edit_draft(|d| d.patch_config(&mapping));
+    handle::Handle::mihomo()
+        .await
+        .patch_base_config(&json_value)
+        .await?;
 
-            // 分离数据获取和异步调用
-            let clash_data = Config::clash().await.data_arc();
-            if clash_data.save_config().await.is_ok() {
-                handle::Handle::refresh_clash();
-                logging_error!(Type::Tray, tray::Tray::global().update_menu().await);
-                logging_error!(
-                    Type::Tray,
-                    tray::Tray::global()
-                        .update_icon(&Config::verge().await.data_arc())
-                        .await
-                );
-            }
+    // 更新订阅
+    Config::clash().await.edit_draft(|d| d.patch_config(&mapping));
 
-            let is_auto_close_connection = Config::verge().await.data_arc().auto_close_connection.unwrap_or(false);
-            if is_auto_close_connection {
-                after_change_clash_mode();
-            }
-        }
-        Err(err) => logging!(error, Type::Core, "{err}"),
+    // 分离数据获取和异步调用
+    let clash_data = Config::clash().await.data_arc();
+    if clash_data.save_config().await.is_ok() {
+        handle::Handle::refresh_clash();
+        logging_error!(Type::Tray, tray::Tray::global().update_menu().await);
+        logging_error!(
+            Type::Tray,
+            tray::Tray::global()
+                .update_icon(&Config::verge().await.data_arc())
+                .await
+        );
     }
+
+    let is_auto_close_connection = Config::verge().await.data_arc().auto_close_connection.unwrap_or(false);
+    if is_auto_close_connection {
+        after_change_clash_mode();
+    }
+
+    Ok(())
 }
 
 /// Test connection delay to a URL

--- a/src/components/home/clash-mode-card.tsx
+++ b/src/components/home/clash-mode-card.tsx
@@ -4,14 +4,14 @@ import {
   MultipleStopRounded,
 } from "@mui/icons-material";
 import { Box, Paper, Stack, Typography } from "@mui/material";
-import { useLockFn } from "ahooks";
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { closeAllConnections } from "tauri-plugin-mihomo-api";
 
 import { useVerge } from "@/hooks/use-verge";
 import { useAppData } from "@/providers/app-data-context";
 import { patchClashMode } from "@/services/cmds";
+import { showNotice } from "@/services/notice-service";
 import type { TranslationKey } from "@/types/generated/i18n-keys";
 
 const CLASH_MODES = ["rule", "global", "direct"] as const;
@@ -53,6 +53,8 @@ export const ClashModeCard = () => {
       ? currentMode
       : undefined;
 
+  const [switching, setSwitching] = useState(false);
+
   const modeDescription = useMemo(() => {
     if (currentModeKey) {
       return t(MODE_META[currentModeKey].description);
@@ -71,24 +73,34 @@ export const ClashModeCard = () => {
   );
 
   // 切换模式的处理函数
-  const onChangeMode = useLockFn(async (mode: ClashMode) => {
-    if (mode === currentModeKey) return;
-    if (verge?.auto_close_connection) {
-      closeAllConnections();
-    }
+  const onChangeMode = useCallback(
+    async (mode: ClashMode) => {
+      if (switching) return;
+      if (mode === currentModeKey) return;
 
-    try {
-      await patchClashMode(mode);
-      // 使用共享的刷新方法
-      refreshClashConfig();
-    } catch (error) {
-      console.error("Failed to change mode:", error);
-    }
-  });
+      setSwitching(true);
+
+      if (verge?.auto_close_connection) {
+        closeAllConnections();
+      }
+
+      try {
+        await patchClashMode(mode);
+        await refreshClashConfig();
+      } catch (error) {
+        console.error("Failed to change mode:", error);
+        showNotice.error(error);
+      } finally {
+        setSwitching(false);
+      }
+    },
+    [currentModeKey, switching, verge, refreshClashConfig],
+  );
 
   // 按钮样式
   const buttonStyles = (mode: ClashMode) => ({
-    cursor: "pointer",
+    cursor: switching ? "not-allowed" : "pointer",
+    pointerEvents: switching ? "none" : "auto",
     px: 2,
     py: 1.2,
     display: "flex",
@@ -97,8 +109,8 @@ export const ClashModeCard = () => {
     gap: 1,
     bgcolor: mode === currentModeKey ? "primary.main" : "background.paper",
     color: mode === currentModeKey ? "primary.contrastText" : "text.primary",
+    opacity: switching ? 0.5 : 1,
     borderRadius: 1.5,
-    transition: "all 0.2s ease-in-out",
     position: "relative",
     overflow: "visible",
     "&:hover": {

--- a/src/pages/proxies.tsx
+++ b/src/pages/proxies.tsx
@@ -16,6 +16,7 @@ import {
   updateProxyChainConfigInRuntime,
 } from "@/services/cmds";
 import { debugLog } from "@/utils/debug";
+import { showNotice } from "@/services/notice-service";
 
 const MODES = ["rule", "global", "direct"] as const;
 type Mode = (typeof MODES)[number];
@@ -53,14 +54,32 @@ const ProxyPage = () => {
   const normalizedMode = clashConfig?.mode?.toLowerCase();
   const curMode = isMode(normalizedMode) ? normalizedMode : undefined;
 
-  const onChangeMode = useLockFn(async (mode: Mode) => {
-    // 断开连接
-    if (mode !== curMode && verge?.auto_close_connection) {
-      closeAllConnections();
-    }
-    await patchClashMode(mode);
-    refreshClashConfig();
-  });
+  const [switching, setSwitching] = useState(false);
+
+  // 切换模式时显式禁用按钮，避免 IPC 期间后续点击被静默吞掉
+  const onChangeMode = useCallback(
+    async (mode: Mode) => {
+      if (switching) return;
+      if (mode === curMode) return;
+
+      setSwitching(true);
+
+      if (mode !== curMode && verge?.auto_close_connection) {
+        closeAllConnections();
+      }
+
+      try {
+        await patchClashMode(mode);
+        await refreshClashConfig();
+      } catch (error) {
+        console.error("Failed to change mode:", error);
+        showNotice.error(error);
+      } finally {
+        setSwitching(false);
+      }
+    },
+    [curMode, switching, verge, refreshClashConfig],
+  );
 
   const onToggleChainMode = useLockFn(async () => {
     const newChainMode = !isChainMode;
@@ -146,6 +165,7 @@ const ProxyPage = () => {
                 key={mode}
                 variant={mode === curMode ? "contained" : "outlined"}
                 onClick={() => onChangeMode(mode)}
+                disabled={switching}
                 sx={{ textTransform: "capitalize" }}
               >
                 {t(`proxies.page.modes.${mode}`)}


### PR DESCRIPTION
## 摘要

这个 PR 修复了 Windows service mode 下，Clash 模式在 `rule`、`global`、`direct` 之间切换时偶发失败的问题。

相对 `origin/dev`，这个 PR 包含两个相关修复：
- [e69af1db](https://github.com/clash-verge-rev/clash-verge-rev/commit/e69af1db) `fix(mode-switch): prevent swallowed clicks during IPC`
- [63e93b7d](https://github.com/clash-verge-rev/clash-verge-rev/commit/63e93b7d) `fix(mode-switch): retry transient mihomo IPC failures`

受影响版本中的主要现象有：
- 切换模式后有时仍停留在原模式
- 上一次切换还没结束时，继续点击看起来像“没反应”

同时，后端日志中可见偶发本地 controller 请求失败，例如：
- `error sending request for url (http://localhost/configs)`

## 原因

主要回归来自 [7fc238c2](https://github.com/clash-verge-rev/clash-verge-rev/commit/7fc238c2)（`refactor: invock mihomo api by use tauri-plugin-mihomo (#4926)`）。

在这次改动之前，模式切换仍走旧的 `/configs` IPC 路径。`v2.4.2` 中这条路径使用带重试的 `IpcManager`，默认配置为：
- `max_retries: 4`
- `retry_delay: 125ms`

在 [7fc238c2](https://github.com/clash-verge-rev/clash-verge-rev/commit/7fc238c2) 之后，模式切换改为通过 `tauri-plugin-mihomo` 发起单次 `PATCH /configs`` 请求。

在 Windows service mode 下，存在一个短暂窗口：`CoreManager` 可能已经认为服务可用，但本地 Mihomo controller pipe 仍暂时不稳定。此时模式切换会偶发失败。

另外，前端侧还有一个问题放大了这个现象：
- `patch_clash_mode` 在后端切换失败时，之前仍可能向前端返回成功
- Home 和 Proxies 页的模式切换使用了加锁处理，请求未结束时，后续点击会被忽略
- 两者叠加后，用户看到的效果就像“点了没反应”

## 修改

- 为模式切换时的 Mihomo `/configs` 临时失败增加重试
- 非临时性错误仍立即返回失败
- 增加重试 warning 日志，方便排查
- 将后端模式切换失败继续传递给前端、托盘和快捷键调用方，不再静默吞掉
- 模式切换进行中时，明确禁用重复点击
- 将模式切换失败反馈给用户，而不是静默失败

## 验证

代码层面：
- 确认 `v2.4.2` 使用的是旧的、带重试的 `IpcManager` `/configs` 路径
- 确认 [7fc238c2](https://github.com/clash-verge-rev/clash-verge-rev/commit/7fc238c2) 将模式切换改为 `tauri-plugin-mihomo` 的 `PATCH /configs`
- 确认本 PR 为模式切换补回重试，并恢复错误透传
- `cargo check --manifest-path src-tauri/Cargo.toml -p clash-verge` 通过

手动验证：
- 修复前测试版本：[`Clash.Verge_2.4.7+autobuild.0309.20a523b_x64-setup.exe`](https://github.com/clash-verge-rev/clash-verge-rev/releases/download/autobuild/Clash.Verge_2.4.7%2Bautobuild.0309.20a523b_x64-setup.exe)
- 修复后测试结果：在上述版本基础上加入本 PR 的两个修复后重新测试
- `rule / global / direct` 切换恢复稳定
- 本地 controller 的瞬时失败可被重试恢复
- 请求进行中时，后续点击不再表现为“没反应”

对比来看，`v2.4.2` 在相同测试场景下没有出现这类用户可见回归。

## 图片

下面的对比图中：
- **修复前**：`Clash.Verge_2.4.7+autobuild.0309.20a523b_x64-setup.exe`
- **修复后**：在该版本基础上加入本 PR 两个修复后的结果

### Home：修复前模式切换会卡住
![home-mode-switch-stuck-before-fix](https://github.com/user-attachments/assets/19c6c9b2-4905-49ec-9df6-cca600f5e5e5)

### Home：修复后模式切换恢复正常
![home-mode-switch-works-after-fix](https://github.com/user-attachments/assets/ad6d31a0-b767-40a1-852b-2100282b1751)

### Proxies：修复前模式切换会卡住
![proxies-mode-switch-stuck-before-fix](https://github.com/user-attachments/assets/2da4156c-9506-47c2-bdf9-fee485ded08c)

### Proxies：修复后模式切换恢复正常
![proxies-mode-switch-works-after-fix](https://github.com/user-attachments/assets/7ec5c20b-5e74-421d-856b-8401f02462f7)

## 相关

- follow-up to #6340
- related to #6326