### PR TITLE
refactor: clean up network interface flow

### DIFF
--- a/src-tauri/src/cmd/network.rs
+++ b/src-tauri/src/cmd/network.rs
@@ -4,6 +4,7 @@ use clash_verge_logging::{Type, logging};
 use gethostname::gethostname;
 use network_interface::NetworkInterface;
 use serde_yaml_ng::Mapping;
+use std::collections::HashSet;
 use std::net::TcpListener;
 use sysproxy::{Autoproxy, Sysproxy};
 use tauri_plugin_clash_verge_sysinfo;
@@ -63,12 +64,7 @@ pub fn get_system_hostname() -> String {
     // 获取系统主机名，处理可能的非UTF-8字符
     match gethostname().into_string() {
         Ok(name) => name,
-        Err(os_string) => {
-            // 对于包含非UTF-8的主机名，使用调试格式化
-            let fallback = format!("{os_string:?}");
-            // 去掉可能存在的引号
-            fallback.trim_matches('"').to_string()
-        }
+        Err(os_string) => format!("{os_string:?}").trim_matches('"').to_string(),
     }
 }
 
@@ -83,18 +79,12 @@ pub fn get_network_interfaces() -> Vec<String> {
 pub fn get_network_interfaces_info() -> CmdResult<Vec<NetworkInterface>> {
     use network_interface::{NetworkInterface, NetworkInterfaceConfig as _};
 
-    let names = get_network_interfaces();
+    let names = get_network_interfaces().into_iter().collect::<HashSet<_>>();
     let interfaces = NetworkInterface::show().stringify_err()?;
-
-    let mut result = Vec::new();
-
-    for interface in interfaces {
-        if names.contains(&interface.name) {
-            result.push(interface);
-        }
-    }
-
-    Ok(result)
+    Ok(interfaces
+        .into_iter()
+        .filter(|interface| names.contains(&interface.name))
+        .collect())
 }
 
 #[tauri::command]

--- a/src/hooks/use-network.ts
+++ b/src/hooks/use-network.ts
@@ -1,10 +1,13 @@
 import useSWR from 'swr'
 
-import { getNetworkInterfacesInfo } from '@/services/cmds'
+import {
+  getNetworkInterfacesInfo,
+  NETWORK_INTERFACES_INFO_QUERY_KEY,
+} from '@/services/cmds'
 
 export const useNetworkInterfaces = () => {
   const { data, error, isLoading, mutate } = useSWR(
-    'getNetworkInterfacesInfo',
+    NETWORK_INTERFACES_INFO_QUERY_KEY,
     getNetworkInterfacesInfo,
     {
       revalidateOnFocus: false,
@@ -14,7 +17,7 @@ export const useNetworkInterfaces = () => {
   )
 
   return {
-    networkInterfaces: data || [],
+    networkInterfaces: data ?? [],
     loading: isLoading,
     error,
     mutate,

--- a/src/services/cmds.ts
+++ b/src/services/cmds.ts
@@ -419,16 +419,22 @@ export async function downloadIconCache(url: string, name: string) {
   return invoke<string>('download_icon_cache', { url, name })
 }
 
+const NETWORK_INTERFACES_CMD = 'get_network_interfaces'
+const SYSTEM_HOSTNAME_CMD = 'get_system_hostname'
+const NETWORK_INTERFACES_INFO_CMD = 'get_network_interfaces_info'
+
+export const NETWORK_INTERFACES_INFO_QUERY_KEY = 'getNetworkInterfacesInfo'
+
 export async function getNetworkInterfaces() {
-  return invoke<string[]>('get_network_interfaces')
+  return invoke<string[]>(NETWORK_INTERFACES_CMD)
 }
 
 export async function getSystemHostname() {
-  return invoke<string>('get_system_hostname')
+  return invoke<string>(SYSTEM_HOSTNAME_CMD)
 }
 
 export async function getNetworkInterfacesInfo() {
-  return invoke<INetworkInterface[]>('get_network_interfaces_info')
+  return invoke<INetworkInterface[]>(NETWORK_INTERFACES_INFO_CMD)
 }
 
 export async function createWebdavBackup() {


### PR DESCRIPTION
Summary:\n- refactor backend network interface filtering in src-tauri/src/cmd/network.rs\n- refactor frontend network interface command/hook flow in src/services/cmds.ts and src/hooks/use-network.ts\n- no behavior changes, only readability/maintainability improvements\n\nValidation:\n- pnpm -s eslint -c eslint.config.ts --max-warnings=0 src/hooks/use-network.ts src/services/cmds.ts\n- cargo check --manifest-path src-tauri/Cargo.toml -p clash-verge --offline\n\nNote: repository has unrelated pre-existing baseline lint/typecheck issues.