### PR TITLE
fix: harden WebDAV TLS and singleton localhost commands

### DIFF
--- a/src-tauri/src/cmd/webdav.rs
+++ b/src-tauri/src/cmd/webdav.rs
@@ -9,11 +9,17 @@ use smartstring::alias::String;
 
 /// 保存 WebDAV 配置
 #[tauri::command]
-pub async fn save_webdav_config(url: String, username: String, password: String) -> CmdResult<()> {
+pub async fn save_webdav_config(
+    url: String,
+    username: String,
+    password: String,
+    danger_accept_invalid_certs: bool,
+) -> CmdResult<()> {
     let patch = IVerge {
         webdav_url: Some(url),
         webdav_username: Some(username),
         webdav_password: Some(password),
+        webdav_danger_accept_invalid_certs: Some(danger_accept_invalid_certs),
         ..IVerge::default()
     };
     Config::verge().await.edit_draft(|e| e.patch_config(&patch));

--- a/src-tauri/src/config/verge.rs
+++ b/src-tauri/src/config/verge.rs
@@ -233,6 +233,8 @@ pub struct IVerge {
     )]
     pub webdav_password: Option<String>,
 
+    pub webdav_danger_accept_invalid_certs: Option<bool>,
+
     #[serde(skip)]
     pub enable_tray_speed: Option<bool>,
 
@@ -438,6 +440,7 @@ impl IVerge {
             webdav_url: None,
             webdav_username: None,
             webdav_password: None,
+            webdav_danger_accept_invalid_certs: Some(false),
             enable_tray_speed: Some(false),
             // enable_tray_icon: Some(true),
             tray_proxy_groups_display_mode: Some("default".into()),
@@ -543,6 +546,7 @@ impl IVerge {
         patch!(webdav_url);
         patch!(webdav_username);
         patch!(webdav_password);
+        patch!(webdav_danger_accept_invalid_certs);
         patch!(enable_tray_speed);
         // patch!(enable_tray_icon);
         patch!(tray_proxy_groups_display_mode);

--- a/src-tauri/src/core/backup.rs
+++ b/src-tauri/src/core/backup.rs
@@ -30,6 +30,7 @@ struct WebDavConfig {
     url: String,
     username: String,
     password: String,
+    danger_accept_invalid_certs: bool,
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
@@ -99,6 +100,9 @@ impl WebDavClient {
                         .into(),
                     username: verge.webdav_username.clone().unwrap_or_default(),
                     password: verge.webdav_password.clone().unwrap_or_default(),
+                    danger_accept_invalid_certs: verge
+                        .webdav_danger_accept_invalid_certs
+                        .unwrap_or(false),
                 };
 
                 // 存储配置到 ArcSwapOption
@@ -112,7 +116,8 @@ impl WebDavClient {
             .set_agent(
                 reqwest::Client::builder()
                     .use_rustls_tls()
-                    .danger_accept_invalid_certs(true)
+                    .danger_accept_invalid_certs(config.danger_accept_invalid_certs)
+                    .danger_accept_invalid_hostnames(config.danger_accept_invalid_certs)
                     .timeout(Duration::from_secs(op.timeout()))
                     .user_agent(format!("clash-verge/{APP_VERSION} ({OS} WebDAV-Client)"))
                     .redirect(reqwest::redirect::Policy::custom(|attempt| {

--- a/src-tauri/src/feat/backup.rs
+++ b/src-tauri/src/feat/backup.rs
@@ -30,6 +30,7 @@ async fn finalize_restored_verge_config(
     webdav_url: Option<String>,
     webdav_username: Option<String>,
     webdav_password: Option<String>,
+    webdav_danger_accept_invalid_certs: Option<bool>,
 ) -> Result<()> {
     // Do NOT silently fallback to defaults; a broken/missing verge.yaml means restore failed.
     // Propagate the error so the UI/user can react accordingly.
@@ -37,6 +38,7 @@ async fn finalize_restored_verge_config(
     restored.webdav_url = webdav_url;
     restored.webdav_username = webdav_username;
     restored.webdav_password = webdav_password;
+    restored.webdav_danger_accept_invalid_certs = webdav_danger_accept_invalid_certs;
     restored.save_file().await?;
 
     let restored_clash = IClashTemp::new().await;
@@ -114,6 +116,7 @@ pub async fn restore_webdav_backup(filename: String) -> Result<()> {
     let webdav_url = verge_data.webdav_url.clone();
     let webdav_username = verge_data.webdav_username.clone();
     let webdav_password = verge_data.webdav_password.clone();
+    let webdav_danger_accept_invalid_certs = verge_data.webdav_danger_accept_invalid_certs;
 
     let backup_storage_path = app_home_dir()
         .map_err(|e| anyhow::anyhow!("Failed to get app home dir: {e}"))?
@@ -131,7 +134,13 @@ pub async fn restore_webdav_backup(filename: String) -> Result<()> {
     let file = AsyncHandler::spawn_blocking(move || std::fs::File::open(&value)).await??;
     let mut zip = zip::ZipArchive::new(file)?;
     zip.extract(app_home_dir()?)?;
-    let res = finalize_restored_verge_config(webdav_url, webdav_username, webdav_password).await;
+    let res = finalize_restored_verge_config(
+        webdav_url,
+        webdav_username,
+        webdav_password,
+        webdav_danger_accept_invalid_certs,
+    )
+    .await;
     // Finally remove the temp file (attempt cleanup even if finalize fails)
     let _ = backup_storage_path.remove_if_exists().await;
     res
@@ -301,20 +310,32 @@ pub async fn restore_local_backup(filename: String) -> Result<()> {
         return Err(anyhow!("Backup file not found: {}", filename));
     }
 
-    let (webdav_url, webdav_username, webdav_password) = {
+    let (
+        webdav_url,
+        webdav_username,
+        webdav_password,
+        webdav_danger_accept_invalid_certs,
+    ) = {
         let verge = Config::verge().await;
         let verge = verge.latest_arc();
         (
             verge.webdav_url.clone(),
             verge.webdav_username.clone(),
             verge.webdav_password.clone(),
+            verge.webdav_danger_accept_invalid_certs,
         )
     };
 
     let file = AsyncHandler::spawn_blocking(move || std::fs::File::open(&target_path)).await??;
     let mut zip = zip::ZipArchive::new(file)?;
     zip.extract(app_home_dir()?)?;
-    finalize_restored_verge_config(webdav_url, webdav_username, webdav_password).await?;
+    finalize_restored_verge_config(
+        webdav_url,
+        webdav_username,
+        webdav_password,
+        webdav_danger_accept_invalid_certs,
+    )
+    .await?;
     Ok(())
 }
 

--- a/src-tauri/src/utils/server.rs
+++ b/src-tauri/src/utils/server.rs
@@ -70,11 +70,93 @@ fn singleton_unauthorized() -> warp::reply::WithStatus<std::string::String> {
     )
 }
 
+async fn notify_existing_instance_visible(
+    client: &reqwest::Client,
+    port: u16,
+    token: Option<&str>,
+) -> Result<()> {
+    if let Some(token) = token {
+        match client
+            .post(format!("http://127.0.0.1:{port}/commands/visible"))
+            .header(SINGLETON_TOKEN_HEADER, token)
+            .send()
+            .await?
+            .error_for_status()
+        {
+            Ok(_) => return Ok(()),
+            Err(err) => {
+                logging!(
+                    warn,
+                    Type::Window,
+                    "singleton auth visible request failed, fallback to legacy GET: {err}"
+                );
+            }
+        }
+    }
+
+    client
+        .get(format!("http://127.0.0.1:{port}/commands/visible"))
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn notify_existing_instance_scheme(
+    client: &reqwest::Client,
+    port: u16,
+    param: &str,
+    token: Option<&str>,
+) -> Result<()> {
+    let query = QueryParam {
+        param: param.to_string().into(),
+    };
+
+    if let Some(token) = token {
+        match client
+            .post(format!("http://127.0.0.1:{port}/commands/scheme"))
+            .header(SINGLETON_TOKEN_HEADER, token)
+            .form(&query)
+            .send()
+            .await?
+            .error_for_status()
+        {
+            Ok(_) => return Ok(()),
+            Err(err) => {
+                logging!(
+                    warn,
+                    Type::Window,
+                    "singleton auth scheme request failed, fallback to legacy GET: {err}"
+                );
+            }
+        }
+    }
+
+    client
+        .get(format!("http://127.0.0.1:{port}/commands/scheme"))
+        .query(&query)
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(())
+}
+
 /// check whether there is already exists
 pub async fn check_singleton() -> Result<()> {
     let port = IVerge::get_singleton_port();
     if is_port_in_use(port) {
-        let token = read_singleton_token()?;
+        let token = match read_singleton_token() {
+            Ok(token) => Some(token),
+            Err(err) => {
+                logging!(
+                    warn,
+                    Type::Window,
+                    "singleton auth token unavailable, fallback to legacy notify: {err}"
+                );
+                None
+            }
+        };
         let client = ClientBuilder::new().timeout(Duration::from_millis(500)).build()?;
         // 需要确保 Send
         #[allow(clippy::needless_collect)]
@@ -84,22 +166,26 @@ pub async fn check_singleton() -> Result<()> {
             {
                 let param = argvs[1].as_str();
                 if param.starts_with("clash:") {
-                    client
-                        .post(format!("http://127.0.0.1:{port}/commands/scheme"))
-                        .header(SINGLETON_TOKEN_HEADER, token.as_str())
-                        .form(&QueryParam {
-                            param: param.to_string().into(),
-                        })
-                        .send()
-                        .await?;
+                    if let Err(err) =
+                        notify_existing_instance_scheme(&client, port, param, token.as_deref()).await
+                    {
+                        logging!(
+                            warn,
+                            Type::Window,
+                            "failed to notify existing instance scheme handler: {err}"
+                        );
+                    }
                 }
             }
         } else {
-            client
-                .post(format!("http://127.0.0.1:{port}/commands/visible"))
-                .header(SINGLETON_TOKEN_HEADER, token.as_str())
-                .send()
-                .await?;
+            if let Err(err) = notify_existing_instance_visible(&client, port, token.as_deref()).await
+            {
+                logging!(
+                    warn,
+                    Type::Window,
+                    "failed to notify existing instance visible handler: {err}"
+                );
+            }
         }
         logging!(error, Type::Window, "failed to setup singleton listen server");
         bail!("app exists");

--- a/src-tauri/src/utils/server.rs
+++ b/src-tauri/src/utils/server.rs
@@ -4,19 +4,23 @@ use crate::{
     config::{Config, DEFAULT_PAC, IVerge},
     module::lightweight,
     process::AsyncHandler,
-    utils::window_manager::WindowManager,
+    utils::{dirs::APP_ID, window_manager::WindowManager},
 };
 use anyhow::{Result, bail};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use clash_verge_logging::{Type, logging, logging_error};
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use reqwest::ClientBuilder;
 use smartstring::alias::String;
-use std::time::Duration;
+use std::{env::temp_dir, fs, path::PathBuf, time::Duration};
 use tokio::sync::oneshot;
 use warp::Filter as _;
 
-#[derive(serde::Deserialize, Debug)]
+const SINGLETON_TOKEN_FILE: &str = "singleton-auth-token";
+const SINGLETON_TOKEN_HEADER: &str = "x-clash-verge-singleton-token";
+
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
 struct QueryParam {
     param: String,
 }
@@ -24,10 +28,53 @@ struct QueryParam {
 // 关闭 embedded server 的信号发送端
 static SHUTDOWN_SENDER: OnceCell<Mutex<Option<oneshot::Sender<()>>>> = OnceCell::new();
 
+fn singleton_token_path() -> PathBuf {
+    temp_dir().join(APP_ID).join(SINGLETON_TOKEN_FILE)
+}
+
+fn write_singleton_token() -> Result<String> {
+    let mut token_bytes = [0_u8; 32];
+    getrandom::fill(&mut token_bytes)?;
+    let token = URL_SAFE_NO_PAD.encode(token_bytes);
+    let token_path = singleton_token_path();
+
+    if let Some(parent) = token_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    fs::write(&token_path, &token)?;
+    Ok(token.into())
+}
+
+fn read_singleton_token() -> Result<String> {
+    let token = fs::read_to_string(singleton_token_path())?;
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        bail!("singleton auth token is empty");
+    }
+    Ok(token.into())
+}
+
+fn cleanup_singleton_token() {
+    let _ = fs::remove_file(singleton_token_path());
+}
+
+fn singleton_ok() -> warp::reply::WithStatus<std::string::String> {
+    warp::reply::with_status("ok".to_string(), warp::http::StatusCode::OK)
+}
+
+fn singleton_unauthorized() -> warp::reply::WithStatus<std::string::String> {
+    warp::reply::with_status(
+        "unauthorized".to_string(),
+        warp::http::StatusCode::UNAUTHORIZED,
+    )
+}
+
 /// check whether there is already exists
 pub async fn check_singleton() -> Result<()> {
     let port = IVerge::get_singleton_port();
     if is_port_in_use(port) {
+        let token = read_singleton_token()?;
         let client = ClientBuilder::new().timeout(Duration::from_millis(500)).build()?;
         // 需要确保 Send
         #[allow(clippy::needless_collect)]
@@ -38,14 +85,19 @@ pub async fn check_singleton() -> Result<()> {
                 let param = argvs[1].as_str();
                 if param.starts_with("clash:") {
                     client
-                        .get(format!("http://127.0.0.1:{port}/commands/scheme?param={param}"))
+                        .post(format!("http://127.0.0.1:{port}/commands/scheme"))
+                        .header(SINGLETON_TOKEN_HEADER, token.as_str())
+                        .form(&QueryParam {
+                            param: param.to_string().into(),
+                        })
                         .send()
                         .await?;
                 }
             }
         } else {
             client
-                .get(format!("http://127.0.0.1:{port}/commands/visible"))
+                .post(format!("http://127.0.0.1:{port}/commands/visible"))
+                .header(SINGLETON_TOKEN_HEADER, token.as_str())
                 .send()
                 .await?;
         }
@@ -58,6 +110,14 @@ pub async fn check_singleton() -> Result<()> {
 /// The embed server only be used to implement singleton process
 /// maybe it can be used as pac server later
 pub fn embed_server() {
+    let auth_token = match write_singleton_token() {
+        Ok(token) => token,
+        Err(err) => {
+            logging!(error, Type::Window, "failed to create singleton auth token: {err}");
+            return;
+        }
+    };
+
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     #[allow(clippy::expect_used)]
     SHUTDOWN_SENDER
@@ -65,53 +125,74 @@ pub fn embed_server() {
         .expect("failed to set shutdown signal for embedded server");
     let port = IVerge::get_singleton_port();
 
-    let visible = warp::path!("commands" / "visible").and_then(|| async {
-        logging!(info, Type::Window, "检测到从单例模式恢复应用窗口");
-        if !lightweight::exit_lightweight_mode().await {
-            WindowManager::show_main_window().await;
-        } else {
-            logging!(error, Type::Window, "轻量模式退出失败，无法恢复应用窗口");
-        };
-        Ok::<_, warp::Rejection>(warp::reply::with_status::<std::string::String>(
-            "ok".to_string(),
-            warp::http::StatusCode::OK,
+    let visible_auth_token = auth_token.clone();
+    let visible = warp::path!("commands" / "visible")
+        .and(warp::post())
+        .and(warp::header::optional::<std::string::String>(
+            SINGLETON_TOKEN_HEADER,
         ))
-    });
+        .and_then(move |token: Option<std::string::String>| {
+            let expected = visible_auth_token.clone();
+            async move {
+                if token.as_deref() != Some(expected.as_str()) {
+                    return Ok::<_, warp::Rejection>(singleton_unauthorized());
+                }
 
-    let pac = warp::path!("commands" / "pac").and_then(|| async move {
-        let verge_config = Config::verge().await;
-        let clash_config = Config::clash().await;
+                logging!(info, Type::Window, "检测到从单例模式恢复应用窗口");
+                if !lightweight::exit_lightweight_mode().await {
+                    WindowManager::show_main_window().await;
+                } else {
+                    logging!(error, Type::Window, "轻量模式退出失败，无法恢复应用窗口");
+                };
+                Ok::<_, warp::Rejection>(singleton_ok())
+            }
+        });
 
-        let pac_content = verge_config
-            .data_arc()
-            .pac_file_content
-            .clone()
-            .unwrap_or_else(|| DEFAULT_PAC.into());
+    let pac = warp::path!("commands" / "pac")
+        .and(warp::get())
+        .and_then(|| async move {
+            let verge_config = Config::verge().await;
+            let clash_config = Config::clash().await;
 
-        let pac_port = verge_config
-            .data_arc()
-            .verge_mixed_port
-            .unwrap_or_else(|| clash_config.data_arc().get_mixed_port());
-        let processed_content = pac_content.replace("%mixed-port%", &format!("{pac_port}"));
-        Ok::<_, warp::Rejection>(
-            warp::http::Response::builder()
-                .header("Content-Type", "application/x-ns-proxy-autoconfig")
-                .body(processed_content)
-                .unwrap_or_default(),
-        )
-    });
+            let pac_content = verge_config
+                .data_arc()
+                .pac_file_content
+                .clone()
+                .unwrap_or_else(|| DEFAULT_PAC.into());
+
+            let pac_port = verge_config
+                .data_arc()
+                .verge_mixed_port
+                .unwrap_or_else(|| clash_config.data_arc().get_mixed_port());
+            let processed_content = pac_content.replace("%mixed-port%", &format!("{pac_port}"));
+            Ok::<_, warp::Rejection>(
+                warp::http::Response::builder()
+                    .header("Content-Type", "application/x-ns-proxy-autoconfig")
+                    .body(processed_content)
+                    .unwrap_or_default(),
+            )
+        });
 
     // Use map instead of and_then to avoid Send issues
+    let scheme_auth_token = auth_token.clone();
     let scheme = warp::path!("commands" / "scheme")
-        .and(warp::query::<QueryParam>())
-        .and_then(|query: QueryParam| async move {
-            AsyncHandler::spawn(|| async move {
-                logging_error!(Type::Setup, resolve::resolve_scheme(&query.param).await);
-            });
-            Ok::<_, warp::Rejection>(warp::reply::with_status::<std::string::String>(
-                "ok".to_string(),
-                warp::http::StatusCode::OK,
-            ))
+        .and(warp::post())
+        .and(warp::header::optional::<std::string::String>(
+            SINGLETON_TOKEN_HEADER,
+        ))
+        .and(warp::body::form::<QueryParam>())
+        .and_then(move |token: Option<std::string::String>, query: QueryParam| {
+            let expected = scheme_auth_token.clone();
+            async move {
+                if token.as_deref() != Some(expected.as_str()) {
+                    return Ok::<_, warp::Rejection>(singleton_unauthorized());
+                }
+
+                AsyncHandler::spawn(|| async move {
+                    logging_error!(Type::Setup, resolve::resolve_scheme(&query.param).await);
+                });
+                Ok::<_, warp::Rejection>(singleton_ok())
+            }
         });
 
     let commands = visible.or(scheme).or(pac);
@@ -130,6 +211,7 @@ pub fn embed_server() {
 
 pub fn shutdown_embedded_server() {
     logging!(info, Type::Window, "shutting down embedded server");
+    cleanup_singleton_token();
     if let Some(sender) = SHUTDOWN_SENDER.get()
         && let Some(sender) = sender.lock().take()
     {

--- a/src/components/setting/mods/backup-config-viewer.tsx
+++ b/src/components/setting/mods/backup-config-viewer.tsx
@@ -1,10 +1,12 @@
 import Visibility from '@mui/icons-material/Visibility'
 import VisibilityOff from '@mui/icons-material/VisibilityOff'
 import {
+  FormControlLabel,
   TextField,
   Button,
   Grid,
   Stack,
+  Switch,
   IconButton,
   InputAdornment,
 } from '@mui/material'
@@ -41,27 +43,38 @@ export const BackupConfigViewer = memo(
   }: BackupConfigViewerProps) => {
     const { t } = useTranslation()
     const { verge, mutateVerge } = useVerge()
-    const { webdav_url, webdav_username, webdav_password } = verge || {}
+    const {
+      webdav_url,
+      webdav_username,
+      webdav_password,
+      webdav_danger_accept_invalid_certs,
+    } = verge || {}
     const [showPassword, setShowPassword] = useState(false)
     const usernameRef = useRef<HTMLInputElement>(null)
     const passwordRef = useRef<HTMLInputElement>(null)
     const urlRef = useRef<HTMLInputElement>(null)
 
-    const { register, handleSubmit, watch } = useForm<IWebDavConfig>({
+    const { register, handleSubmit, watch, setValue } = useForm<IWebDavConfig>({
       defaultValues: {
         url: webdav_url,
         username: webdav_username,
         password: webdav_password,
+        danger_accept_invalid_certs:
+          webdav_danger_accept_invalid_certs ?? false,
       },
     })
     const url = watch('url')
     const username = watch('username')
     const password = watch('password')
+    const dangerAcceptInvalidCerts =
+      watch('danger_accept_invalid_certs') ?? false
 
     const webdavChanged =
       webdav_url !== url ||
       webdav_username !== username ||
-      webdav_password !== password
+      webdav_password !== password ||
+      (webdav_danger_accept_invalid_certs ?? false) !==
+        dangerAcceptInvalidCerts
 
     const webdavSignature = buildWebdavSignature(verge)
     const webdavStatus = getWebdavStatus(webdavSignature)
@@ -113,13 +126,19 @@ export const BackupConfigViewer = memo(
         webdav_url: data.url,
         webdav_username: data.username,
         webdav_password: data.password,
+        webdav_danger_accept_invalid_certs: data.danger_accept_invalid_certs,
       })
       const trimmedUrl = data.url.trim()
       const trimmedUsername = data.username.trim()
 
       try {
         setLoading(true)
-        await saveWebdavConfig(trimmedUrl, trimmedUsername, data.password)
+        await saveWebdavConfig(
+          trimmedUrl,
+          trimmedUsername,
+          data.password,
+          data.danger_accept_invalid_certs,
+        )
         await mutateVerge(
           (current) =>
             current
@@ -128,6 +147,8 @@ export const BackupConfigViewer = memo(
                   webdav_url: trimmedUrl,
                   webdav_username: trimmedUsername,
                   webdav_password: data.password,
+                  webdav_danger_accept_invalid_certs:
+                    data.danger_accept_invalid_certs,
                 }
               : current,
           false,
@@ -152,6 +173,7 @@ export const BackupConfigViewer = memo(
         webdav_url: url,
         webdav_username: username,
         webdav_password: password,
+        webdav_danger_accept_invalid_certs: dangerAcceptInvalidCerts,
       })
 
       try {
@@ -227,6 +249,21 @@ export const BackupConfigViewer = memo(
                       ),
                     },
                   }}
+                />
+              </Grid>
+              <Grid size={{ xs: 12 }}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={dangerAcceptInvalidCerts}
+                      onChange={(_, checked) =>
+                        setValue('danger_accept_invalid_certs', checked)
+                      }
+                    />
+                  }
+                  label={t(
+                    'profiles.modals.profileForm.fields.acceptInvalidCerts',
+                  )}
                 />
               </Grid>
             </Grid>

--- a/src/services/cmds.ts
+++ b/src/services/cmds.ts
@@ -467,11 +467,13 @@ export async function saveWebdavConfig(
   url: string,
   username: string,
   password: string,
+  dangerAcceptInvalidCerts: boolean,
 ) {
   return invoke<void>('save_webdav_config', {
     url,
     username,
     password,
+    dangerAcceptInvalidCerts,
   })
 }
 

--- a/src/services/webdav-status.ts
+++ b/src/services/webdav-status.ts
@@ -11,16 +11,21 @@ const WEBDAV_STATUS_KEY = 'webdav_status_cache'
 export const buildWebdavSignature = (
   verge?: Pick<
     IVergeConfig,
-    'webdav_url' | 'webdav_username' | 'webdav_password'
+    | 'webdav_url'
+    | 'webdav_username'
+    | 'webdav_password'
+    | 'webdav_danger_accept_invalid_certs'
   > | null,
 ) => {
   const url = verge?.webdav_url?.trim() ?? ''
   const username = verge?.webdav_username?.trim() ?? ''
   const password = verge?.webdav_password ?? ''
+  const dangerAcceptInvalidCerts =
+    verge?.webdav_danger_accept_invalid_certs ?? false
 
-  if (!url && !username && !password) return ''
+  if (!url && !username && !password && !dangerAcceptInvalidCerts) return ''
 
-  return JSON.stringify([url, username, password])
+  return JSON.stringify([url, username, password, dangerAcceptInvalidCerts])
 }
 
 const canUseStorage = () => typeof localStorage !== 'undefined'

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -976,6 +976,7 @@ interface IVergeConfig {
   webdav_url?: string
   webdav_username?: string
   webdav_password?: string
+  webdav_danger_accept_invalid_certs?: boolean
   home_cards?: Record<string, boolean>
   enable_hover_jump_navigator?: boolean
   hover_jump_navigator_delay?: number
@@ -1002,6 +1003,7 @@ interface IWebDavConfig {
   url: string
   username: string
   password: string
+  danger_accept_invalid_certs: boolean
 }
 
 // Traffic monitor types


### PR DESCRIPTION
## Summary / ??

This PR fixes two repo-local security issues in Clash Verge Rev. These are separate from the upstream sing-tun/TUN routing issue tracked elsewhere.

?? PR ??? Clash Verge Rev ?????????????????? sing-tun/TUN ???????

1. WebDAV backup TLS validation is now secure-by-default.
   WebDAV ????????????????????????????????
2. The singleton localhost control server now requires a per-run auth token and POST requests.
   ?? localhost ????????????????? token???????????? POST?

## Details / ??

### 1. WebDAV invalid certificates / WebDAV ????

Before:
- `reqwest` for WebDAV was created with `danger_accept_invalid_certs(true)` unconditionally.
- Any self-signed or intercepted HTTPS endpoint was accepted by default.

After:
- Added `webdav_danger_accept_invalid_certs` to verge config, default `false`.
- Plumbed the option through the Tauri command and backup settings UI.
- Reused the existing "accept invalid certs" translation string.
- Preserved the setting across backup restore flows.

### 2. Singleton localhost commands / ?? localhost ????

Before:
- `127.0.0.1:<port>/commands/visible` and `/commands/scheme` accepted unauthenticated GET requests.
- Other local processes, and browser-triggerable localhost requests, could hit those state-changing endpoints.

After:
- Generate a per-run random token and store it in the app temp dir for the second instance to read.
- Require `x-clash-verge-singleton-token` on `/commands/visible` and `/commands/scheme`.
- Change those state-changing endpoints to POST.
- Keep `/commands/pac` as GET.
- Clean up the token file on shutdown.

## Validation / ??

Ran locally:
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm typecheck`
- `corepack pnpm eslint src/components/setting/mods/backup-config-viewer.tsx src/services/cmds.ts src/services/webdav-status.ts --max-warnings=0`

Not run locally:
- Rust build / `cargo fmt` / `cargo clippy`
- Reason: this machine does not have `cargo` installed, and the repo's hooks currently require it.

## Notes / ??

- This PR does not address the upstream TUN routing issue; that fix has already been proposed separately upstream.
- I kept these as two separate commits in one PR. If maintainers prefer, I can split them further.
