### PR TITLE
fix: use IP addresses for proxy-server-nameserver to prevent DNS loops

### DIFF
--- a/src-tauri/src/utils/init.rs
+++ b/src-tauri/src/utils/init.rs
@@ -178,8 +178,11 @@ async fn init_dns_config() -> Result<()> {
         (
             "proxy-server-nameserver".into(),
             Value::Sequence(vec![
-                Value::String("https://doh.pub/dns-query".into()),
-                Value::String("https://dns.alidns.com/dns-query".into()),
+                // Use IP addresses to avoid DNS resolution loops
+                // when proxy-server-nameserver domain matches a rule routing to proxy
+                // See: https://github.com/clash-verge-rev/clash-verge-rev/issues/6158
+                Value::String("223.6.6.6".into()),
+                Value::String("8.8.8.8".into()),
                 Value::String("tls://223.5.5.5".into()),
             ]),
         ),


### PR DESCRIPTION
## Summary

- Change default `proxy-server-nameserver` from domain names to IP addresses
- Prevents DNS resolution loops that cause memory exhaustion (Issue #6158)

## Problem

When `proxy-server-nameserver` uses domain names like `doh.pub` or `dns.alidns.com`, and a rule matches these domains routing to a proxy, it creates an infinite DNS resolution loop:

```
1. Connect to proxy server -> need to resolve proxy server domain
2. Use proxy-server-nameserver (doh.pub) to resolve
3. Rule matches doh.pub -> route to PROXY
4. PROXY needs to connect -> back to step 1 -> infinite loop
5. Memory exhaustion (20GB+)
```

## Solution

Use IP addresses instead of domain names for `proxy-server-nameserver`:
- `223.6.6.6` (AliDNS)
- `8.8.8.8` (Google DNS)
- `tls://223.5.5.5` (AliDNS over TLS)

IPs don't require DNS resolution, so no loop can occur.

## Related

- Issue: #6158 (memory leak due to DNS loop)
- Upstream Mihomo PR: MetaCubeX/mihomo#2631 (DNS loop detection in core)

This provides defense-in-depth: both the upstream core AND the default config now protect against DNS loops.

## Changes

**Before:**
```yaml
proxy-server-nameserver:
  - https://doh.pub/dns-query        # domain - can loop
  - https://dns.alidns.com/dns-query # domain - can loop
  - tls://223.5.5.5                  # IP - safe
```

**After:**
```yaml
proxy-server-nameserver:
  - 223.6.6.6        # IP - safe
  - 8.8.8.8          # IP - safe
  - tls://223.5.5.5  # IP - safe
```