### PR TITLE
feat(installer): add Russian language to Windows installer

### DIFF
--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -14,7 +14,7 @@
       "nsis": {
         "displayLanguageSelector": true,
         "installerIcon": "icons/icon.ico",
-        "languages": ["SimpChinese", "English"],
+        "languages": ["SimpChinese", "English", "Russian"],
         "installMode": "perMachine",
         "template": "./packages/windows/installer.nsi"
       }

--- a/src-tauri/webview2.arm64.json
+++ b/src-tauri/webview2.arm64.json
@@ -14,7 +14,7 @@
       "nsis": {
         "displayLanguageSelector": true,
         "installerIcon": "icons/icon.ico",
-        "languages": ["SimpChinese", "English"],
+        "languages": ["SimpChinese", "English", "Russian"],
         "installMode": "perMachine",
         "template": "./packages/windows/installer.nsi"
       }

--- a/src-tauri/webview2.x64.json
+++ b/src-tauri/webview2.x64.json
@@ -14,7 +14,7 @@
       "nsis": {
         "displayLanguageSelector": true,
         "installerIcon": "icons/icon.ico",
-        "languages": ["SimpChinese", "English"],
+        "languages": ["SimpChinese", "English", "Russian"],
         "installMode": "perMachine",
         "template": "./packages/windows/installer.nsi"
       }

--- a/src-tauri/webview2.x86.json
+++ b/src-tauri/webview2.x86.json
@@ -14,7 +14,7 @@
       "nsis": {
         "displayLanguageSelector": true,
         "installerIcon": "icons/icon.ico",
-        "languages": ["SimpChinese", "English"],
+        "languages": ["SimpChinese", "English", "Russian"],
         "installMode": "perMachine",
         "template": "./packages/windows/installer.nsi"
       }


### PR DESCRIPTION
Closes #6642 

Add Russian language support to the Windows installer.

The application already includes Russian localization, but the installer currently only supports Chinese and English. This change adds Russian to the NSIS language list in `src-tauri/tauri.windows.conf.json`.

I manually reviewed the installer-related config changes and kept the scope limited to the Windows installer language lists.