### PR TITLE
fix(proxy): avoid reporting requested state when system proxy toggle fails

### DIFF
--- a/src-tauri/src/feat/proxy.rs
+++ b/src-tauri/src/feat/proxy.rs
@@ -9,21 +9,21 @@ use tauri_plugin_clipboard_manager::ClipboardExt as _;
 /// Toggle system proxy on/off
 pub async fn toggle_system_proxy() -> bool {
     let verge = Config::verge().await;
-    let enable = verge.latest_arc().enable_system_proxy.unwrap_or(false);
+    let current = verge.latest_arc().enable_system_proxy.unwrap_or(false);
     let auto_close_connection = verge.latest_arc().auto_close_connection.unwrap_or(false);
 
     // 如果当前系统代理即将关闭，且自动关闭连接设置为true，则关闭所有连接
-    if enable
+    if current
         && auto_close_connection
         && let Err(err) = handle::Handle::mihomo().await.close_all_connections().await
     {
         logging!(error, Type::ProxyMode, "Failed to close all connections: {err}");
     }
 
-    let enable = !enable;
+    let requested = !current;
     let patch_result = super::patch_verge(
         &IVerge {
-            enable_system_proxy: Some(enable),
+            enable_system_proxy: Some(requested),
             ..IVerge::default()
         },
         false,
@@ -31,11 +31,15 @@ pub async fn toggle_system_proxy() -> bool {
     .await;
 
     match patch_result {
-        Ok(_) => handle::Handle::refresh_verge(),
-        Err(err) => logging!(error, Type::ProxyMode, "{err}"),
+        Ok(_) => {
+            handle::Handle::refresh_verge();
+            requested
+        }
+        Err(err) => {
+            logging!(error, Type::ProxyMode, "{err}");
+            current
+        }
     }
-
-    enable
 }
 
 /// Toggle TUN mode on/off


### PR DESCRIPTION
Fixes #6682

## Summary
- avoid reporting the requested system proxy state when apply fails
- return the current state when `patch_verge` fails
