### PR TITLE
fix: 修复 URL 中包含百分号编码凭据时 Basic Auth 鉴权失败的问题

### DIFF
--- a/src-tauri/src/utils/network.rs
+++ b/src-tauri/src/utils/network.rs
@@ -155,7 +155,13 @@ impl NetworkManager {
         if !parsed.username().is_empty()
             && let Some(pass) = parsed.password()
         {
-            let auth_str = format!("{}:{}", parsed.username(), pass);
+            let username = percent_encoding::percent_decode_str(parsed.username())
+                .decode_utf8_lossy()
+                .into_owned();
+            let password = percent_encoding::percent_decode_str(pass)
+                .decode_utf8_lossy()
+                .into_owned();
+            let auth_str = format!("{}:{}", username, password);
             let encoded = general_purpose::STANDARD.encode(auth_str);
             extra_headers.insert("Authorization", HeaderValue::from_str(&format!("Basic {}", encoded))?);
         }


### PR DESCRIPTION
## 问题描述

当订阅 URL 的用户名或密码中包含百分号编码的特殊字符（如 `%40` 代表 `@`）时，添加配置文件会返回 401 Unauthorized 错误。

**复现示例：**
`https://user%40example.com:password@example.com/config.yaml`

## 根本原因

`tauri::Url` 解析 URL 后，再通过 `as_str()` 序列化时会对用户名中的 `%` 重新编码为 `%25`，导致双重编码（如 `%40` → `%2540`）。此时调用 `parsed.username()` 返回的是含字面量 `%40` 的字符串而非真实的 `@` 字符，最终构造出错误的 Basic Auth 凭据，服务器验证失败。

## 修复方案

在构造 Basic Auth 头之前，使用 `percent_encoding::percent_decode_str` 对 `username` 和 `password` 分别进行解码，确保传给服务器的是真实字符串。

同时修复了密码中包含特殊字符时存在的同类问题。