### PR TITLE
Improve TUN proxy DNS defaults and fallback

### DIFF
--- a/src-tauri/src/config/verge.rs
+++ b/src-tauri/src/config/verge.rs
@@ -445,7 +445,7 @@ impl IVerge {
             enable_global_hotkey: Some(true),
             enable_auto_light_weight_mode: Some(false),
             auto_light_weight_minutes: Some(10),
-            enable_dns_settings: Some(false),
+            enable_dns_settings: Some(true),
             home_cards: None,
             enable_external_controller: Some(false),
             ..Self::default()
@@ -573,5 +573,15 @@ impl IVerge {
         } else {
             LevelFilter::Info
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IVerge;
+
+    #[test]
+    fn dns_settings_are_enabled_by_default() {
+        assert_eq!(IVerge::template().enable_dns_settings, Some(true));
     }
 }

--- a/src-tauri/src/enhance/tun.rs
+++ b/src-tauri/src/enhance/tun.rs
@@ -57,6 +57,19 @@ pub fn use_tun(mut config: Mapping, enable: bool) -> Mapping {
                 revise!(dns_val, "fake-ip-range", "198.18.0.1/16");
             }
 
+            let proxy_server_nameserver_key = Value::from("proxy-server-nameserver");
+            let has_proxy_server_nameserver = dns_val
+                .get(&proxy_server_nameserver_key)
+                .and_then(Value::as_sequence)
+                .is_some_and(|servers| !servers.is_empty());
+
+            if !has_proxy_server_nameserver {
+                dns_val.insert(
+                    proxy_server_nameserver_key,
+                    Value::Sequence(vec![Value::String("system".into())]),
+                );
+            }
+
             #[cfg(target_os = "macos")]
             {
                 AsyncHandler::spawn(move || async move {
@@ -81,4 +94,35 @@ pub fn use_tun(mut config: Mapping, enable: bool) -> Mapping {
     revise!(config, "tun", tun_val);
 
     config
+}
+
+#[cfg(test)]
+mod tests {
+    use super::use_tun;
+    use serde_yaml_ng::{Mapping, Value};
+
+    #[test]
+    fn enable_tun_adds_system_proxy_server_nameserver_when_missing() {
+        let mut config = Mapping::new();
+        config.insert(Value::from("ipv6"), Value::Bool(false));
+        config.insert(
+            Value::from("dns"),
+            Value::Mapping(Mapping::from_iter([(
+                Value::from("enhanced-mode"),
+                Value::from("fake-ip"),
+            )])),
+        );
+
+        let updated = use_tun(config, true);
+        let dns = updated
+            .get(Value::from("dns"))
+            .and_then(Value::as_mapping)
+            .expect("dns mapping");
+        let servers = dns
+            .get(Value::from("proxy-server-nameserver"))
+            .and_then(Value::as_sequence)
+            .expect("proxy-server-nameserver sequence");
+
+        assert_eq!(servers, &vec![Value::String("system".into())]);
+    }
 }

--- a/src-tauri/src/utils/init.rs
+++ b/src-tauri/src/utils/init.rs
@@ -178,6 +178,7 @@ async fn init_dns_config() -> Result<()> {
         (
             "proxy-server-nameserver".into(),
             Value::Sequence(vec![
+                Value::String("system".into()),
                 Value::String("https://doh.pub/dns-query".into()),
                 Value::String("https://dns.alidns.com/dns-query".into()),
                 Value::String("tls://223.5.5.5".into()),

--- a/src/components/setting/mods/dns-viewer.tsx
+++ b/src/components/setting/mods/dns-viewer.tsx
@@ -167,6 +167,7 @@ const DEFAULT_DNS_CONFIG = {
   fallback: [],
   'nameserver-policy': {},
   'proxy-server-nameserver': [
+    'system',
     'https://doh.pub/dns-query',
     'https://dns.alidns.com/dns-query',
     'tls://223.5.5.5',


### PR DESCRIPTION
## Summary
- enable DNS overwrite by default in new Verge configs so `dns_config.yaml` is merged without requiring a manual toggle
- add `system` to the default `dns.proxy-server-nameserver` list in generated config and the DNS settings UI
- when TUN is enabled and `proxy-server-nameserver` is missing, inject `['system']` as a safe fallback
- add unit tests for the new defaults and TUN fallback behavior

## Why
A real macOS TUN failure mode here was not the utun device itself, but proxy hostname resolution after TUN was enabled.

Two things had to line up for users to recover:
- `enable_dns_settings` had to be turned on, otherwise `dns_config.yaml` was generated but never merged into runtime config
- `dns.proxy-server-nameserver` needed a resolver that still works in this scenario; using `system` fixes cases where the default public DoH/TLS list cannot resolve the proxy server hostname once TUN takes over

This PR reduces the need for manual YAML edits by fixing both the default path and the runtime fallback path.

## Scope
Files changed:
- `src-tauri/src/config/verge.rs`
- `src-tauri/src/utils/init.rs`
- `src/components/setting/mods/dns-viewer.tsx`
- `src-tauri/src/enhance/tun.rs`

Related user report / reproduction context:
- discussion: https://github.com/clash-verge-rev/clash-verge-rev/discussions/6089

## Validation
- `rustup run 1.93.0-aarch64-apple-darwin cargo fmt --all --check`
- `rustup run 1.93.0-aarch64-apple-darwin cargo test --manifest-path src-tauri/Cargo.toml enable_tun_adds_system_proxy_server_nameserver_when_missing --quiet`
  - fails locally before test execution because the Tauri build script expects the sidecar resource `sidecar/verge-mihomo-aarch64-apple-darwin`, which is not present in this checkout
