### PR TITLE
fix: fallback to default icon when custom tray icon format is unsupported

### DIFF
--- a/src-tauri/src/core/tray/mod.rs
+++ b/src-tauri/src/core/tray/mod.rs
@@ -238,12 +238,30 @@ impl Tray {
             return Ok(());
         };
 
-        let (_is_custom_icon, icon_bytes) = TrayState::get_tray_icon(verge).await;
+        let (is_custom_icon, icon_bytes) = TrayState::get_tray_icon(verge).await;
 
-        logging_error!(
-            Type::Tray,
-            tray.set_icon(Some(tauri::image::Image::from_bytes(&icon_bytes)?))
-        );
+        let icon = match tauri::image::Image::from_bytes(&icon_bytes) {
+            Ok(img) => img,
+            Err(e) if is_custom_icon => {
+                logging!(
+                    warn,
+                    Type::Tray,
+                    "Failed to load custom tray icon: {e}, falling back to default"
+                );
+                let kind = if verge.enable_tun_mode.unwrap_or(false) {
+                    IconKind::Tun
+                } else if verge.enable_system_proxy.unwrap_or(false) {
+                    IconKind::SysProxy
+                } else {
+                    IconKind::Common
+                };
+                let (_, default_bytes) = TrayState::default_icon(verge, kind);
+                tauri::image::Image::from_bytes(&default_bytes)?
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        logging_error!(Type::Tray, tray.set_icon(Some(icon)));
 
         #[cfg(target_os = "macos")]
         {
@@ -345,8 +363,27 @@ impl Tray {
 
         let verge = Config::verge().await.data_arc();
 
-        let icon_bytes = TrayState::get_tray_icon(&verge).await.1;
-        let icon = tauri::image::Image::from_bytes(&icon_bytes)?;
+        let (is_custom_icon, icon_bytes) = TrayState::get_tray_icon(&verge).await;
+        let icon = match tauri::image::Image::from_bytes(&icon_bytes) {
+            Ok(img) => img,
+            Err(e) if is_custom_icon => {
+                logging!(
+                    warn,
+                    Type::Tray,
+                    "Failed to load custom tray icon: {e}, falling back to default"
+                );
+                let kind = if verge.enable_tun_mode.unwrap_or(false) {
+                    IconKind::Tun
+                } else if verge.enable_system_proxy.unwrap_or(false) {
+                    IconKind::SysProxy
+                } else {
+                    IconKind::Common
+                };
+                let (_, default_bytes) = TrayState::default_icon(&verge, kind);
+                tauri::image::Image::from_bytes(&default_bytes)?
+            }
+            Err(e) => return Err(e.into()),
+        };
 
         #[cfg(target_os = "linux")]
         let builder = TrayIconBuilder::with_id("main").icon(icon).icon_as_template(false);


### PR DESCRIPTION
## Summary

- When a custom tray icon uses an unsupported image format (e.g. GIF renamed to `.png`), `Image::from_bytes()` fails and the error propagates up, causing the entire tray to disappear
- This is especially problematic in silent startup mode where no UI is displayed, leaving the user with no way to interact with the app
- Now catches the decode error for custom icons and gracefully falls back to the built-in default icon with a warning log

Closes #4620

## Changes

- `update_icon()`: wrap `Image::from_bytes()` in a match — if it fails for a custom icon, log a warning and load the corresponding default icon instead
- `create_tray_from_handle()`: same fallback logic for the initial tray creation path

## Test plan

- [ ] Set a valid `.png` / `.ico` file as custom tray icon → icon displays normally
- [ ] Set an unsupported format file (e.g. GIF renamed to `.png`) as custom tray icon → default icon displays, warning logged
- [ ] Silent startup with broken custom icon → tray icon still appears, app remains functional
- [ ] Verify no regression when no custom icon is configured