### PR TITLE
fix(tray): use an app-specific tray id

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - 修复订阅 TLS 1.0/1.1 等过旧协议时显示更明确错误原因
 - 修复 gzip 压缩订阅响应被当作无效 YAML 导致导入失败的问题
 - 修复订阅 URL 使用空密码 Basic Auth 时未发送认证信息的问题
+- Linux 托盘可能与其他 tauri 程序托盘冲突导致图标异常
 
 <details>
 <summary><strong> ✨ 新增功能 </strong></summary>

--- a/src-tauri/src/core/tray/mod.rs
+++ b/src-tauri/src/core/tray/mod.rs
@@ -39,6 +39,7 @@ use menu_def::{MenuIds, MenuTexts};
 type ProxyMenuItem = (Option<Submenu<Wry>>, Vec<Box<dyn IsMenuItem<Wry>>>);
 
 const TRAY_CLICK_DEBOUNCE_MS: u64 = 300;
+pub const TRAY_ID: &str = "clash-verge-rev-tray";
 
 #[derive(Clone)]
 struct TrayState {}
@@ -169,7 +170,7 @@ impl Tray {
         let tray_event = { Config::verge().await.latest_arc().tray_event.clone() };
         let tray_event = TrayAction::from(tray_event.as_deref().unwrap_or("main_window"));
         let tray = app_handle
-            .tray_by_id("main")
+            .tray_by_id(TRAY_ID)
             .ok_or_else(|| anyhow::anyhow!("Failed to get main tray"))?;
         match tray_event {
             TrayAction::TrayMenu => tray.set_show_menu_on_left_click(true)?,
@@ -189,7 +190,7 @@ impl Tray {
     }
 
     async fn update_menu_internal(&self, app_handle: &AppHandle) -> Result<()> {
-        let Some(tray) = app_handle.tray_by_id("main") else {
+        let Some(tray) = app_handle.tray_by_id(TRAY_ID) else {
             logging!(warn, Type::Tray, "Failed to update tray menu: tray not found");
             return Ok(());
         };
@@ -243,7 +244,7 @@ impl Tray {
 
         let app_handle = handle::Handle::app_handle();
 
-        let Some(tray) = app_handle.tray_by_id("main") else {
+        let Some(tray) = app_handle.tray_by_id(TRAY_ID) else {
             logging!(warn, Type::Tray, "Failed to update tray icon: tray not found");
             return Ok(());
         };
@@ -317,7 +318,7 @@ impl Tray {
             current_profile_name
         );
 
-        let Some(tray) = app_handle.tray_by_id("main") else {
+        let Some(tray) = app_handle.tray_by_id(TRAY_ID) else {
             logging!(warn, Type::Tray, "Failed to update tray tooltip: tray not found");
             return Ok(());
         };
@@ -361,13 +362,13 @@ impl Tray {
         let icon = tauri::image::Image::from_bytes(&icon_bytes)?;
 
         #[cfg(target_os = "linux")]
-        let builder = TrayIconBuilder::with_id("main").icon(icon).icon_as_template(false);
+        let builder = TrayIconBuilder::with_id(TRAY_ID).icon(icon).icon_as_template(false);
 
         #[cfg(any(target_os = "macos", target_os = "windows"))]
         let show_menu_on_left_click = verge.tray_event.as_ref().is_some_and(|v| v == "tray_menu");
 
         #[cfg(not(target_os = "linux"))]
-        let mut builder = TrayIconBuilder::with_id("main").icon(icon).icon_as_template(false);
+        let mut builder = TrayIconBuilder::with_id(TRAY_ID).icon(icon).icon_as_template(false);
         #[cfg(target_os = "macos")]
         {
             let is_monochrome = verge.tray_icon.as_ref().is_none_or(|v| v == "monochrome");

--- a/src-tauri/src/core/tray/speed_task.rs
+++ b/src-tauri/src/core/tray/speed_task.rs
@@ -145,7 +145,7 @@ impl TraySpeedController {
         });
 
         let app_handle = handle::Handle::app_handle();
-        if let Some(tray) = app_handle.tray_by_id("main") {
+        if let Some(tray) = app_handle.tray_by_id(super::TRAY_ID) {
             let result = tray.with_inner_tray_icon(|inner| {
                 if let Some(status_item) = inner.ns_status_item() {
                     tray_speed::clear_speed_attributed_title(&status_item);
@@ -158,7 +158,7 @@ impl TraySpeedController {
     }
 
     fn has_main_tray() -> bool {
-        handle::Handle::app_handle().tray_by_id("main").is_some()
+        handle::Handle::app_handle().tray_by_id(super::TRAY_ID).is_some()
     }
 
     fn set_speed_connection_id(
@@ -180,7 +180,7 @@ impl TraySpeedController {
 
     fn apply_tray_speed(up: u64, down: u64) {
         let app_handle = handle::Handle::app_handle();
-        if let Some(tray) = app_handle.tray_by_id("main") {
+        if let Some(tray) = app_handle.tray_by_id(super::TRAY_ID) {
             let result = tray.with_inner_tray_icon(move |inner| {
                 if let Some(status_item) = inner.ns_status_item() {
                     tray_speed::set_speed_attributed_title(&status_item, up, down);


### PR DESCRIPTION
## Summary
- replace the shared tray id `"main"` with the app-specific id `"clash-verge"`
- update internal `tray_by_id(...)` lookups to use the same constant
- add a small unit test that guards against regressing back to `"main"`

## Why
On Linux, `tray-icon` derives both the AppIndicator identifier and the temporary PNG filename from the tray id. Using a generic id like `"main"` makes `clash-verge-rev` collide with other Tauri apps that do the same thing.

A concrete reproducer is `cc-switch`, which also uses `with_id("main")`:
- `cc-switch` starts first and exposes `/run/user/$UID/tray-icon/tray-icon-main-0.png`
- starting `clash-verge-rev` creates the same `tray-icon-main-0.png`
- when `clash-verge-rev` updates its tray icon, `tray-icon` deletes the previously active `tray-icon-main-0.png` and moves on to `tray-icon-main-1.png` / `tray-icon-main-3.png`
- GNOME AppIndicator then refreshes `cc-switch` against a stale path and the icon disappears or falls back to a broken placeholder

Using an app-specific tray id avoids the collision entirely.

Closes #6771.

## Verification
- `cargo test --lib --features clippy tray_id_is_unique_to_app --manifest-path src-tauri/Cargo.toml`

Note: the plain `cargo test` path in this checkout currently needs the Linux sidecar resources present, so I used the existing `clippy` feature gate in `build.rs` to skip `tauri_build` for this focused unit test.