### PR TITLE
fix(profile): handle lazily-created chain files and include path in read errors

### DIFF
--- a/src-tauri/src/cmd/profile.rs
+++ b/src-tauri/src/cmd/profile.rs
@@ -466,6 +466,19 @@ pub async fn read_profile_file(index: String) -> CmdResult<String> {
             ..Default::default()
         }
     };
+
+    // Chain profile files (rules/proxies/groups/merge/script) are lazily
+    // materialized: registered in profiles.yaml on subscription import but
+    // only written to disk on first edit. Return an empty document when the
+    // file is missing so the editor opens cleanly instead of surfacing
+    // "failed to read the file" to the user.
+    if let Some(file) = item.file.as_ref() {
+        let path = dirs::app_profiles_dir().stringify_err()?.join(file.as_str());
+        if !tokio::fs::try_exists(&path).await.unwrap_or(false) {
+            return Ok(String::new());
+        }
+    }
+
     let data = item.read_file().await.stringify_err()?;
     Ok(data)
 }

--- a/src-tauri/src/cmd/save_profile.rs
+++ b/src-tauri/src/cmd/save_profile.rs
@@ -34,18 +34,26 @@ pub async fn save_profile_file(index: String, file_data: Option<String>) -> CmdR
         (path, is_merge)
     };
 
-    // 读取原始内容（在释放profiles_guard后进行）
-    let original_content = PrfItem {
-        file: Some(rel_path.clone()),
-        ..Default::default()
-    }
-    .read_file()
-    .await
-    .stringify_err()?;
-
     let profiles_dir = dirs::app_profiles_dir().stringify_err()?;
     let file_path = profiles_dir.join(rel_path.as_str());
     let file_path_str = file_path.to_string_lossy().to_string();
+
+    // Read the original content to enable rollback if validation fails.
+    // Chain profile files (rules/proxies/groups/merge/script) are lazily
+    // created: they are registered in profiles.yaml but only materialized on
+    // disk the first time the user edits them. Treat a missing file as empty
+    // original content instead of surfacing a confusing read error.
+    let original_content = if fs::try_exists(&file_path).await.unwrap_or(false) {
+        PrfItem {
+            file: Some(rel_path.clone()),
+            ..Default::default()
+        }
+        .read_file()
+        .await
+        .stringify_err()?
+    } else {
+        String::new()
+    };
 
     // 保存新的配置文件
     fs::write(&file_path, &file_data).await.stringify_err()?;

--- a/src-tauri/src/config/prfitem.rs
+++ b/src-tauri/src/config/prfitem.rs
@@ -533,8 +533,7 @@ impl PrfItem {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("could not find the file"))?;
         let path = dirs::app_profiles_dir()?.join(file.as_str());
-        let content = fs::read_to_string(path).await.context("failed to read the file")?;
-        Ok(content.into())
+        read_file_from_path(&path).await
     }
 
     /// save the file data
@@ -610,4 +609,46 @@ fn fix_dirty_url(input: &str) -> Result<Url> {
     }
 
     Ok(url)
+}
+
+/// Read a profile file at an absolute path, returning the content as a string.
+/// On failure, the error context includes the path so users and logs can pinpoint
+/// the missing or unreadable file rather than seeing a bare "failed to read the file".
+async fn read_file_from_path(path: &std::path::Path) -> Result<String> {
+    let content = fs::read_to_string(path)
+        .await
+        .with_context(|| format!("failed to read the file \"{}\"", path.display()))?;
+    Ok(content.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    #[allow(clippy::expect_used)]
+    async fn read_file_from_path_error_contains_path() {
+        let missing = std::env::temp_dir().join("clash-verge-rev-nonexistent-8f3a2c91.yaml");
+        let _ = fs::remove_file(&missing).await;
+        let err = read_file_from_path(&missing)
+            .await
+            .expect_err("reading a missing file should fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(&missing.display().to_string()),
+            "error message should include the file path, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::unwrap_used)]
+    #[allow(clippy::expect_used)]
+    async fn read_file_from_path_returns_content() {
+        let path = std::env::temp_dir().join("clash-verge-rev-read-test-9d1e.yaml");
+        fs::write(&path, "hello: world\n").await.unwrap();
+        let content = read_file_from_path(&path).await.unwrap();
+        assert_eq!(content.as_str(), "hello: world\n");
+        let _ = fs::remove_file(&path).await;
+    }
 }


### PR DESCRIPTION
## 遇到的问题

Fixes #6428

新导入订阅后想给某个域名加条自定义规则（下图场景：`DOMAIN-KEYWORD,xiaohongshu,DIRECT`），点进"编辑规则"直接弹 `failed to read the file`：

![failed-to-read-the-file](https://github.com/zhijun42/clash-verge-rev/releases/download/pr-6846-assets/failed-to-read-file-rules-editor.png)

错误消息既不说是哪个文件，也没提示怎么恢复。在 #6428 里 maintainer 的回复是"删除配置目录"，reporter 后来自己发现是 `Script.js` 没落盘，手动重建文件才绕过。同类问题更早在 pre-release 2.4.4 也被报过一次 (#5649)。这条 PR 补上根因修复，同时把路径信息写进错误消息以便未来其它场景排障。

## 根因

Chain profile 文件（rules / proxies / groups / merge / script）在订阅导入时会被登记到 `profiles.yaml`，但**本体文件要到用户第一次手动保存才会落盘**。在此之前：

- `cmd::profile::read_profile_file`（打开编辑器）会对不存在的路径调 `fs::read_to_string`
- `cmd::save_profile::save_profile_file`（保存新内容时会先读一份 "original" 以便校验失败回滚）同样触发

于是都抛出 `failed to read the file`，且没有路径线索。

## 修复

- `cmd::profile::read_profile_file`：读之前先 `tokio::fs::try_exists`。文件不存在时直接返回空串，编辑器打开一份空白模板让用户写，和"第一次编辑"的语义一致。
- `cmd::save_profile::save_profile_file`：同样处理 —— `original_content` 在文件不存在时退化为空串，rollback-on-validation-failure 的语义保持一致。
- `config::prfitem`：把 `PrfItem::read_file` 里读文件的那行抽成 `read_file_from_path` helper，用 `anyhow::with_context` 把**完整路径**带进错误链。未来因权限、I/O、符号链接断裂等其它原因读失败时，错误信息能直接指出是哪个文件，不用用户盲猜。

## 测试

新增两个 `#[tokio::test]`：

- `read_file_from_path_error_contains_path`：构造一个不存在的路径调 helper，断言错误消息 `contains(path.display())`。机械性守护"错误里必须带路径"这条不变量，任何回滚都会被测试挡住。
- `read_file_from_path_returns_content`：写入临时文件后读出比对，守护 happy path。