### PR TITLE
fix: node selection for remembered profiles during switch

### DIFF
--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -526,7 +526,6 @@ const ProfilePage = () => {
       profiles,
       patchProfiles,
       mutateLogs,
-      // executeBackgroundTasks,
       handleProfileInterrupt,
       cleanupSwitchState,
     ],

--- a/src/pages/profiles.tsx
+++ b/src/pages/profiles.tsx
@@ -37,7 +37,10 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router'
-import { closeAllConnections } from 'tauri-plugin-mihomo-api'
+import {
+  closeAllConnections,
+  selectNodeForGroup,
+} from 'tauri-plugin-mihomo-api'
 
 import { BasePage, BaseStyledTextField, DialogRef } from '@/components/base'
 import { ProfileItem } from '@/components/profile/profile-item'
@@ -50,6 +53,7 @@ import { ConfigViewer } from '@/components/setting/mods/config-viewer'
 import { useListen } from '@/hooks/use-listen'
 import { useProfiles } from '@/hooks/use-profiles'
 import {
+  calcuProxies,
   createProfile,
   deleteProfile,
   enhanceProfiles,
@@ -178,7 +182,6 @@ const ProfilePage = () => {
 
   const {
     profiles = {},
-    activateSelected,
     patchProfiles,
     mutateProfiles,
     error,
@@ -389,34 +392,6 @@ const ProfilePage = () => {
     }
   }
 
-  const executeBackgroundTasks = useCallback(
-    async (
-      profile: string,
-      sequence: number,
-      abortController: AbortController,
-    ) => {
-      try {
-        if (
-          sequence === requestSequenceRef.current &&
-          switchingProfileRef.current === profile &&
-          !abortController.signal.aborted
-        ) {
-          await activateSelected(profiles)
-          debugLog(`[Profile] 后台处理完成，序列号: ${sequence}`)
-        } else {
-          debugProfileSwitch(
-            'BACKGROUND_TASK_SKIPPED',
-            profile,
-            `序列号过期或被中断: ${sequence} vs ${requestSequenceRef.current}`,
-          )
-        }
-      } catch (err: any) {
-        console.warn('Failed to activate selected proxies:', err)
-      }
-    },
-    [activateSelected, profiles],
-  )
-
   const activateProfile = useCallback(
     async (profile: string, notifySuccess: boolean) => {
       if (profiles.current === profile && !notifySuccess) {
@@ -486,6 +461,22 @@ const ProfilePage = () => {
           return
         }
 
+        // 选择所记忆的节点
+        const current = profiles.items?.find((e) => e.uid === profile)
+        for (const item of current?.selected ?? []) {
+          if (item.name && item.now) {
+            try {
+              await selectNodeForGroup(item.name, item.now)
+            } catch (err) {
+              debugLog(
+                `[Profile] 选择节点失败: ${item.name} -> ${item.now}`,
+                err,
+              )
+            }
+          }
+        }
+        queryClient.setQueryData(['getProxies'], await calcuProxies())
+
         // 完成切换
         await mutateLogs()
         closeAllConnections()
@@ -499,17 +490,6 @@ const ProfilePage = () => {
 
         debugLog(
           `[Profile] 切换到 ${profile} 完成，序列号: ${currentSequence}，开始后台处理`,
-        )
-
-        // 延迟执行后台任务
-        setTimeout(
-          () =>
-            executeBackgroundTasks(
-              profile,
-              currentSequence,
-              currentAbortController,
-            ),
-          50,
         )
       } catch (err: any) {
         if (pendingRequestRef.current) {
@@ -546,7 +526,7 @@ const ProfilePage = () => {
       profiles,
       patchProfiles,
       mutateLogs,
-      executeBackgroundTasks,
+      // executeBackgroundTasks,
       handleProfileInterrupt,
       cleanupSwitchState,
     ],


### PR DESCRIPTION
在使用类似如下配置时
```
profile:
  store-selected: true

proxy-groups:
  - name: PROXY
    type: select
    include-all: true

rules:
  - "MATCH,DIRECT"
``` 
从订阅A切换到订阅B,然后给代理组换一个节点,再切换回到订阅A,此时代理组选择的将会是第一个节点
预期的状态是选择切换前订阅A所选择的节点

#6836

通过在切换订阅后,设置每个代理组所选择节点,能够解决以上问题