### PR TITLE
Port display not updating after change & eliminate hardcoded port magic numbers

### DIFF
--- a/src-tauri/src/config/clash.rs
+++ b/src-tauri/src/config/clash.rs
@@ -188,9 +188,9 @@ impl IClashTemp {
                 Value::Number(val_num) => val_num.as_u64().map(|u| u as u16),
                 _ => None,
             })
-            .unwrap_or(7895);
+            .unwrap_or(network::ports::DEFAULT_REDIR);
         if port == 0 {
-            port = 7895;
+            port = network::ports::DEFAULT_REDIR;
         }
         port
     }
@@ -220,10 +220,10 @@ impl IClashTemp {
                 Value::Number(val_num) => val_num.as_u64().map(|u| u as u16),
                 _ => None,
             })
-            .unwrap_or(7897);
+            .unwrap_or(network::ports::DEFAULT_MIXED);
 
         if port == 0 {
-            port = 7897;
+            port = network::ports::DEFAULT_MIXED;
         }
 
         port
@@ -237,9 +237,9 @@ impl IClashTemp {
                 Value::Number(val_num) => val_num.as_u64().map(|u| u as u16),
                 _ => None,
             })
-            .unwrap_or(7898);
+            .unwrap_or(network::ports::DEFAULT_SOCKS);
         if port == 0 {
-            port = 7898;
+            port = network::ports::DEFAULT_SOCKS;
         }
         port
     }
@@ -252,9 +252,9 @@ impl IClashTemp {
                 Value::Number(val_num) => val_num.as_u64().map(|u| u as u16),
                 _ => None,
             })
-            .unwrap_or(7899);
+            .unwrap_or(network::ports::DEFAULT_HTTP);
         if port == 0 {
-            port = 7899;
+            port = network::ports::DEFAULT_HTTP;
         }
         port
     }

--- a/src-tauri/src/config/verge.rs
+++ b/src-tauri/src/config/verge.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::constants::network::ports;
 use crate::{
     config::{DEFAULT_PAC, deserialize_encrypted, serialize_encrypted},
     utils::{dirs, help},
@@ -412,17 +413,17 @@ impl IVerge {
             pac_file_content: Some(DEFAULT_PAC.into()),
             proxy_host: Some("127.0.0.1".into()),
             #[cfg(not(target_os = "windows"))]
-            verge_redir_port: Some(7895),
+            verge_redir_port: Some(ports::DEFAULT_REDIR),
             #[cfg(not(target_os = "windows"))]
             verge_redir_enabled: Some(false),
             #[cfg(target_os = "linux")]
-            verge_tproxy_port: Some(7896),
+            verge_tproxy_port: Some(ports::DEFAULT_TPROXY),
             #[cfg(target_os = "linux")]
             verge_tproxy_enabled: Some(false),
-            verge_mixed_port: Some(7897),
-            verge_socks_port: Some(7898),
+            verge_mixed_port: Some(ports::DEFAULT_MIXED),
+            verge_socks_port: Some(ports::DEFAULT_SOCKS),
             verge_socks_enabled: Some(false),
-            verge_port: Some(7899),
+            verge_port: Some(ports::DEFAULT_HTTP),
             verge_http_enabled: Some(false),
             enable_proxy_guard: Some(false),
             enable_bypass_check: Some(true),

--- a/src-tauri/src/feat/config.rs
+++ b/src-tauri/src/feat/config.rs
@@ -204,6 +204,7 @@ async fn process_terminated_flags(update_flags: UpdateFlags, patch: &IVerge) -> 
     if update_flags.contains(UpdateFlags::RESTART_CORE) {
         Config::generate().await?;
         CoreManager::global().restart_core().await?;
+        handle::Handle::refresh_verge();
     }
     if update_flags.contains(UpdateFlags::CLASH_CONFIG) {
         CoreManager::global().update_config().await?;

--- a/src-tauri/src/feat/proxy.rs
+++ b/src-tauri/src/feat/proxy.rs
@@ -77,7 +77,10 @@ pub async fn copy_clash_env() {
         .unwrap_or_else(|| verge_cfg.proxy_host.as_deref().unwrap_or("127.0.0.1"));
 
     let app_handle = handle::Handle::app_handle();
-    let port = verge_cfg.verge_mixed_port.unwrap_or(7897);
+    let port = match verge_cfg.verge_mixed_port {
+        Some(port) => port,
+        None => Config::clash().await.latest_arc().get_mixed_port(),
+    };
     let http_proxy = format!("http://{ip}:{port}");
     let socks5_proxy = format!("socks5://{ip}:{port}");
 

--- a/src/components/setting/mods/clash-port-viewer.tsx
+++ b/src/components/setting/mods/clash-port-viewer.tsx
@@ -18,6 +18,7 @@ import { useVerge } from '@/hooks/use-verge'
 import { isPortInUse } from '@/services/cmds'
 import { showNotice } from '@/services/notice-service'
 import getSystem from '@/utils/get-system'
+import { DEFAULT_PORTS } from '@/utils/ports'
 
 const OS = getSystem()
 
@@ -37,23 +38,31 @@ export const ClashPortViewer = forwardRef<ClashPortViewerRef>((_, ref) => {
 
   // Mixed Port
   const [mixedPort, setMixedPort] = useState(
-    verge?.verge_mixed_port ?? clashInfo?.mixed_port ?? 7897,
+    verge?.verge_mixed_port ?? clashInfo?.mixed_port ?? DEFAULT_PORTS.MIXED,
   )
 
   // 其他端口状态
-  const [socksPort, setSocksPort] = useState(verge?.verge_socks_port ?? 7898)
+  const [socksPort, setSocksPort] = useState(
+    verge?.verge_socks_port ?? DEFAULT_PORTS.SOCKS,
+  )
   const [socksEnabled, setSocksEnabled] = useState(
     verge?.verge_socks_enabled ?? false,
   )
-  const [httpPort, setHttpPort] = useState(verge?.verge_port ?? 7899)
+  const [httpPort, setHttpPort] = useState(
+    verge?.verge_port ?? DEFAULT_PORTS.HTTP,
+  )
   const [httpEnabled, setHttpEnabled] = useState(
     verge?.verge_http_enabled ?? false,
   )
-  const [redirPort, setRedirPort] = useState(verge?.verge_redir_port ?? 7895)
+  const [redirPort, setRedirPort] = useState(
+    verge?.verge_redir_port ?? DEFAULT_PORTS.REDIR,
+  )
   const [redirEnabled, setRedirEnabled] = useState(
     verge?.verge_redir_enabled ?? false,
   )
-  const [tproxyPort, setTproxyPort] = useState(verge?.verge_tproxy_port ?? 7896)
+  const [tproxyPort, setTproxyPort] = useState(
+    verge?.verge_tproxy_port ?? DEFAULT_PORTS.TPROXY,
+  )
   const [tproxyEnabled, setTproxyEnabled] = useState(
     verge?.verge_tproxy_enabled ?? false,
   )
@@ -65,7 +74,8 @@ export const ClashPortViewer = forwardRef<ClashPortViewerRef>((_, ref) => {
   const { loading, run: saveSettings } = useRequest(
     async (params: { clashConfig: any; vergeConfig: any }) => {
       const { clashConfig, vergeConfig } = params
-      await Promise.all([patchInfo(clashConfig), patchVerge(vergeConfig)])
+      await patchVerge(vergeConfig)
+      await patchInfo(clashConfig)
     },
     {
       manual: true,
@@ -82,14 +92,17 @@ export const ClashPortViewer = forwardRef<ClashPortViewerRef>((_, ref) => {
   useImperativeHandle(ref, () => ({
     open: () => {
       originalPortsRef.current = {
-        mixedPort: verge?.verge_mixed_port ?? clashInfo?.mixed_port ?? 7897,
-        socksPort: verge?.verge_socks_port ?? 7898,
+        mixedPort:
+          verge?.verge_mixed_port ??
+          clashInfo?.mixed_port ??
+          DEFAULT_PORTS.MIXED,
+        socksPort: verge?.verge_socks_port ?? DEFAULT_PORTS.SOCKS,
         socksEnabled: verge?.verge_socks_enabled ?? false,
-        httpPort: verge?.verge_port ?? 7899,
+        httpPort: verge?.verge_port ?? DEFAULT_PORTS.HTTP,
         httpEnabled: verge?.verge_http_enabled ?? false,
-        redirPort: verge?.verge_redir_port ?? 7895,
+        redirPort: verge?.verge_redir_port ?? DEFAULT_PORTS.REDIR,
         redirEnabled: verge?.verge_redir_enabled ?? false,
-        tproxyPort: verge?.verge_tproxy_port ?? 7896,
+        tproxyPort: verge?.verge_tproxy_port ?? DEFAULT_PORTS.TPROXY,
         tproxyEnabled: verge?.verge_tproxy_enabled ?? false,
       }
 
@@ -168,15 +181,17 @@ export const ClashPortViewer = forwardRef<ClashPortViewerRef>((_, ref) => {
             setTproxyEnabled(original.tproxyEnabled)
           } else {
             setMixedPort(
-              verge?.verge_mixed_port ?? clashInfo?.mixed_port ?? 7897,
+              verge?.verge_mixed_port ??
+                clashInfo?.mixed_port ??
+                DEFAULT_PORTS.MIXED,
             )
-            setSocksPort(verge?.verge_socks_port ?? 7898)
+            setSocksPort(verge?.verge_socks_port ?? DEFAULT_PORTS.SOCKS)
             setSocksEnabled(verge?.verge_socks_enabled ?? false)
-            setHttpPort(verge?.verge_port ?? 7899)
+            setHttpPort(verge?.verge_port ?? DEFAULT_PORTS.HTTP)
             setHttpEnabled(verge?.verge_http_enabled ?? false)
-            setRedirPort(verge?.verge_redir_port ?? 7895)
+            setRedirPort(verge?.verge_redir_port ?? DEFAULT_PORTS.REDIR)
             setRedirEnabled(verge?.verge_redir_enabled ?? false)
-            setTproxyPort(verge?.verge_tproxy_port ?? 7896)
+            setTproxyPort(verge?.verge_tproxy_port ?? DEFAULT_PORTS.TPROXY)
             setTproxyEnabled(verge?.verge_tproxy_enabled ?? false)
           }
           return

--- a/src/components/setting/mods/sysproxy-viewer.tsx
+++ b/src/components/setting/mods/sysproxy-viewer.tsx
@@ -45,6 +45,7 @@ import {
 import { showNotice } from '@/services/notice-service'
 import { debugLog } from '@/utils/debug'
 import getSystem from '@/utils/get-system'
+import { DEFAULT_PORTS } from '@/utils/ports'
 
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => {
@@ -189,7 +190,8 @@ export const SysproxyViewer = forwardRef<DialogRef>((props, ref) => {
 
     if (isPacMode) {
       const host = value.proxy_host || '127.0.0.1'
-      const port = verge?.verge_mixed_port || clashConfig.mixedPort || 7897
+      const port =
+        verge?.verge_mixed_port || clashConfig.mixedPort || DEFAULT_PORTS.MIXED
       return `${host}:${port}`
     } else {
       return systemProxyAddress

--- a/src/components/setting/setting-clash.tsx
+++ b/src/components/setting/setting-clash.tsx
@@ -13,6 +13,7 @@ import { useVerge } from '@/hooks/use-verge'
 import { invoke_uwp_tool } from '@/services/cmds'
 import { showNotice } from '@/services/notice-service'
 import getSystem from '@/utils/get-system'
+import { DEFAULT_PORTS } from '@/utils/ports'
 
 import { ClashCoreViewer } from './mods/clash-core-viewer'
 import { ClashPortViewer } from './mods/clash-port-viewer'
@@ -220,7 +221,7 @@ const SettingClash = ({ onError }: Props) => {
           autoComplete="new-password"
           disabled={false}
           size="small"
-          value={verge_mixed_port ?? 7897}
+          value={verge_mixed_port ?? DEFAULT_PORTS.MIXED}
           sx={{ width: 100, input: { py: '7.5px', cursor: 'pointer' } }}
           onClick={(e) => {
             portRef.current?.open()

--- a/src/hooks/use-system-proxy-state.ts
+++ b/src/hooks/use-system-proxy-state.ts
@@ -6,6 +6,7 @@ import { useVerge } from '@/hooks/use-verge'
 import { useAppData } from '@/providers/app-data-context'
 import { getAutotemProxy } from '@/services/cmds'
 import { queryClient } from '@/services/query-client'
+import { DEFAULT_PORTS } from '@/utils/ports'
 
 // 系统代理状态检测统一逻辑
 export const useSystemProxyState = () => {
@@ -34,7 +35,8 @@ export const useSystemProxyState = () => {
       return autoproxy.url === `http://${host}:${pacPort}/commands/pac`
     } else {
       if (!sysproxy?.enable) return false
-      const port = verge_mixed_port || clashConfig?.mixedPort || 7897
+      const port =
+        verge_mixed_port || clashConfig?.mixedPort || DEFAULT_PORTS.MIXED
       return sysproxy.server === `${host}:${port}`
     }
   })()

--- a/src/providers/app-data-provider.tsx
+++ b/src/providers/app-data-provider.tsx
@@ -15,6 +15,7 @@ import {
   getRunningMode,
   getSystemProxy,
 } from '@/services/cmds'
+import { DEFAULT_PORTS } from '@/utils/ports'
 
 import {
   ClashConfigContext,
@@ -235,7 +236,7 @@ export const AppDataProvider = ({
         // PAC模式：显示我们期望设置的代理地址
         const proxyHost = verge.proxy_host || '127.0.0.1'
         const proxyPort =
-          verge.verge_mixed_port || clashConfig.mixedPort || 7897
+          verge.verge_mixed_port || clashConfig.mixedPort || DEFAULT_PORTS.MIXED
         return `${proxyHost}:${proxyPort}`
       } else {
         // HTTP代理模式：优先使用系统地址，但如果格式不正确则使用期望地址
@@ -250,7 +251,9 @@ export const AppDataProvider = ({
           // 系统地址无效，返回期望的代理地址
           const proxyHost = verge.proxy_host || '127.0.0.1'
           const proxyPort =
-            verge.verge_mixed_port || clashConfig.mixedPort || 7897
+            verge.verge_mixed_port ||
+            clashConfig.mixedPort ||
+            DEFAULT_PORTS.MIXED
           return `${proxyHost}:${proxyPort}`
         }
       }

--- a/src/utils/ports.ts
+++ b/src/utils/ports.ts
@@ -1,0 +1,10 @@
+/**
+ * Default port constants - must match Rust constants in src-tauri/src/constants.rs
+ */
+export const DEFAULT_PORTS = {
+  REDIR: 7895,
+  TPROXY: 7896,
+  MIXED: 7897,
+  SOCKS: 7898,
+  HTTP: 7899,
+} as const


### PR DESCRIPTION
## Fix: Port display not updating after change & eliminate hardcoded port magic numbers

### Problem

After changing the mixed-port from 7897 to another value (e.g. 7890) in the port config dialog, the proxy port actually takes effect, but the frontend settings page still displays the old value 7897.

### Root Cause

`clash-port-viewer.tsx` used `Promise.all` to call `patchClashConfig` and `patchVergeConfig` concurrently. Both requests trigger `restart_core` on the backend, creating a race condition:

1. `patchVerge` sets `verge_mixed_port = 7890` and enters `process_terminated_flags`
2. Concurrently, `patchClashConfig` also executes `update_config` / `restart_core`
3. The two `restart_core` calls contend on the `CoreManager` singleton; `patchVerge`'s `restart_core` may fail
4. On failure, `discard()` rolls back `verge_mixed_port` to 7897
5. But `patchClashConfig` successfully set `mixed-port = 7890`, so the core actually listens on the new port
6. The frontend refetch gets the rolled-back `verge_mixed_port = 7897`

Additionally, the backend `RESTART_CORE` flag does not trigger the `refresh_verge` event, so the frontend cannot refresh the verge config via the event mechanism.

### Changes

| Fix | File | Description |
| --- | --- | --- |
| **Core fix** | `clash-port-viewer.tsx` | `Promise.all` → sequential execution (patchVerge first, then patchInfo) |
| **Backend event fix** | `feat/config.rs` | Add `refresh_verge()` call in `RESTART_CORE` handler |
| **Backend constants** | `clash.rs`, `verge.rs`, `proxy.rs` | Hardcoded `7895-7899` → `network::ports::DEFAULT_*` constants |
| **Frontend constants** | New `utils/ports.ts` + 5 files | Hardcoded `7897` fallbacks → `DEFAULT_PORTS.MIXED` etc. |
| **Logic unification** | `feat/proxy.rs` | Align `copy_clash_env` port fallback logic with `sysopt.rs` |

### Testing

- [x] TypeScript type check passed (`tsc --noEmit`)
- [x] Rust compilation check passed (`cargo check`)
- [x] Rust unit test `test_clash_info` passed
- [x] Manual test: change mixed-port → save → verify frontend display updates correctly
- [x] Manual test: copy env vars (`copy_clash_env`) contains correct port number