### PR TITLE
feat(proxy): add per-group download speed test

### DIFF
--- a/src-tauri/src/cmd/clash.rs
+++ b/src-tauri/src/cmd/clash.rs
@@ -118,6 +118,21 @@ pub async fn test_delay(url: String) -> CmdResult<u32> {
     Ok(result)
 }
 
+/// 通过混合端口代理测试下载速度，返回 MB/s。失败时返回 0.0。
+#[tauri::command]
+pub async fn test_download_speed(url: String, timeout_ms: u64) -> CmdResult<f64> {
+    match feat::test_download_speed(url, timeout_ms).await {
+        Ok(speed) => {
+            logging!(info, Type::Cmd, "speed test result: {:.2} MB/s", speed);
+            Ok(speed)
+        }
+        Err(e) => {
+            logging!(error, Type::Cmd, "speed test error: {}", e);
+            Ok(0.0)
+        }
+    }
+}
+
 /// 保存DNS配置到单独文件
 #[tauri::command]
 pub async fn save_dns_config(dns_config: Mapping) -> CmdResult {

--- a/src-tauri/src/feat/clash.rs
+++ b/src-tauri/src/feat/clash.rs
@@ -183,3 +183,76 @@ pub async fn test_delay(url: String) -> anyhow::Result<u32> {
     .await
     .unwrap_or(Ok(10000u32))
 }
+
+/// 通过混合端口代理下载字节并返回速度（MB/s）。
+/// 当系统代理或 TUN 模式启用时，流量经由 127.0.0.1:{mixed_port} 路由。
+/// 失败时返回 Err（调用方将其映射为 0.0）。
+pub async fn test_download_speed(url: String, timeout_ms: u64) -> anyhow::Result<f64> {
+    use std::time::Duration;
+    use tokio::time::Instant;
+
+    let verge = Config::verge().await.latest_arc();
+    let proxy_port: Option<u16> = {
+        let enabled = verge.enable_system_proxy.unwrap_or(false)
+            || verge.enable_tun_mode.unwrap_or(false);
+        if enabled {
+            Some(match verge.verge_mixed_port {
+                Some(p) => p,
+                None => Config::clash().await.data_arc().get_mixed_port(),
+            })
+        } else {
+            None
+        }
+    };
+
+    let client = {
+        let mut builder = reqwest::Client::builder()
+            .timeout(Duration::from_millis(timeout_ms))
+            .danger_accept_invalid_certs(true);
+        if let Some(port) = proxy_port {
+            let proxy_url = format!("http://127.0.0.1:{port}");
+            builder = builder.proxy(
+                reqwest::Proxy::all(&proxy_url)
+                    .map_err(|e| anyhow::anyhow!("bad proxy url: {e}"))?,
+            );
+        }
+        builder
+            .build()
+            .map_err(|e| anyhow::anyhow!("reqwest build: {e}"))?
+    };
+
+    let start = Instant::now();
+    let mut response = client
+        .get(&*url)
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "HTTP {} from speed-test URL",
+            response.status()
+        ));
+    }
+
+    const BYTES_CAP: u64 = 10 * 1024 * 1024; // 最多下载 10 MB
+    let mut total_bytes: u64 = 0;
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| anyhow::anyhow!("chunk error: {e}"))?
+    {
+        total_bytes += chunk.len() as u64;
+        if total_bytes >= BYTES_CAP || start.elapsed() >= Duration::from_millis(timeout_ms) {
+            break;
+        }
+    }
+
+    let elapsed_secs = start.elapsed().as_secs_f64();
+    if elapsed_secs < 0.1 || total_bytes == 0 {
+        return Err(anyhow::anyhow!("too few bytes received"));
+    }
+
+    Ok((total_bytes as f64) / elapsed_secs / (1024.0 * 1024.0))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -181,6 +181,7 @@ mod app_init {
             cmd::get_verge_config,
             cmd::patch_verge_config,
             cmd::test_delay,
+            cmd::test_download_speed,
             cmd::get_app_dir,
             cmd::copy_icon_file,
             cmd::download_icon_cache,

--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -22,6 +22,7 @@ import { useVerge } from '@/hooks/use-verge'
 import { useAppData } from '@/providers/app-data-context'
 import { calcuProxies, updateProxyChainConfigInRuntime } from '@/services/cmds'
 import delayManager from '@/services/delay'
+import speedManager from '@/services/speed'
 import { debugLog } from '@/utils/debug'
 
 import { ScrollTopButton } from '../layout/scroll-top-button'
@@ -376,6 +377,55 @@ export const ProxyGroups = (props: Props) => {
     }),
   )
 
+  // 仅对 ping < 250ms（绿色）的代理依次进行下载速度测试
+  const handleCheckSpeed = useStableCallback(
+    useLockFn(async (groupName: string) => {
+      // 收集该组的所有代理
+      const proxies = renderList
+        .filter(
+          (e) => e.group?.name === groupName && (e.type === 2 || e.type === 4),
+        )
+        .flatMap((e) => e.proxyCol || e.proxy!)
+        .filter(Boolean)
+
+      // 仅筛选 ping < 250ms 的绿色代理（排除 provider 节点）
+      const greenProxies = proxies.filter((p) => {
+        if (!p || p.provider) return false
+        const delay = delayManager.getDelay(p.name, groupName)
+        return delay > 0 && delay < 250
+      })
+
+      if (greenProxies.length === 0) {
+        debugLog(`[ProxyGroups] 速度测试：无绿色节点（请先运行延迟测试）`)
+        return
+      }
+
+      // 查找当前组对象（用于恢复 group.now）
+      const group = renderList.find(
+        (e) => e.type === 1 && e.group?.name === groupName,
+      )?.group
+
+      if (!group) return
+
+      debugLog(
+        `[ProxyGroups] 开始速度测试，组: ${groupName}，目标数量: ${greenProxies.length}`,
+      )
+
+      const downloadUrl = 'https://speed.cloudflare.com/__down?bytes=10000000'
+
+      await speedManager.checkListSpeed(
+        greenProxies.map((p) => ({ name: p!.name })),
+        { name: groupName, now: group.now },
+        downloadUrl,
+        15_000,
+        () => onProxies(),
+      )
+
+      debugLog(`[ProxyGroups] 速度测试完成，组: ${groupName}`)
+      onProxies()
+    }),
+  )
+
   // 滚到对应的节点
   const handleLocation = useStableCallback((group: IProxyGroupItem) => {
     if (!group) return
@@ -528,6 +578,7 @@ export const ProxyGroups = (props: Props) => {
                       indent={mode === 'rule' || mode === 'script'}
                       onLocation={handleLocation}
                       onCheckAll={handleCheckAll}
+                      onCheckSpeed={handleCheckSpeed}
                       onHeadState={onHeadState}
                       onChangeProxy={handleChangeProxy}
                       isChainMode={isChainMode}
@@ -660,6 +711,7 @@ export const ProxyGroups = (props: Props) => {
                 indent={mode === 'rule' || mode === 'script'}
                 onLocation={handleLocation}
                 onCheckAll={handleCheckAll}
+                onCheckSpeed={handleCheckSpeed}
                 onHeadState={onHeadState}
                 onChangeProxy={handleChangeProxy}
               />

--- a/src/components/proxy/proxy-head.tsx
+++ b/src/components/proxy/proxy-head.tsx
@@ -2,6 +2,7 @@ import {
   AccessTimeRounded,
   MyLocationRounded,
   NetworkCheckRounded,
+  SpeedRounded,
   FilterAltRounded,
   FilterAltOffRounded,
   VisibilityRounded,
@@ -30,6 +31,7 @@ interface Props {
   headState: HeadState
   onLocation: () => void
   onCheckDelay: () => void
+  onCheckSpeed: () => void
   onHeadState: (val: Partial<HeadState>) => void
 }
 
@@ -43,6 +45,7 @@ export const ProxyHead = ({
   onHeadState,
   onLocation,
   onCheckDelay,
+  onCheckSpeed,
 }: Props) => {
   const {
     showType,
@@ -99,6 +102,15 @@ export const ProxyHead = ({
         }}
       >
         <NetworkCheckRounded />
+      </IconButton>
+
+      <IconButton
+        size="small"
+        color="inherit"
+        title={t('proxies.page.tooltips.speedCheck')}
+        onClick={onCheckSpeed}
+      >
+        <SpeedRounded />
       </IconButton>
 
       <IconButton

--- a/src/components/proxy/proxy-item-mini.tsx
+++ b/src/components/proxy/proxy-item-mini.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from 'react-i18next'
 
 import { BaseLoading } from '@/components/base'
 import { useProxyDelayState } from '@/hooks/use-proxy-delay-state'
+import { useProxySpeedState } from '@/hooks/use-proxy-speed-state'
 import delayManager from '@/services/delay'
+import speedManager from '@/services/speed'
 
 interface Props {
   group: IProxyGroupItem
@@ -25,6 +27,7 @@ export const ProxyItemMini = (props: Props) => {
     proxy,
     group.name,
   )
+  const { speedValue } = useProxySpeedState(proxy, group.name)
 
   return (
     <ListItemButton
@@ -154,6 +157,22 @@ export const ProxyItemMini = (props: Props) => {
       <Box
         sx={{ ml: 0.5, color: 'primary.main', display: isPreset ? 'none' : '' }}
       >
+        {/* 下载速度（有数据时显示在 ping 上方） */}
+        {speedValue > 0 && (
+          <Box
+            sx={{
+              fontSize: '10px',
+              lineHeight: 1.2,
+              textAlign: 'right',
+              color: speedManager.formatSpeedColor(speedValue),
+              fontVariantNumeric: 'tabular-nums',
+              px: '4px',
+              mb: '1px',
+            }}
+          >
+            {speedManager.formatSpeed(speedValue)}
+          </Box>
+        )}
         {delayValue === -2 && (
           <Widget>
             <BaseLoading />

--- a/src/components/proxy/proxy-item.tsx
+++ b/src/components/proxy/proxy-item.tsx
@@ -13,7 +13,9 @@ import {
 
 import { BaseLoading } from '@/components/base'
 import { useProxyDelayState } from '@/hooks/use-proxy-delay-state'
+import { useProxySpeedState } from '@/hooks/use-proxy-speed-state'
 import delayManager from '@/services/delay'
+import speedManager from '@/services/speed'
 
 interface Props {
   group: IProxyGroupItem
@@ -50,6 +52,7 @@ export const ProxyItem = (props: Props) => {
     proxy,
     group.name,
   )
+  const { speedValue } = useProxySpeedState(proxy, group.name)
 
   return (
     <ListItem sx={sx}>
@@ -79,7 +82,7 @@ export const ProxyItem = (props: Props) => {
               },
               backgroundColor: bgcolor,
               marginBottom: '8px',
-              height: '40px',
+              height: speedValue > 0 ? '52px' : '40px',
             }
           },
         ]}
@@ -119,58 +122,76 @@ export const ProxyItem = (props: Props) => {
             display: isPreset ? 'none' : '',
           }}
         >
-          {delayValue === -2 && (
-            <Widget>
-              <BaseLoading />
-            </Widget>
-          )}
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
+            {/* 下载速度（有数据时显示在 ping 上方） */}
+            {speedValue > 0 && (
+              <Box
+                sx={{
+                  fontSize: '10px',
+                  lineHeight: 1.2,
+                  color: speedManager.formatSpeedColor(speedValue),
+                  fontVariantNumeric: 'tabular-nums',
+                  px: '6px',
+                  pb: '1px',
+                }}
+              >
+                {speedManager.formatSpeed(speedValue)}
+              </Box>
+            )}
 
-          {!proxy.provider && delayValue !== -2 && (
-            // provider 的节点不支持检测
-            <Widget
-              className="the-check"
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                onDelay()
-              }}
-              sx={({ palette }) => ({
-                display: 'none', // hover 时显示
-                ':hover': { bgcolor: alpha(palette.primary.main, 0.15) },
-              })}
-            >
-              Check
-            </Widget>
-          )}
+            {delayValue === -2 && (
+              <Widget>
+                <BaseLoading />
+              </Widget>
+            )}
 
-          {delayValue > 0 && (
-            // 显示延迟
-            <Widget
-              className="the-delay"
-              onClick={(e) => {
-                if (proxy.provider) return
-                e.preventDefault()
-                e.stopPropagation()
-                onDelay()
-              }}
-              sx={({ palette }) => ({
-                color: delayManager.formatDelayColor(delayValue, timeout),
-                ...(!proxy.provider
-                  ? { ':hover': { bgcolor: alpha(palette.primary.main, 0.15) } }
-                  : {}),
-              })}
-            >
-              {delayManager.formatDelay(delayValue, timeout)}
-            </Widget>
-          )}
+            {!proxy.provider && delayValue !== -2 && (
+              // provider 的节点不支持检测
+              <Widget
+                className="the-check"
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  onDelay()
+                }}
+                sx={({ palette }) => ({
+                  display: 'none', // hover 时显示
+                  ':hover': { bgcolor: alpha(palette.primary.main, 0.15) },
+                })}
+              >
+                Check
+              </Widget>
+            )}
 
-          {delayValue !== -2 && delayValue <= 0 && selected && (
-            // 展示已选择的 icon
-            <CheckCircleOutlineRounded
-              className="the-icon"
-              sx={{ fontSize: 16 }}
-            />
-          )}
+            {delayValue > 0 && (
+              // 显示延迟
+              <Widget
+                className="the-delay"
+                onClick={(e) => {
+                  if (proxy.provider) return
+                  e.preventDefault()
+                  e.stopPropagation()
+                  onDelay()
+                }}
+                sx={({ palette }) => ({
+                  color: delayManager.formatDelayColor(delayValue, timeout),
+                  ...(!proxy.provider
+                    ? { ':hover': { bgcolor: alpha(palette.primary.main, 0.15) } }
+                    : {}),
+                })}
+              >
+                {delayManager.formatDelay(delayValue, timeout)}
+              </Widget>
+            )}
+
+            {delayValue !== -2 && delayValue <= 0 && selected && (
+              // 展示已选择的 icon
+              <CheckCircleOutlineRounded
+                className="the-icon"
+                sx={{ fontSize: 16 }}
+              />
+            )}
+          </Box>
         </ListItemIcon>
       </ListItemButton>
     </ListItem>

--- a/src/components/proxy/proxy-render.tsx
+++ b/src/components/proxy/proxy-render.tsx
@@ -32,6 +32,7 @@ interface RenderProps {
   isChainMode?: boolean
   onLocation: (group: IRenderItem['group']) => void
   onCheckAll: (groupName: string) => void
+  onCheckSpeed: (groupName: string) => void
   onHeadState: (groupName: string, patch: Partial<HeadState>) => void
   onChangeProxy: (
     group: IRenderItem['group'],
@@ -46,6 +47,7 @@ export const ProxyRender = (props: RenderProps) => {
     item,
     onLocation,
     onCheckAll,
+    onCheckSpeed,
     onHeadState,
     onChangeProxy,
     isChainMode: _ = false,
@@ -172,6 +174,7 @@ export const ProxyRender = (props: RenderProps) => {
         headState={headState!}
         onLocation={() => onLocation(group)}
         onCheckDelay={() => onCheckAll(group.name)}
+        onCheckSpeed={() => onCheckSpeed(group.name)}
         onHeadState={(p) => onHeadState(group.name, p)}
       />
     )

--- a/src/hooks/use-proxy-speed-state.ts
+++ b/src/hooks/use-proxy-speed-state.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useReducer } from 'react'
+
+import speedManager, { type SpeedUpdate } from '@/services/speed'
+
+const PRESET_PROXY_NAMES = ['DIRECT', 'REJECT', 'REJECT-DROP', 'PASS', 'COMPATIBLE']
+
+const identity = (_: SpeedUpdate, next: SpeedUpdate): SpeedUpdate => next
+
+const INITIAL_SPEED: SpeedUpdate = { speed: -1, updatedAt: 0 }
+
+export interface UseProxySpeedState {
+  speedState: SpeedUpdate
+  speedValue: number // 原始值：-1 / -2 / 0 / MB/s
+  isPreset: boolean
+}
+
+export function useProxySpeedState(
+  proxy: IProxyItem,
+  groupName: string,
+): UseProxySpeedState {
+  const isPreset = PRESET_PROXY_NAMES.includes(proxy.name)
+  const [speedState, setSpeedState] = useReducer(identity, INITIAL_SPEED)
+
+  // 为该代理注册 SpeedManager 更新监听器
+  useEffect(() => {
+    if (isPreset) return
+    speedManager.setListener(proxy.name, groupName, setSpeedState)
+    return () => speedManager.removeListener(proxy.name, groupName)
+  }, [proxy.name, groupName, isPreset])
+
+  // 挂载时从缓存加载初始值
+  const updateFromCache = useCallback(() => {
+    if (isPreset) return
+    const cached = speedManager.getSpeedUpdate(proxy.name, groupName)
+    if (cached) {
+      setSpeedState(cached)
+    }
+  }, [proxy.name, groupName, isPreset])
+
+  useEffect(() => {
+    updateFromCache()
+  }, [updateFromCache])
+
+  return {
+    speedState,
+    speedValue: speedState.speed,
+    isPreset,
+  }
+}

--- a/src/locales/en/proxies.json
+++ b/src/locales/en/proxies.json
@@ -30,6 +30,7 @@
     "tooltips": {
       "locate": "locate",
       "delayCheck": "Delay check",
+      "speedCheck": "Download speed test (green nodes only)",
       "sortDefault": "Sort by default",
       "sortDelay": "Sort by delay",
       "sortName": "Sort by name",

--- a/src/locales/ko/proxies.json
+++ b/src/locales/ko/proxies.json
@@ -30,6 +30,7 @@
     "tooltips": {
       "locate": "위치 찾기",
       "delayCheck": "지연 확인",
+      "speedCheck": "다운로드 속도 테스트 (녹색 노드만)",
       "sortDefault": "기본 정렬",
       "sortDelay": "지연으로 정렬",
       "sortName": "이름으로 정렬",

--- a/src/locales/zh/proxies.json
+++ b/src/locales/zh/proxies.json
@@ -30,6 +30,7 @@
     "tooltips": {
       "locate": "当前节点",
       "delayCheck": "延迟测试",
+      "speedCheck": "下载速度测试（仅绿色节点）",
       "sortDefault": "默认排序",
       "sortDelay": "按延迟排序",
       "sortName": "按名称排序",

--- a/src/services/cmds.ts
+++ b/src/services/cmds.ts
@@ -370,6 +370,16 @@ export async function cmdTestDelay(url: string) {
   return invoke<number>('test_delay', { url })
 }
 
+/** 通过当前活跃代理的混合端口下载指定 URL，测量速度（MB/s）。
+ *  失败时返回 0。
+ */
+export async function cmdTestDownloadSpeed(
+  url: string,
+  timeoutMs = 15_000,
+): Promise<number> {
+  return invoke<number>('test_download_speed', { url, timeoutMs })
+}
+
 export async function invoke_uwp_tool() {
   return invoke<void>('invoke_uwp_tool').catch((err) =>
     showNotice.error(err, 1500),

--- a/src/services/speed.ts
+++ b/src/services/speed.ts
@@ -1,0 +1,215 @@
+// SpeedManager – 追踪各代理节点下载速度（MB/s）的单例
+// 使用与 DelayManager 相同的批量/监听器模式
+//
+// 哨兵值：
+//   -1  = 无数据（不显示）
+//   -2  = 测速中（显示加载动画）
+//    0  = 测速失败 / 出错
+//   >0  = MB/s
+
+import { cmdTestDownloadSpeed } from '@/services/cmds'
+import { selectNodeForGroup } from 'tauri-plugin-mihomo-api'
+
+const hashKey = (name: string, group: string) => `${group ?? ''}::${name}`
+
+export interface SpeedUpdate {
+  /** MB/s，或哨兵值 -1 / -2 / 0 */
+  speed: number
+  updatedAt: number
+}
+
+const CACHE_TTL = 30 * 60 * 1000 // 30分钟
+
+class SpeedManager {
+  private cache = new Map<string, SpeedUpdate>()
+  private listenerMap = new Map<string, (update: SpeedUpdate) => void>()
+  private groupListenerMap = new Map<string, () => void>()
+
+  private pendingItemUpdates = new Map<string, SpeedUpdate[]>()
+  private pendingGroupUpdates = new Set<string>()
+  private itemFlushScheduled = false
+  private groupFlushScheduled = false
+
+  // ── 内部调度（与 DelayManager 相同的模式）──────────────────────────
+
+  private scheduleOnNextFrame(run: () => void): void {
+    if (typeof window !== 'undefined') {
+      if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(run)
+        return
+      }
+      if (typeof window.setTimeout === 'function') {
+        window.setTimeout(run, 0)
+        return
+      }
+    }
+    Promise.resolve().then(run)
+  }
+
+  private scheduleItemFlush() {
+    if (this.itemFlushScheduled) return
+    this.itemFlushScheduled = true
+    this.scheduleOnNextFrame(() => {
+      this.itemFlushScheduled = false
+      const updates = this.pendingItemUpdates
+      this.pendingItemUpdates = new Map()
+      updates.forEach((queue, key) => {
+        const listener = this.listenerMap.get(key)
+        if (!listener) return
+        queue.forEach((u) => {
+          try {
+            listener(u)
+          } catch {
+            /* swallow */
+          }
+        })
+      })
+    })
+  }
+
+  private scheduleGroupFlush() {
+    if (this.groupFlushScheduled) return
+    this.groupFlushScheduled = true
+    this.scheduleOnNextFrame(() => {
+      this.groupFlushScheduled = false
+      const groups = this.pendingGroupUpdates
+      this.pendingGroupUpdates = new Set()
+      groups.forEach((group) => {
+        try {
+          this.groupListenerMap.get(group)?.()
+        } catch {
+          /* swallow */
+        }
+      })
+    })
+  }
+
+  private queueGroupNotification(group: string) {
+    this.pendingGroupUpdates.add(group)
+    this.scheduleGroupFlush()
+  }
+
+  // ── 公开 API ─────────────────────────────────────────────────────────────
+
+  setListener(name: string, group: string, listener: (u: SpeedUpdate) => void) {
+    this.listenerMap.set(hashKey(name, group), listener)
+  }
+
+  removeListener(name: string, group: string) {
+    this.listenerMap.delete(hashKey(name, group))
+  }
+
+  setGroupListener(group: string, listener: () => void) {
+    this.groupListenerMap.set(group, listener)
+  }
+
+  removeGroupListener(group: string) {
+    this.groupListenerMap.delete(group)
+  }
+
+  setSpeed(name: string, group: string, speed: number): SpeedUpdate {
+    const key = hashKey(name, group)
+    const update: SpeedUpdate = { speed, updatedAt: Date.now() }
+    this.cache.set(key, update)
+
+    const queue = this.pendingItemUpdates.get(key)
+    if (queue) {
+      queue.push(update)
+    } else {
+      this.pendingItemUpdates.set(key, [update])
+    }
+    this.scheduleItemFlush()
+    return update
+  }
+
+  getSpeedUpdate(name: string, group: string): SpeedUpdate | undefined {
+    const key = hashKey(name, group)
+    const entry = this.cache.get(key)
+    if (!entry) return undefined
+    if (Date.now() - entry.updatedAt > CACHE_TTL) {
+      this.cache.delete(key)
+      return undefined
+    }
+    return { ...entry }
+  }
+
+  getSpeed(name: string, group: string): number {
+    return this.getSpeedUpdate(name, group)?.speed ?? -1
+  }
+
+  /**
+   * 将速度值转换为显示用字符串。
+   * -1  → ''（无数据，不显示）
+   * -2  → 'testing'（由组件显示加载动画）
+   *  0  → 'Err'
+   * >0  → '12.3 MB/s'
+   */
+  formatSpeed(speed: number): string {
+    if (speed === -1) return ''
+    if (speed === -2) return 'testing'
+    if (speed === 0) return 'Err'
+    return `${speed.toFixed(1)} MB/s`
+  }
+
+  /** 根据速度值返回对应的 MUI 颜色。 */
+  formatSpeedColor(speed: number): string {
+    if (speed <= 0) return '' // -1, -2, 0 → 无颜色
+    if (speed < 1) return 'error.main'
+    if (speed < 5) return 'warning.main'
+    return 'success.main' // ≥ 5 MB/s → 绿色
+  }
+
+  /**
+   * 对绿色（ping < 250ms）代理列表依次进行下载速度测试。
+   * 每个代理：临时切换 → 下载 → 记录速度 → 继续下一个。
+   * 全部完成后恢复原来选中的代理。
+   *
+   * @param entries      待测试的 { name } 列表
+   * @param group        代理组信息（name, now）
+   * @param downloadUrl  下载测试 URL
+   * @param timeoutMs    每个代理的超时时间（ms）
+   * @param onProgress   每个代理完成后调用的回调（用于刷新 UI）
+   */
+  async checkListSpeed(
+    entries: Array<{ name: string }>,
+    group: { name: string; now?: string },
+    downloadUrl: string,
+    timeoutMs: number,
+    onProgress?: () => void,
+  ): Promise<void> {
+    // 将所有目标标记为测速中（-2）
+    for (const { name } of entries) {
+      this.setSpeed(name, group.name, -2)
+    }
+
+    const originalProxy = group.now ?? null
+
+    for (const { name } of entries) {
+      try {
+        // 切换到该代理
+        await selectNodeForGroup(group.name, name)
+        // 等待 mihomo 通过新节点路由流量
+        await new Promise((r) => setTimeout(r, 300))
+
+        const mbps = await cmdTestDownloadSpeed(downloadUrl, timeoutMs)
+        this.setSpeed(name, group.name, mbps > 0 ? mbps : 0)
+      } catch {
+        this.setSpeed(name, group.name, 0)
+      }
+
+      this.queueGroupNotification(group.name)
+      onProgress?.()
+    }
+
+    // 恢复原来选中的代理（尽力而为）
+    if (originalProxy) {
+      try {
+        await selectNodeForGroup(group.name, originalProxy)
+      } catch {
+        // 恢复失败时忽略
+      }
+    }
+  }
+}
+
+export default new SpeedManager()


### PR DESCRIPTION
## Summary

- 在每个代理组工具栏新增**下载速度测试**按钮（位于 ping 按钮右侧）
- 仅对**绿色节点**（ping < 250 ms）依次测速，避免浪费时间在慢节点上
- 速度结果显示在每个代理卡片的 ping 值**上方**，按阈值色彩标注：
  - 🔴 `< 1 MB/s` — 红色
  - 🟡 `1–4.9 MB/s` — 橙色
  - 🟢 `≥ 5 MB/s` — 绿色

## 工作原理

1. 点击代理组工具栏的速度测试按钮（⚡图标）
2. 所有绿色节点标记为"测速中"（-2）
3. 依次临时切换到每个节点 → 等待 300 ms → 通过 mixed-port 从 Cloudflare 下载最多 10 MB
4. 测得的 MB/s 存入 SpeedManager 并显示在代理卡片上
5. 全部完成后恢复原来的代理选择

## 新增文件

- `src/services/speed.ts` — SpeedManager 单例（镜像 DelayManager 模式）
- `src/hooks/use-proxy-speed-state.ts` — 每个代理的 React 速度状态 hook
