### PR TITLE
fix: remove unsafe exec() in publish-version.mjs

### DIFF
--- a/scripts/portable-fixed-webview2.mjs
+++ b/scripts/portable-fixed-webview2.mjs
@@ -6,14 +6,19 @@ import path from 'path'
 import { context, getOctokit } from '@actions/github'
 import AdmZip from 'adm-zip'
 
-const target = process.argv.slice(2)[0]
-const alpha = process.argv.slice(2)[1]
-
 const ARCH_MAP = {
   'x86_64-pc-windows-msvc': 'x64',
   'i686-pc-windows-msvc': 'x86',
   'aarch64-pc-windows-msvc': 'arm64',
 }
+
+const rawTarget = process.argv.slice(2)[0]
+if (rawTarget !== undefined && !Object.hasOwn(ARCH_MAP, rawTarget)) {
+  console.error(`[ERROR]: Invalid target platform: ${rawTarget}`)
+  process.exit(1)
+}
+const target = rawTarget
+const alpha = process.argv.slice(2)[1]
 
 const PROCESS_MAP = {
   x64: 'x64',

--- a/scripts/publish-version.mjs
+++ b/scripts/publish-version.mjs
@@ -49,10 +49,10 @@ async function run() {
 
   if (tag) {
     // 打 tag 并推送
-    const { execSync } = await import('child_process')
+    const { execFileSync } = await import('child_process')
     try {
-      execSync(`git tag ${tag}`, { stdio: 'inherit' })
-      execSync(`git push origin ${tag}`, { stdio: 'inherit' })
+      execFileSync('git', ['tag', tag], { stdio: 'inherit' })
+      execFileSync('git', ['push', 'origin', tag], { stdio: 'inherit' })
       console.log(`[INFO]: Git tag ${tag} created and pushed.`)
     } catch {
       console.error(`[ERROR]: Failed to create or push git tag: ${tag}`)


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/publish-version.mjs`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/publish-version.mjs:14` |

**Description**: Three build scripts accept raw command-line arguments (process.argv) without input validation. In scripts/publish-version.mjs, the version string is read directly from argv[2] and is likely interpolated into shell commands or file-system operations used during the release process. In scripts/portable-fixed-webview2.mjs, the target platform string and alpha flag are similarly unvalidated. If any of these values are passed to a shell command via template literals or exec() with shell:true, an attacker who can control the arguments supplied to the CI/CD pipeline can inject arbitrary operating-system commands. Note: the FORCE flag in prebuild.mjs uses a boolean includes() check and is safe as written.

## Changes
- `scripts/publish-version.mjs`
- `scripts/portable-fixed-webview2.mjs`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
