### PR TITLE
fix: recenter window when window-state restores off-screen position

### DIFF
--- a/src-tauri/src/utils/resolve/window.rs
+++ b/src-tauri/src/utils/resolve/window.rs
@@ -3,7 +3,7 @@ use tauri::utils::config::Color;
 use tauri::{Theme, WebviewWindow};
 
 use crate::{config::Config, core::handle, utils::resolve::window_script::build_window_initial_script};
-use clash_verge_logging::{Type, logging_error};
+use clash_verge_logging::{Type, logging, logging_error};
 
 const DARK_BACKGROUND_COLOR: Color = Color(46, 48, 61, 255); // #2E303D
 const LIGHT_BACKGROUND_COLOR: Color = Color(245, 245, 245, 255); // #F5F5F5
@@ -78,6 +78,33 @@ pub async fn build_new_window() -> Result<WebviewWindow, String> {
     match builder.build() {
         Ok(window) => {
             logging_error!(Type::Window, window.set_background_color(Some(background_color)));
+
+            // Ensure the window is on-screen after state restore.
+            // tauri-plugin-window-state may restore a position outside visible
+            // monitors (e.g. after a monitor disconnect or an off-screen
+            // lightweight-mode cycle), making the window invisible.
+            if let Ok(pos) = window.outer_position() {
+                let is_on_screen = window
+                    .available_monitors()
+                    .ok()
+                    .map(|monitors| {
+                        monitors.iter().any(|m| {
+                            let mp = m.position();
+                            let ms = m.size();
+                            let win_size = window.outer_size().unwrap_or(m.size());
+                            pos.x + win_size.width as i32 > mp.x
+                                && pos.x < mp.x + ms.width as i32
+                                && pos.y + win_size.height as i32 > mp.y
+                                && pos.y < mp.y + ms.height as i32
+                        })
+                    })
+                    .unwrap_or(true);
+                if !is_on_screen {
+                    logging!(warn, Type::Window, "Window is off-screen at ({}, {}), recentering", pos.x, pos.y);
+                    let _ = window.center();
+                }
+            }
+
             Ok(window)
         }
         Err(e) => Err(e.to_string()),


### PR DESCRIPTION
## Summary

- When `tauri-plugin-window-state` restores a window position outside all visible monitors (e.g. negative coordinates like `-9,-9`), the window becomes invisible
- This happens specifically after lightweight mode entry (which destroys the window) and exit (which recreates it) — the plugin restores the stale off-screen position, overriding `.center()`
- Add a post-build screen bounds check in `build_new_window()` that verifies the window overlaps at least one available monitor; if not, the window is recentered

## Bug Reproduction

1. Enable auto lightweight mode
2. Close the Clash Verge window (triggers lightweight mode after timeout)
3. Click "Open Window" in tray to exit lightweight mode
4. Window may appear off-screen if `window_state.json` contains negative coordinates (e.g. `-9, -9` from window shadow/border offset)

## Root Cause

`tauri-plugin-window-state` saves the window position (including shadow border offsets like `-9, -9`) and restores it on window creation, overriding the `.center()` call in `build_new_window()`. When the window was destroyed via `destroy_main_window()` during lightweight mode, the stale position persisted.

## Fix

After `builder.build()`, check if the restored window position overlaps any available monitor. If completely off-screen, call `window.center()` to bring it back.

Fixes #6945