### PR TITLE
fix: disable WebView2 general autofill

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,5 +9,5 @@
 
 <details>
 <summary><strong> 🚀 优化改进 </strong></summary>
-
+- 关闭 autofill 弹出窗口
 </details>

--- a/src-tauri/src/utils/resolve/window.rs
+++ b/src-tauri/src/utils/resolve/window.rs
@@ -69,6 +69,7 @@ pub async fn build_new_window() -> Result<WebviewWindow, String> {
     .min_inner_size(MINIMAL_WIDTH, MINIMAL_HEIGHT)
     .visible(false) // 等待主题色准备好后再展示，避免启动色差
     .initialization_script(&initial_script)
+    .general_autofill_enabled(false) // 禁用自动填充
     .on_page_load(move |window, payload| {
         if payload.event() != PageLoadEvent::Finished {
             return;


### PR DESCRIPTION
Close #5944

为主窗口增加 `general_autofill_enabled(false)` 配置，
禁用 WebView 的普通表单自动填充行为。

Docs:
- https://docs.rs/tauri/latest/tauri/webview/struct.WebviewWindowBuilder.html#method.general_autofill_enabled