### PR TITLE
fix(ci): resolve pnpm lint issues

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -88,7 +88,6 @@ export default defineConfig([
       '@eslint-react/no-unused-class-component-members': 'error',
       '@eslint-react/no-unused-state': 'error',
       '@eslint-react/jsx-no-useless-fragment': 'warn',
-      '@eslint-react/prefer-destructuring-assignment': 'warn',
 
       // TypeScript
       '@typescript-eslint/no-explicit-any': 'off',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -6,6 +6,7 @@ import pluginImportX from 'eslint-plugin-import-x'
 import pluginReactCompiler from 'eslint-plugin-react-compiler'
 import pluginReactHooks from 'eslint-plugin-react-hooks'
 import pluginReactRefresh from 'eslint-plugin-react-refresh'
+import PluginSukka from 'eslint-plugin-sukka'
 import pluginUnusedImports from 'eslint-plugin-unused-imports'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
@@ -22,6 +23,7 @@ export default defineConfig([
       'import-x': pluginImportX,
       'react-refresh': pluginReactRefresh,
       'unused-imports': pluginUnusedImports,
+      sukka: PluginSukka,
     },
 
     extends: [
@@ -88,6 +90,7 @@ export default defineConfig([
       '@eslint-react/no-unused-class-component-members': 'error',
       '@eslint-react/no-unused-state': 'error',
       '@eslint-react/jsx-no-useless-fragment': 'warn',
+      'sukka/react-prefer-destructuring-assignment': 'warn',
 
       // TypeScript
       '@typescript-eslint/no-explicit-any': 'off',

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-sukka": "^9.5.0",
     "eslint-plugin-unused-imports": "^4.4.1",
     "glob": "^13.0.6",
     "globals": "^17.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
         version: 0.5.2(eslint@10.2.1(jiti@2.6.1))
+      eslint-plugin-sukka:
+        specifier: ^9.5.0
+        version: 9.5.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       eslint-plugin-unused-imports:
         specifier: ^4.4.1
         version: 4.4.1(@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))
@@ -2340,6 +2343,12 @@ packages:
       eslint: ^10.3.0
       typescript: '*'
 
+  eslint-plugin-sukka@9.5.0:
+    resolution: {integrity: sha512-G8Q2fcfMQHhyWAxf5i8/7OVCkGCa5vftYlX/hZjYy3B06YoBEHwBUevSOC8cMsYqd0tJbGW2obAJ3v5fSsmkQg==}
+    peerDependencies:
+      eslint: '>=9.29.0'
+      typescript: '*'
+
   eslint-plugin-unused-imports@4.4.1:
     resolution: {integrity: sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==}
     peerDependencies:
@@ -2489,6 +2498,9 @@ packages:
 
   foxts@5.4.1:
     resolution: {integrity: sha512-v/k4gR+NtazTauirS9o1KzNII4x7vX5NsLVv2pN2apfcuBM/GMwQj09hUiKkDiJqAQEOF//ydDyXrztQpBmkJQ==}
+
+  foxts@5.4.2:
+    resolution: {integrity: sha512-FKzYjarnrPNwMOiqaGT6S+/V4jDd3nt/MuJK5CjmJla7VSfyA8ZKjYGcoAvIr17ldYKj79eBBEYiRrYklsDRFA==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -5917,6 +5929,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-sukka@9.5.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/utils': 8.59.4(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+      eslint: 10.2.1(jiti@2.6.1)
+      foxts: 5.4.2
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1)):
     dependencies:
       eslint: 10.2.1(jiti@2.6.1)
@@ -6074,6 +6096,8 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   foxts@5.4.1: {}
+
+  foxts@5.4.2: {}
 
   fsevents@2.3.3:
     optional: true


### PR DESCRIPTION
~移除 prefer-destructuring-assignment规则~
迁移 `prefer-destructuring-assignment` 规则至`sukka/react-prefer-destructuring-assignment`
该规则已经在 `@eslint-react/eslint-plugin 5.6.0`后移除
当前 情况会导致 `pnpm lint` 错误

Docs
- https://www.eslint-react.xyz/docs/changelog#removed-rules