### PR TITLE
Improve Russian localization

### DIFF
--- a/crates/clash-verge-i18n/locales/ru.yml
+++ b/crates/clash-verge-i18n/locales/ru.yml
@@ -8,12 +8,12 @@ notifications:
     body: Переключено на {mode}.
   systemProxyToggled:
     title: Системный прокси
-    'on': System proxy has been enabled.
-    'off': System proxy has been disabled.
+    'on': Системный прокси включён.
+    'off': Системный прокси отключён.
   tunModeToggled:
     title: Режим TUN
-    'on': TUN mode has been enabled.
-    'off': TUN mode has been disabled.
+    'on': Режим TUN включён.
+    'off': Режим TUN отключён.
   lightweightModeEntered:
     title: Легкий режим
     body: Включен легкий режим.
@@ -27,10 +27,10 @@ notifications:
     title: Приложение скрыто
     body: Clash Verge работает в фоновом режиме.
   updateReady:
-    title: Clash Verge Update
-    body: A new version (v{version}) has been downloaded and is ready to install.
-    installNow: Install Now
-    later: Later
+    title: Обновление Clash Verge
+    body: Новая версия (v{version}) скачана и готова к установке.
+    installNow: Установить сейчас
+    later: Позже
 service:
   adminInstallPrompt: Для установки службы Clash Verge требуются права администратора.
   adminUninstallPrompt: Для удаления службы Clash Verge требуются права администратора.

--- a/src/components/setting/mods/update-viewer.tsx
+++ b/src/components/setting/mods/update-viewer.tsx
@@ -59,6 +59,8 @@ const GITHUB_ALERT_PATTERN =
 const GITHUB_ALERT_CLASS_PATTERN =
   /markdown-alert-(note|tip|important|warning|caution)/
 
+const shouldShowReleaseNotes = (language: string) => language === 'zh'
+
 const LazyReactMarkdown = lazy(async () => {
   const [{ default: ReactMarkdown }, { default: rehypeRaw }] =
     await Promise.all([import('react-markdown'), import('rehype-raw')])
@@ -136,7 +138,7 @@ const remarkGitHubAlerts = (labels: Record<GitHubAlertType, string>) => {
 }
 
 export function UpdateViewer({ ref }: { ref?: Ref<DialogRef> }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   const [open, setOpen] = useState(false)
   const updateState = useUpdateState()
@@ -174,12 +176,16 @@ export function UpdateViewer({ ref }: { ref?: Ref<DialogRef> }) {
     [githubAlertLabels],
   )
 
+  const activeLanguage = i18n.resolvedLanguage ?? i18n.language
   const markdownContent = useMemo(() => {
     if (!updateInfo?.body) {
       return t('settings.modals.update.messages.available')
     }
+    if (!shouldShowReleaseNotes(activeLanguage)) {
+      return t('settings.modals.update.messages.available')
+    }
     return updateInfo?.body
-  }, [t, updateInfo])
+  }, [activeLanguage, t, updateInfo])
 
   const breakChangeFlag = useMemo(() => {
     if (!updateInfo?.body) {

--- a/src/locales/ru/profiles.json
+++ b/src/locales/ru/profiles.json
@@ -71,7 +71,7 @@
     "menu": {
       "home": "Главная",
       "select": "Выбрать",
-      "shareQrCode": "Share QR Code",
+      "shareQrCode": "Поделиться QR-кодом",
       "editInfo": "Изменить информацию",
       "editFile": "Изменить файл",
       "editRules": "Редактировать правила",
@@ -203,7 +203,7 @@
       "title": "Консоль скрипта"
     },
     "qrViewer": {
-      "title": "Subscription QR Code"
+      "title": "QR-код подписки"
     }
   }
 }


### PR DESCRIPTION
Improve Russian localization in frontend and native UI strings.

This also replaces several hardcoded Chinese fallback labels with i18n keys, so Russian UI text is loaded from locale files.

Checks:
- pnpm i18n:check
- pnpm typecheck
- pnpm lint
- pnpm web:build

Related: #6641, #6642