### PR TITLE
Fix/proxy group navigator misclick

### DIFF
--- a/src-tauri/src/config/verge.rs
+++ b/src-tauri/src/config/verge.rs
@@ -405,7 +405,7 @@ impl IVerge {
             tun_tray_icon: Some(false),
             enable_auto_launch: Some(false),
             enable_silent_start: Some(false),
-            enable_hover_jump_navigator: Some(true),
+            enable_hover_jump_navigator: Some(false),
             hover_jump_navigator_delay: Some(280),
             enable_system_proxy: Some(false),
             proxy_auto_config: Some(false),

--- a/src/components/home/home-profile-card.tsx
+++ b/src/components/home/home-profile-card.tsx
@@ -15,27 +15,17 @@ import {
   Stack,
   Typography,
   alpha,
-  keyframes,
   useTheme,
 } from '@mui/material'
-import { useLockFn } from 'ahooks'
 import dayjs from 'dayjs'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 
-import { useAppRefreshers } from '@/providers/app-data-context'
-import { openWebUrl, updateProfile } from '@/services/cmds'
-import { showNotice } from '@/services/notice-service'
+import { openWebUrl } from '@/services/cmds'
 import parseTraffic from '@/utils/parse-traffic'
 
 import { EnhancedCard } from './enhanced-card'
-
-// 定义旋转动画
-const round = keyframes`
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-`
 
 // 辅助函数解析URL和过期时间
 const parseUrl = (url?: string) => {
@@ -76,15 +66,7 @@ interface HomeProfileCardProps {
 }
 
 // 提取独立组件减少主组件复杂度
-const ProfileDetails = ({
-  current,
-  onUpdateProfile,
-  updating,
-}: {
-  current: ProfileItem
-  onUpdateProfile: () => void
-  updating: boolean
-}) => {
+const ProfileDetails = ({ current }: { current: ProfileItem }) => {
   const { t } = useTranslation()
   const theme = useTheme()
 
@@ -111,7 +93,7 @@ const ProfileDetails = ({
               noWrap
               sx={{ display: 'flex', alignItems: 'center' }}
             >
-              <span style={{ flexShrink: 0 }}>{t('shared.labels.from')}: </span>
+              <span style={{ flexShrink: 0 }}>{t('shared.labels.from')}：</span>
               {current.home ? (
                 <Link
                   component="button"
@@ -171,22 +153,9 @@ const ProfileDetails = ({
 
         {current.updated && (
           <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <UpdateOutlined
-              fontSize="small"
-              color="action"
-              sx={{
-                cursor: 'pointer',
-                animation: updating ? `${round} 1.5s linear infinite` : 'none',
-              }}
-              onClick={onUpdateProfile}
-            />
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ cursor: 'pointer' }}
-              onClick={onUpdateProfile}
-            >
-              {t('shared.labels.updateTime')}:{' '}
+            <UpdateOutlined fontSize="small" color="action" />
+            <Typography variant="body2" color="text.secondary">
+              {t('shared.labels.updateTime')}：
               <Box component="span" sx={{ fontWeight: 'medium' }}>
                 {dayjs(current.updated * 1000).format('YYYY-MM-DD HH:mm')}
               </Box>
@@ -199,7 +168,7 @@ const ProfileDetails = ({
             <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
               <SpeedOutlined fontSize="small" color="action" />
               <Typography variant="body2" color="text.secondary">
-                {t('shared.labels.usedTotal')}:{' '}
+                {t('shared.labels.usedTotal')}：
                 <Box component="span" sx={{ fontWeight: 'medium' }}>
                   {parseTraffic(usedTraffic)} /{' '}
                   {parseTraffic(current.extra.total)}
@@ -211,7 +180,7 @@ const ProfileDetails = ({
               <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
                 <EventOutlined fontSize="small" color="action" />
                 <Typography variant="body2" color="text.secondary">
-                  {t('shared.labels.expireTime')}:{' '}
+                  {t('shared.labels.expireTime')}：
                   <Box component="span" sx={{ fontWeight: 'medium' }}>
                     {parseExpire(current.extra.expire)}
                   </Box>
@@ -275,33 +244,9 @@ const EmptyProfile = ({ onClick }: { onClick: () => void }) => {
   )
 }
 
-export const HomeProfileCard = ({
-  current,
-  onProfileUpdated,
-}: HomeProfileCardProps) => {
+export const HomeProfileCard = ({ current }: HomeProfileCardProps) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { refreshAll } = useAppRefreshers()
-
-  // 更新当前订阅
-  const [updating, setUpdating] = useState(false)
-
-  const onUpdateProfile = useLockFn(async () => {
-    if (!current?.uid) return
-
-    setUpdating(true)
-    try {
-      await updateProfile(current.uid, current.option)
-      onProfileUpdated?.()
-
-      // 刷新首页数据
-      refreshAll()
-    } catch (err) {
-      showNotice.error(err, 3000)
-    } finally {
-      setUpdating(false)
-    }
-  })
 
   // 导航到订阅页面
   const goToProfiles = useCallback(() => {
@@ -376,11 +321,7 @@ export const HomeProfileCard = ({
       action={cardAction}
     >
       {current ? (
-        <ProfileDetails
-          current={current}
-          onUpdateProfile={onUpdateProfile}
-          updating={updating}
-        />
+        <ProfileDetails current={current} />
       ) : (
         <EmptyProfile onClick={goToProfiles} />
       )}

--- a/src/components/home/home-profile-card.tsx
+++ b/src/components/home/home-profile-card.tsx
@@ -62,7 +62,6 @@ interface ProfileItem {
 
 interface HomeProfileCardProps {
   current: ProfileItem | null | undefined
-  onProfileUpdated?: () => void
 }
 
 // 提取独立组件减少主组件复杂度

--- a/src/components/home/proxy-tun-card.tsx
+++ b/src/components/home/proxy-tun-card.tsx
@@ -1,7 +1,6 @@
 import {
   ComputerRounded,
   TroubleshootRounded,
-  HelpOutlineRounded,
   SvgIconComponent,
 } from '@mui/icons-material'
 import {
@@ -9,7 +8,6 @@ import {
   Typography,
   Stack,
   Paper,
-  Tooltip,
   alpha,
   useTheme,
   Fade,
@@ -95,44 +93,36 @@ const TabButton: FC<TabButtonProps> = memo(
 
 interface TabDescriptionProps {
   description: string
-  tooltipTitle: string
 }
 
 // 描述文本组件
-const TabDescription: FC<TabDescriptionProps> = memo(
-  ({ description, tooltipTitle }) => (
-    <Fade in={true} timeout={200}>
-      <Typography
-        variant="caption"
-        component="div"
-        sx={{
-          width: '95%',
-          textAlign: 'center',
-          color: 'text.secondary',
-          p: 0.8,
-          borderRadius: 1,
-          borderColor: 'primary.main',
-          borderWidth: 1,
-          borderStyle: 'solid',
-          backgroundColor: 'background.paper',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: 0.5,
-          wordBreak: 'break-word',
-          hyphens: 'auto',
-        }}
-      >
-        {description}
-        <Tooltip title={tooltipTitle}>
-          <HelpOutlineRounded
-            sx={{ fontSize: 14, opacity: 0.7, flexShrink: 0 }}
-          />
-        </Tooltip>
-      </Typography>
-    </Fade>
-  ),
-)
+const TabDescription: FC<TabDescriptionProps> = memo(({ description }) => (
+  <Fade in={true} timeout={200}>
+    <Typography
+      variant="caption"
+      component="div"
+      sx={{
+        width: '95%',
+        textAlign: 'center',
+        color: 'text.secondary',
+        p: 0.8,
+        borderRadius: 1,
+        borderColor: 'primary.main',
+        borderWidth: 1,
+        borderStyle: 'solid',
+        backgroundColor: 'background.paper',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 0.5,
+        wordBreak: 'break-word',
+        hyphens: 'auto',
+      }}
+    >
+      {description}
+    </Typography>
+  </Fade>
+))
 
 export const ProxyTunCard: FC = () => {
   const { t } = useTranslation()
@@ -162,7 +152,6 @@ export const ProxyTunCard: FC = () => {
         text: systemProxyConfigState
           ? t('home.components.proxyTun.status.systemProxyEnabled')
           : t('home.components.proxyTun.status.systemProxyDisabled'),
-        tooltip: t('home.components.proxyTun.tooltips.systemProxy'),
       }
     } else {
       return {
@@ -171,7 +160,6 @@ export const ProxyTunCard: FC = () => {
           : enable_tun_mode
             ? t('home.components.proxyTun.status.tunModeEnabled')
             : t('home.components.proxyTun.status.tunModeDisabled'),
-        tooltip: t('home.components.proxyTun.tooltips.tunMode'),
       }
     }
   }, [
@@ -220,10 +208,7 @@ export const ProxyTunCard: FC = () => {
           overflow: 'visible',
         }}
       >
-        <TabDescription
-          description={tabDescription.text}
-          tooltipTitle={tabDescription.tooltip}
-        />
+        <TabDescription description={tabDescription.text} />
       </Box>
 
       <Box

--- a/src/components/proxy/proxy-group-navigator.tsx
+++ b/src/components/proxy/proxy-group-navigator.tsx
@@ -9,6 +9,7 @@ interface ProxyGroupNavigatorProps {
 }
 
 export const DEFAULT_HOVER_DELAY = 280
+export const NAVIGATOR_GUTTER_WIDTH = 18
 
 // 提取代理组名的第一个字符
 const getGroupDisplayChar = (groupName: string): string => {
@@ -93,17 +94,19 @@ export const ProxyGroupNavigator = ({
     <Box
       sx={{
         position: 'absolute',
-        right: 2,
+        right: 10,
         top: '50%',
         transform: 'translateY(-50%)',
         zIndex: 10,
         display: 'flex',
         flexDirection: 'column',
+        alignItems: 'center',
         gap: 0.25,
         bgcolor: 'transparent',
         borderRadius: 0.5,
         boxShadow: 0,
-        p: 0.25,
+        p: 0,
+        width: 28,
         maxHeight: '70vh',
         overflowY: 'auto',
         scrollbarWidth: 'none',

--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -41,6 +41,7 @@ import { ScrollTopButton } from '../layout/scroll-top-button'
 import { ProxyChain } from './proxy-chain'
 import {
   DEFAULT_HOVER_DELAY,
+  NAVIGATOR_GUTTER_WIDTH,
   ProxyGroupNavigator,
 } from './proxy-group-navigator'
 import { ProxyRender } from './proxy-render'
@@ -477,11 +478,13 @@ export const ProxyGroups = (props: Props) => {
       .map((item) => item.group!.name)
     return Array.from(new Set(names))
   }, [renderList])
+  const showGroupNavigator = mode === 'rule' && proxyGroupNames.length > 0
 
-  const renderProxyList = (height: string) => (
+  const renderProxyList = (height: string, endGutter = 0) => (
     <ProxyVirtualList
       parentRef={parentRef}
       height={height}
+      endGutter={endGutter}
       totalSize={virtualizer.getTotalSize()}
       virtualItems={virtualItems}
       renderList={renderList}
@@ -568,16 +571,19 @@ export const ProxyGroups = (props: Props) => {
       style={{ position: 'relative', height: '100%', willChange: 'transform' }}
     >
       {/* 代理组导航栏 */}
-      {mode === 'rule' && (
+      {showGroupNavigator && (
         <ProxyGroupNavigator
           proxyGroupNames={proxyGroupNames}
           onGroupLocation={handleGroupLocationByName}
-          enableHoverJump={verge?.enable_hover_jump_navigator ?? true}
+          enableHoverJump={verge?.enable_hover_jump_navigator ?? false}
           hoverDelay={verge?.hover_jump_navigator_delay ?? DEFAULT_HOVER_DELAY}
         />
       )}
 
-      {renderProxyList('calc(100% - 14px)')}
+      {renderProxyList(
+        'calc(100% - 14px)',
+        showGroupNavigator ? NAVIGATOR_GUTTER_WIDTH : 0,
+      )}
       <ScrollTopButton show={showScrollTop} onClick={scrollToTop} />
     </div>
   )
@@ -593,6 +599,7 @@ type VirtualListItem = {
 interface ProxyVirtualListProps {
   parentRef: RefObject<HTMLDivElement | null>
   height: string
+  endGutter?: number
   totalSize: number
   virtualItems: VirtualListItem[]
   renderList: IRenderItem[]
@@ -757,6 +764,7 @@ function GroupSelectMenu({
 function ProxyVirtualList({
   parentRef,
   height,
+  endGutter = 0,
   totalSize,
   virtualItems,
   renderList,
@@ -774,7 +782,15 @@ function ProxyVirtualList({
     theme.palette.mode === 'dark' ? '#1e1f27' : 'var(--background-color)'
 
   return (
-    <div ref={parentRef} style={{ height, overflow: 'auto' }}>
+    <div
+      ref={parentRef}
+      style={{
+        height,
+        overflow: 'auto',
+        paddingRight: endGutter,
+        boxSizing: 'border-box',
+      }}
+    >
       <div style={{ height: totalSize, position: 'relative' }}>
         {virtualItems.map((virtualItem) => (
           <div

--- a/src/components/setting/mods/layout-viewer.tsx
+++ b/src/components/setting/mods/layout-viewer.tsx
@@ -264,7 +264,7 @@ export const LayoutViewer = forwardRef<DialogRef>((_, ref) => {
             }
           />
           <GuardState
-            value={verge?.enable_hover_jump_navigator ?? true}
+            value={verge?.enable_hover_jump_navigator ?? false}
             valueProps="checked"
             onCatch={onError}
             onFormat={onSwitchFormat}
@@ -315,7 +315,7 @@ export const LayoutViewer = forwardRef<DialogRef>((_, ref) => {
               autoCapitalize="off"
               spellCheck={false}
               sx={{ width: 120 }}
-              disabled={!(verge?.enable_hover_jump_navigator ?? true)}
+              disabled={!(verge?.enable_hover_jump_navigator ?? false)}
               slotProps={{
                 input: {
                   endAdornment: (

--- a/src/components/shared/proxy-control-switches.tsx
+++ b/src/components/shared/proxy-control-switches.tsx
@@ -189,7 +189,7 @@ const ProxyControlSwitches = ({
         <SwitchRow
           label={t('settings.sections.proxyControl.fields.systemProxy')}
           active={systemProxyIndicator}
-          infoTitle={t('settings.sections.proxyControl.tooltips.systemProxy')}
+          infoTitle={t('settings.modals.sysproxy.title')}
           onInfoClick={() => sysproxyRef.current?.open()}
           onToggle={(value) => toggleSystemProxy(value)}
           onError={onError}
@@ -201,7 +201,7 @@ const ProxyControlSwitches = ({
         <SwitchRow
           label={t('settings.sections.proxyControl.fields.tunMode')}
           active={enable_tun_mode || false}
-          infoTitle={t('settings.sections.proxyControl.tooltips.tunMode')}
+          infoTitle={t('settings.modals.tun.title')}
           onInfoClick={() => tunRef.current?.open()}
           onToggle={handleTunToggle}
           onError={onError}

--- a/src/locales/en/home.json
+++ b/src/locales/en/home.json
@@ -31,13 +31,13 @@
       "status": {
         "systemProxyEnabled": "System Proxy Enabled",
         "systemProxyDisabled": "System Proxy Disabled",
-        "tunModeServiceRequired": "Virtual NIC requires Service Mode",
-        "tunModeEnabled": "Virtual NIC enabled",
-        "tunModeDisabled": "Virtual NIC disabled"
+        "tunModeServiceRequired": "TUN Mode requires Service Mode",
+        "tunModeEnabled": "TUN Mode enabled",
+        "tunModeDisabled": "TUN Mode disabled"
       },
       "tooltips": {
         "systemProxy": "System Proxy Info",
-        "tunMode": "Virtual NIC (TUN) traffic interception info"
+        "tunMode": "TUN Mode traffic interception info"
       }
     },
     "clashInfo": {

--- a/src/locales/en/home.json
+++ b/src/locales/en/home.json
@@ -7,14 +7,14 @@
     },
     "cards": {
       "trafficStats": "Traffic Stats",
-      "networkSettings": "Network Settings",
+      "networkSettings": "Proxy Switches",
       "proxyMode": "Proxy Mode"
     },
     "settings": {
       "cards": {
         "profile": "Profile Card",
         "currentProxy": "Current Proxy Card",
-        "network": "Network Settings Card",
+        "network": "Proxy Switches Card",
         "proxyMode": "Proxy Mode Card",
         "traffic": "Traffic Stats Card",
         "tests": "Website Tests Card",
@@ -31,13 +31,13 @@
       "status": {
         "systemProxyEnabled": "System Proxy Enabled",
         "systemProxyDisabled": "System Proxy Disabled",
-        "tunModeServiceRequired": "TUN Mode Service Required",
-        "tunModeEnabled": "TUN Mode Enabled",
-        "tunModeDisabled": "TUN Mode Disabled"
+        "tunModeServiceRequired": "Virtual NIC requires Service Mode",
+        "tunModeEnabled": "Virtual NIC enabled",
+        "tunModeDisabled": "Virtual NIC disabled"
       },
       "tooltips": {
         "systemProxy": "System Proxy Info",
-        "tunMode": "TUN Mode Intercept Info"
+        "tunMode": "Virtual NIC (TUN) traffic interception info"
       }
     },
     "clashInfo": {

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -11,7 +11,7 @@
     "system": {
       "title": "System Setting",
       "toggles": {
-        "tunMode": "Tun Mode",
+        "tunMode": "Virtual NIC",
         "systemProxy": "System Proxy"
       },
       "tooltips": {
@@ -23,16 +23,16 @@
       },
       "notifications": {
         "tunMode": {
-          "autoDisabled": "TUN Mode automatically disabled due to service unavailable",
-          "autoDisableFailed": "Failed to disable TUN Mode automatically"
+          "autoDisabled": "Virtual NIC automatically disabled due to service unavailable",
+          "autoDisableFailed": "Failed to disable Virtual NIC automatically"
         }
       }
     },
     "proxyControl": {
       "tooltips": {
         "systemProxy": "Enable to modify the operating system's proxy settings. If enabling fails, modify the operating system's proxy settings manually",
-        "tunMode": "Tun (Virtual NIC) mode: Captures all system traffic, when enabled, there is no need to enable system proxy.",
-        "tunUnavailable": "TUN requires Service Mode or Admin Mode"
+        "tunMode": "Virtual NIC (TUN) captures all system traffic, so System Proxy is not required when enabled.",
+        "tunUnavailable": "Virtual NIC requires Service Mode or Admin Mode"
       },
       "actions": {
         "installService": "Install Service",
@@ -40,7 +40,7 @@
       },
       "fields": {
         "systemProxy": "System Proxy",
-        "tunMode": "Tun Mode"
+        "tunMode": "Virtual NIC"
       }
     },
     "externalController": {
@@ -238,7 +238,7 @@
           "showOutboundModesInline": "Show Outbound Modes Inline",
           "commonTrayIcon": "Common Tray Icon",
           "systemProxyTrayIcon": "System Proxy Tray Icon",
-          "tunTrayIcon": "Tun Tray Icon",
+          "tunTrayIcon": "Virtual NIC Tray Icon",
           "enableTrayIcon": "Enable Tray Icon",
           "enableTraySpeed": "Enable Tray Speed",
           "pauseRenderTrafficStatsOnBlur": "Pause rendering traffic statistics when blurred"
@@ -465,9 +465,9 @@
       }
     },
     "tun": {
-      "title": "Tun Mode",
+      "title": "Virtual NIC Settings",
       "fields": {
-        "stack": "Tun Stack",
+        "stack": "TUN Stack",
         "device": "Device Name",
         "autoRoute": "Auto Route",
         "routeExcludeAddress": "Route Exclude Address",
@@ -602,7 +602,7 @@
         "global": "Global Mode",
         "openOrCloseDashboard": "Open/Close Dashboard",
         "toggleSystemProxy": "Enable/Disable System Proxy",
-        "toggleTunMode": "Enable/Disable Tun Mode",
+        "toggleTunMode": "Enable/Disable Virtual NIC",
         "entryLightweightMode": "Entry Lightweight Mode",
         "direct": "Direct Mode",
         "reactivateProfiles": "Reactivate Profiles"

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -11,7 +11,7 @@
     "system": {
       "title": "System Setting",
       "toggles": {
-        "tunMode": "Virtual NIC",
+        "tunMode": "TUN Mode",
         "systemProxy": "System Proxy"
       },
       "tooltips": {
@@ -23,16 +23,16 @@
       },
       "notifications": {
         "tunMode": {
-          "autoDisabled": "Virtual NIC automatically disabled due to service unavailable",
-          "autoDisableFailed": "Failed to disable Virtual NIC automatically"
+          "autoDisabled": "TUN Mode automatically disabled due to service unavailable",
+          "autoDisableFailed": "Failed to disable TUN Mode automatically"
         }
       }
     },
     "proxyControl": {
       "tooltips": {
         "systemProxy": "Enable to modify the operating system's proxy settings. If enabling fails, modify the operating system's proxy settings manually",
-        "tunMode": "Virtual NIC (TUN) captures all system traffic, so System Proxy is not required when enabled.",
-        "tunUnavailable": "Virtual NIC requires Service Mode or Admin Mode"
+        "tunMode": "TUN Mode captures all system traffic, so System Proxy is not required when enabled.",
+        "tunUnavailable": "TUN Mode requires Service Mode or Admin Mode"
       },
       "actions": {
         "installService": "Install Service",
@@ -40,7 +40,7 @@
       },
       "fields": {
         "systemProxy": "System Proxy",
-        "tunMode": "Virtual NIC"
+        "tunMode": "TUN Mode"
       }
     },
     "externalController": {
@@ -238,7 +238,7 @@
           "showOutboundModesInline": "Show Outbound Modes Inline",
           "commonTrayIcon": "Common Tray Icon",
           "systemProxyTrayIcon": "System Proxy Tray Icon",
-          "tunTrayIcon": "Virtual NIC Tray Icon",
+          "tunTrayIcon": "TUN Mode Tray Icon",
           "enableTrayIcon": "Enable Tray Icon",
           "enableTraySpeed": "Enable Tray Speed",
           "pauseRenderTrafficStatsOnBlur": "Pause rendering traffic statistics when blurred"
@@ -465,7 +465,7 @@
       }
     },
     "tun": {
-      "title": "Virtual NIC Settings",
+      "title": "TUN Mode Settings",
       "fields": {
         "stack": "TUN Stack",
         "device": "Device Name",
@@ -602,7 +602,7 @@
         "global": "Global Mode",
         "openOrCloseDashboard": "Open/Close Dashboard",
         "toggleSystemProxy": "Enable/Disable System Proxy",
-        "toggleTunMode": "Enable/Disable Virtual NIC",
+        "toggleTunMode": "Enable/Disable TUN Mode",
         "entryLightweightMode": "Entry Lightweight Mode",
         "direct": "Direct Mode",
         "reactivateProfiles": "Reactivate Profiles"

--- a/src/locales/zh/home.json
+++ b/src/locales/zh/home.json
@@ -31,13 +31,13 @@
       "status": {
         "systemProxyEnabled": "系统代理已启用，您的应用将通过代理访问网络",
         "systemProxyDisabled": "系统代理已关闭，建议大多数用户打开此选项",
-        "tunModeServiceRequired": "虚拟网卡需要服务模式，请先安装服务",
-        "tunModeEnabled": "虚拟网卡已启用，应用流量将通过虚拟网卡访问网络",
-        "tunModeDisabled": "虚拟网卡已关闭，适用于不遵循系统代理的应用"
+        "tunModeServiceRequired": "TUN 模式需要服务模式，请先安装服务",
+        "tunModeEnabled": "TUN 模式已启用，应用流量将通过 TUN 模式访问网络",
+        "tunModeDisabled": "TUN 模式已关闭，适用于不遵循系统代理的应用"
       },
       "tooltips": {
         "systemProxy": "修改操作系统的代理设置，如果开启失败，可手动修改操作系统的代理设置",
-        "tunMode": "虚拟网卡模式（TUN）可以接管所有应用流量，适用于不遵循系统代理设置的应用"
+        "tunMode": "TUN 模式可以接管所有应用流量，适用于不遵循系统代理设置的应用"
       }
     },
     "clashInfo": {

--- a/src/locales/zh/home.json
+++ b/src/locales/zh/home.json
@@ -7,14 +7,14 @@
     },
     "cards": {
       "trafficStats": "流量统计",
-      "networkSettings": "网络设置",
+      "networkSettings": "代理开关",
       "proxyMode": "代理模式"
     },
     "settings": {
       "cards": {
         "profile": "订阅卡",
         "currentProxy": "当前代理卡",
-        "network": "网络设置卡",
+        "network": "代理开关卡",
         "proxyMode": "代理模式卡",
         "traffic": "流量统计卡",
         "tests": "网站测试卡",
@@ -31,13 +31,13 @@
       "status": {
         "systemProxyEnabled": "系统代理已启用，您的应用将通过代理访问网络",
         "systemProxyDisabled": "系统代理已关闭，建议大多数用户打开此选项",
-        "tunModeServiceRequired": "TUN 模式需要服务模式，请先安装服务",
-        "tunModeEnabled": "TUN 模式已启用，应用将通过虚拟网卡访问网络",
-        "tunModeDisabled": "TUN 模式已关闭，适用于特殊应用"
+        "tunModeServiceRequired": "虚拟网卡需要服务模式，请先安装服务",
+        "tunModeEnabled": "虚拟网卡已启用，应用流量将通过虚拟网卡访问网络",
+        "tunModeDisabled": "虚拟网卡已关闭，适用于不遵循系统代理的应用"
       },
       "tooltips": {
         "systemProxy": "修改操作系统的代理设置，如果开启失败，可手动修改操作系统的代理设置",
-        "tunMode": "TUN 模式可以接管所有应用流量，适用于特殊不遵循系统代理设置的应用"
+        "tunMode": "虚拟网卡模式（TUN）可以接管所有应用流量，适用于不遵循系统代理设置的应用"
       }
     },
     "clashInfo": {

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -11,7 +11,7 @@
     "system": {
       "title": "系统设置",
       "toggles": {
-        "tunMode": "虚拟网卡模式",
+        "tunMode": "虚拟网卡",
         "systemProxy": "系统代理"
       },
       "tooltips": {
@@ -23,16 +23,16 @@
       },
       "notifications": {
         "tunMode": {
-          "autoDisabled": "由于服务不可用，TUN 模式已自动关闭",
-          "autoDisableFailed": "自动关闭 TUN 模式失败"
+          "autoDisabled": "由于服务不可用，虚拟网卡已自动关闭",
+          "autoDisableFailed": "自动关闭虚拟网卡失败"
         }
       }
     },
     "proxyControl": {
       "tooltips": {
         "systemProxy": "修改操作系统的代理设置，如果开启失败，可手动修改操作系统的代理设置",
-        "tunMode": "TUN（虚拟网卡）模式接管系统所有流量，启用时无须打开系统代理",
-        "tunUnavailable": "TUN 模式需要安装服务模式或管理员模式"
+        "tunMode": "虚拟网卡模式（TUN）接管系统所有流量，启用时无须打开系统代理",
+        "tunUnavailable": "虚拟网卡需要服务模式或管理员模式"
       },
       "actions": {
         "installService": "安装服务",
@@ -40,7 +40,7 @@
       },
       "fields": {
         "systemProxy": "系统代理",
-        "tunMode": "虚拟网卡模式"
+        "tunMode": "虚拟网卡"
       }
     },
     "externalController": {
@@ -238,7 +238,7 @@
           "showOutboundModesInline": "将出站模式显示在托盘一级菜单",
           "commonTrayIcon": "常规托盘图标",
           "systemProxyTrayIcon": "系统代理托盘图标",
-          "tunTrayIcon": "TUN 模式托盘图标",
+          "tunTrayIcon": "虚拟网卡托盘图标",
           "enableTrayIcon": "启用托盘图标",
           "enableTraySpeed": "启用托盘速率",
           "pauseRenderTrafficStatsOnBlur": "失去焦点时暂停渲染流量统计"
@@ -465,9 +465,9 @@
       }
     },
     "tun": {
-      "title": "虚拟网卡模式",
+      "title": "虚拟网卡设置",
       "fields": {
-        "stack": "TUN 模式堆栈",
+        "stack": "TUN 堆栈",
         "device": "虚拟网卡名称",
         "autoRoute": "自动设置全局路由",
         "routeExcludeAddress": "排除自定义网段",
@@ -602,7 +602,7 @@
         "global": "全局模式",
         "openOrCloseDashboard": "打开/关闭面板",
         "toggleSystemProxy": "打开/关闭系统代理",
-        "toggleTunMode": "打开/关闭 TUN 模式",
+        "toggleTunMode": "打开/关闭虚拟网卡",
         "entryLightweightMode": "进入轻量模式",
         "direct": "直连模式",
         "reactivateProfiles": "重新激活订阅"

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -11,7 +11,7 @@
     "system": {
       "title": "系统设置",
       "toggles": {
-        "tunMode": "虚拟网卡",
+        "tunMode": "TUN 模式",
         "systemProxy": "系统代理"
       },
       "tooltips": {
@@ -23,16 +23,16 @@
       },
       "notifications": {
         "tunMode": {
-          "autoDisabled": "由于服务不可用，虚拟网卡已自动关闭",
-          "autoDisableFailed": "自动关闭虚拟网卡失败"
+          "autoDisabled": "由于服务不可用，TUN 模式已自动关闭",
+          "autoDisableFailed": "自动关闭 TUN 模式失败"
         }
       }
     },
     "proxyControl": {
       "tooltips": {
         "systemProxy": "修改操作系统的代理设置，如果开启失败，可手动修改操作系统的代理设置",
-        "tunMode": "虚拟网卡模式（TUN）接管系统所有流量，启用时无须打开系统代理",
-        "tunUnavailable": "虚拟网卡需要服务模式或管理员模式"
+        "tunMode": "TUN 模式接管系统所有流量，启用时无须打开系统代理",
+        "tunUnavailable": "TUN 模式需要服务模式或管理员模式"
       },
       "actions": {
         "installService": "安装服务",
@@ -40,7 +40,7 @@
       },
       "fields": {
         "systemProxy": "系统代理",
-        "tunMode": "虚拟网卡"
+        "tunMode": "TUN 模式"
       }
     },
     "externalController": {
@@ -238,7 +238,7 @@
           "showOutboundModesInline": "将出站模式显示在托盘一级菜单",
           "commonTrayIcon": "常规托盘图标",
           "systemProxyTrayIcon": "系统代理托盘图标",
-          "tunTrayIcon": "虚拟网卡托盘图标",
+          "tunTrayIcon": "TUN 模式托盘图标",
           "enableTrayIcon": "启用托盘图标",
           "enableTraySpeed": "启用托盘速率",
           "pauseRenderTrafficStatsOnBlur": "失去焦点时暂停渲染流量统计"
@@ -465,7 +465,7 @@
       }
     },
     "tun": {
-      "title": "虚拟网卡设置",
+      "title": "TUN 模式设置",
       "fields": {
         "stack": "TUN 堆栈",
         "device": "虚拟网卡名称",
@@ -602,7 +602,7 @@
         "global": "全局模式",
         "openOrCloseDashboard": "打开/关闭面板",
         "toggleSystemProxy": "打开/关闭系统代理",
-        "toggleTunMode": "打开/关闭虚拟网卡",
+        "toggleTunMode": "打开/关闭 TUN 模式",
         "entryLightweightMode": "进入轻量模式",
         "direct": "直连模式",
         "reactivateProfiles": "重新激活订阅"

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -211,7 +211,7 @@ const HomeSettingsDialog = ({
 const HomePage = () => {
   const { t } = useTranslation()
   const { verge } = useVerge()
-  const { current, mutateProfiles } = useProfiles()
+  const { current } = useProfiles()
 
   // 设置弹窗的状态
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -286,15 +286,12 @@ const HomePage = () => {
 
   const criticalCards = useMemo(
     () => [
-      renderCard(
-        'profile',
-        <HomeProfileCard current={current} onProfileUpdated={mutateProfiles} />,
-      ),
+      renderCard('profile', <HomeProfileCard current={current} />),
       renderCard('proxy', <CurrentProxyCard />),
       renderCard('network', <NetworkSettingsCard />),
       renderCard('mode', <ClashModeEnhancedCard />),
     ],
-    [current, mutateProfiles, renderCard],
+    [current, renderCard],
   )
 
   // 新增：保存设置时用requestIdleCallback/setTimeout


### PR DESCRIPTION
## 改动说明

本 PR 主要解决代理页中导航按钮太靠近节点列表和滚动条区域的问题。文案和交互调整可视情况拆成独立 PR。

- 调整代理组右侧导航按钮和节点列表的间距，减少误触导航按钮或滚动条的情况。
- 默认关闭代理组导航的悬停跳转功能。
- 简化首页“系统代理 / TUN 模式”的重复提示文案。
- 将首页“网络设置”调整为“代理开关”，并统一部分 TUN 模式相关命名。
- 移除首页点击“更新时间”更新订阅的隐藏交互。
- 将首页订阅信息中的中文标签冒号改为全角冒号。

## 测试

- `pnpm typecheck`
- pre-commit 已在主要改动提交中通过：
  - `cargo fmt`
  - i18n format / types
  - lint-staged