### PR TITLE
 fix(frontend): reduce long-running memory pressure in connections

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,5 @@
 <summary><strong> 🚀 优化改进 </strong></summary>
 
 - 关闭 autofill 弹出窗口
-- 优化前端性能
 
 </details>

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - 修复 gzip 压缩订阅响应被当作无效 YAML 导致导入失败的问题
 - 修复订阅 URL 使用空密码 Basic Auth 时未发送认证信息的问题
 - Linux 托盘可能与其他 tauri 程序托盘冲突导致图标异常
+- 修复前端 Connection 页面导致的内存泄漏
 
 <details>
 <summary><strong> ✨ 新增功能 </strong></summary>
@@ -19,5 +20,6 @@
 <summary><strong> 🚀 优化改进 </strong></summary>
 
 - 关闭 autofill 弹出窗口
+- 优化前端性能
 
 </details>

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@
 - 修复 gzip 压缩订阅响应被当作无效 YAML 导致导入失败的问题
 - 修复订阅 URL 使用空密码 Basic Auth 时未发送认证信息的问题
 - Linux 托盘可能与其他 tauri 程序托盘冲突导致图标异常
-- 修复前端 Connection 页面导致的内存泄漏
+- 修复前端连接页面导致的内存泄漏
 
 <details>
 <summary><strong> ✨ 新增功能 </strong></summary>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",
     "@tanstack/react-query": "^5.100.14",
-    "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.25",
     "@tauri-apps/api": "2.11.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.100.14
         version: 5.100.14(react@19.2.6)
-      '@tanstack/react-table':
-        specifier: ^8.21.3
-        version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-virtual':
         specifier: ^3.13.25
         version: 3.13.25(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1483,22 +1480,11 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
   '@tanstack/react-virtual@3.13.25':
     resolution: {integrity: sha512-bmNoqMu6gcAW9JGrKVB0Q1tN1i5RONZF8r1fW0bbE4Oyf3DwEGnzzQJ2OW+Ozg1P4s8PyugkHg2ULZoFQN+cqw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.15.0':
     resolution: {integrity: sha512-0AwPGx0I8QxPYjAxShT/+z+ZOe9u8mW5rsXvivCTjRfRmz9a43+3mRyi4wwlyoUqOC56q/jatKa0Bh9M99BEHQ==}
@@ -5002,19 +4988,11 @@ snapshots:
       '@tanstack/query-core': 5.100.14
       react: 19.2.6
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@tanstack/table-core': 8.21.3
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
   '@tanstack/react-virtual@3.13.25(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/virtual-core': 3.15.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-
-  '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.15.0': {}
 

--- a/src/components/connection/connection-column-manager.tsx
+++ b/src/components/connection/connection-column-manager.tsx
@@ -21,13 +21,19 @@ import {
   ListItem,
   ListItemText,
 } from '@mui/material'
-import type { Column } from '@tanstack/react-table'
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
+export interface ConnectionColumnOption {
+  id: string
+  label: string
+  visible: boolean
+  toggleVisibility: (visible: boolean) => void
+}
+
 interface Props {
   open: boolean
-  columns: Column<IConnectionsItem, unknown>[]
+  columns: ConnectionColumnOption[]
   onClose: () => void
   onOrderChange: (order: string[]) => void
   onReset: () => void
@@ -49,7 +55,7 @@ export const ConnectionColumnManager = ({
 
   const items = useMemo(() => columns.map((column) => column.id), [columns])
   const visibleCount = useMemo(
-    () => columns.filter((column) => column.getIsVisible()).length,
+    () => columns.filter((column) => column.visible).length,
     [columns],
   )
 
@@ -89,14 +95,10 @@ export const ConnectionColumnManager = ({
                 <SortableColumnItem
                   key={column.id}
                   column={column}
-                  label={getColumnLabel(column)}
                   dragHandleLabel={t(
                     'connections.components.columnManager.dragHandle',
                   )}
-                  disableToggle={
-                    !column.getCanHide() ||
-                    (column.getIsVisible() && visibleCount <= 1)
-                  }
+                  disableToggle={column.visible && visibleCount <= 1}
                 />
               ))}
             </List>
@@ -116,15 +118,13 @@ export const ConnectionColumnManager = ({
 }
 
 interface SortableColumnItemProps {
-  column: Column<IConnectionsItem, unknown>
-  label: string
+  column: ConnectionColumnOption
   dragHandleLabel: string
   disableToggle?: boolean
 }
 
 const SortableColumnItem = ({
   column,
-  label,
   dragHandleLabel,
   disableToggle = false,
 }: SortableColumnItemProps) => {
@@ -163,12 +163,12 @@ const SortableColumnItem = ({
     >
       <Checkbox
         edge="start"
-        checked={column.getIsVisible()}
+        checked={column.visible}
         disabled={disableToggle}
         onChange={(event) => column.toggleVisibility(event.target.checked)}
       />
       <ListItemText
-        primary={label}
+        primary={column.label}
         slotProps={{ primary: { variant: 'body2' } }}
         sx={{ mr: 1 }}
       />
@@ -184,12 +184,4 @@ const SortableColumnItem = ({
       </IconButton>
     </ListItem>
   )
-}
-
-const getColumnLabel = (column: Column<IConnectionsItem, unknown>) => {
-  const meta = column.columnDef.meta as { label?: string } | undefined
-  if (meta?.label) return meta.label
-
-  const header = column.columnDef.header
-  return typeof header === 'string' ? header : column.id
 }

--- a/src/components/connection/connection-detail.tsx
+++ b/src/components/connection/connection-detail.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Snackbar, useTheme } from '@mui/material'
 import { useLockFn } from 'ahooks'
 import dayjs from 'dayjs'
-import { useImperativeHandle, useState, type Ref } from 'react'
+import { useCallback, useImperativeHandle, useState, type Ref } from 'react'
 import { useTranslation } from 'react-i18next'
 import { closeConnection } from 'tauri-plugin-mihomo-api'
 
@@ -9,13 +9,20 @@ import parseTraffic from '@/utils/parse-traffic'
 
 export interface ConnectionDetailRef {
   open: (detail: IConnectionsItem, closed: boolean) => void
+  close: () => void
 }
 
 export function ConnectionDetail({ ref }: { ref?: Ref<ConnectionDetailRef> }) {
   const [open, setOpen] = useState(false)
-  const [detail, setDetail] = useState<IConnectionsItem>(null!)
+  const [detail, setDetail] = useState<IConnectionsItem | null>(null)
   const [closed, setClosed] = useState(false)
   const theme = useTheme()
+
+  const onClose = useCallback(() => {
+    setOpen(false)
+    setDetail(null)
+    setClosed(false)
+  }, [])
 
   useImperativeHandle(ref, () => ({
     open: (detail: IConnectionsItem, closed: boolean) => {
@@ -24,9 +31,8 @@ export function ConnectionDetail({ ref }: { ref?: Ref<ConnectionDetailRef> }) {
       setDetail(detail)
       setClosed(closed)
     },
+    close: onClose,
   }))
-
-  const onClose = () => setOpen(false)
 
   return (
     <Snackbar

--- a/src/components/connection/connection-relative-time.tsx
+++ b/src/components/connection/connection-relative-time.tsx
@@ -1,0 +1,54 @@
+import dayjs from 'dayjs'
+import { memo, useSyncExternalStore } from 'react'
+
+type RelativeTimeListener = () => void
+
+let currentTime = Date.now()
+let timerId: number | null = null
+const listeners: RelativeTimeListener[] = []
+
+const startTimer = () => {
+  if (timerId !== null) return
+
+  timerId = window.setInterval(() => {
+    currentTime = Date.now()
+    for (let i = 0; i < listeners.length; i++) {
+      listeners[i]()
+    }
+  }, 5_000)
+}
+
+const stopTimer = () => {
+  if (listeners.length > 0 || timerId === null) return
+
+  window.clearInterval(timerId)
+  timerId = null
+}
+
+const subscribeRelativeTime = (listener: RelativeTimeListener) => {
+  listeners.push(listener)
+  startTimer()
+
+  return () => {
+    const index = listeners.indexOf(listener)
+    if (index !== -1) listeners.splice(index, 1)
+    stopTimer()
+  }
+}
+
+const getRelativeTimeSnapshot = () => currentTime
+
+interface RelativeTimeProps {
+  start: string
+}
+
+export const RelativeTime = memo(function RelativeTime({
+  start,
+}: RelativeTimeProps) {
+  const now = useSyncExternalStore(
+    subscribeRelativeTime,
+    getRelativeTimeSnapshot,
+    getRelativeTimeSnapshot,
+  )
+  return <>{dayjs(start).from(now)}</>
+})

--- a/src/components/connection/connection-relative-time.tsx
+++ b/src/components/connection/connection-relative-time.tsx
@@ -5,33 +5,31 @@ type RelativeTimeListener = () => void
 
 let currentTime = Date.now()
 let timerId: number | null = null
-const listeners: RelativeTimeListener[] = []
+const listeners = new Set<RelativeTimeListener>()
 
 const startTimer = () => {
   if (timerId !== null) return
 
+  currentTime = Date.now()
   timerId = window.setInterval(() => {
     currentTime = Date.now()
-    for (let i = 0; i < listeners.length; i++) {
-      listeners[i]()
-    }
+    listeners.forEach((listener) => listener())
   }, 5_000)
 }
 
 const stopTimer = () => {
-  if (listeners.length > 0 || timerId === null) return
+  if (listeners.size > 0 || timerId === null) return
 
   window.clearInterval(timerId)
   timerId = null
 }
 
 const subscribeRelativeTime = (listener: RelativeTimeListener) => {
-  listeners.push(listener)
+  listeners.add(listener)
   startTimer()
 
   return () => {
-    const index = listeners.indexOf(listener)
-    if (index !== -1) listeners.splice(index, 1)
+    listeners.delete(listener)
     stopTimer()
   }
 }

--- a/src/components/connection/connection-row-item.tsx
+++ b/src/components/connection/connection-row-item.tsx
@@ -5,6 +5,7 @@ import { memo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { closeConnection } from 'tauri-plugin-mihomo-api'
 
+import { RelativeTime } from './connection-relative-time'
 import type { ConnectionRowView } from './connection-row-view'
 
 interface Props {
@@ -87,7 +88,9 @@ export const ConnectionRowItem = memo(
             <span style={tagStyle}>{row.type}</span>
             {row.process && <span style={tagStyle}>{row.process}</span>}
             {row.chains && <span style={tagStyle}>{row.chains}</span>}
-            <span style={tagStyle}>{row.time}</span>
+            <span style={tagStyle}>
+              <RelativeTime start={row.time} />
+            </span>
             {showTraffic && (
               <span style={tagStyle}>
                 {row.uploadSpeedText} / {row.downloadSpeedText}

--- a/src/components/connection/connection-row-item.tsx
+++ b/src/components/connection/connection-row-item.tsx
@@ -1,0 +1,117 @@
+import { CloseRounded } from '@mui/icons-material'
+import { IconButton } from '@mui/material'
+import { useLockFn } from 'ahooks'
+import { memo, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { closeConnection } from 'tauri-plugin-mihomo-api'
+
+import type { ConnectionRowView } from './connection-row-view'
+
+interface Props {
+  row: ConnectionRowView
+  closed: boolean
+  onShowDetail: (id: string) => void
+}
+
+const tagStyle = {
+  boxSizing: 'border-box',
+  maxWidth: '100%',
+  padding: '0 4px',
+  border: '1px solid rgba(128,128,128,0.35)',
+  borderRadius: 4,
+  fontSize: 10,
+  lineHeight: 1.375,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+} as const
+
+const itemStyle = {
+  boxSizing: 'border-box',
+  minHeight: 56,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '6px 48px 6px 12px',
+  borderBottom: '1px solid var(--divider-color)',
+  position: 'relative',
+  overflow: 'hidden',
+} as const
+
+const contentStyle = {
+  minWidth: 0,
+  flex: 1,
+  cursor: 'pointer',
+  userSelect: 'text',
+} as const
+
+const primaryStyle = {
+  fontSize: 14,
+  lineHeight: 1.4,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+} as const
+
+const tagsStyle = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 4,
+  marginTop: 4,
+  overflow: 'hidden',
+} as const
+
+const actionStyle = {
+  position: 'absolute',
+  right: 8,
+  top: '50%',
+  transform: 'translateY(-50%)',
+} as const
+
+export const ConnectionRowItem = memo(
+  function ConnectionRowItem({ row, closed, onShowDetail }: Props) {
+    const { t } = useTranslation()
+    const onDelete = useLockFn(async () => closeConnection(row.id))
+    const handleShowDetail = useCallback(
+      () => onShowDetail(row.id),
+      [onShowDetail, row.id],
+    )
+    const showTraffic = row.uploadSpeed >= 100 || row.downloadSpeed >= 100
+
+    return (
+      <div style={itemStyle}>
+        <div style={contentStyle} onClick={handleShowDetail}>
+          <div style={primaryStyle}>{row.host}</div>
+          <div style={tagsStyle}>
+            <span style={tagStyle}>{row.network}</span>
+            <span style={tagStyle}>{row.type}</span>
+            {row.process && <span style={tagStyle}>{row.process}</span>}
+            {row.chains && <span style={tagStyle}>{row.chains}</span>}
+            <span style={tagStyle}>{row.time}</span>
+            {showTraffic && (
+              <span style={tagStyle}>
+                {row.uploadSpeedText} / {row.downloadSpeedText}
+              </span>
+            )}
+          </div>
+        </div>
+        {!closed && (
+          <IconButton
+            size="small"
+            color="inherit"
+            onClick={onDelete}
+            title={t('connections.components.actions.closeConnection')}
+            aria-label={t('connections.components.actions.closeConnection')}
+            sx={actionStyle}
+          >
+            <CloseRounded fontSize="small" />
+          </IconButton>
+        )}
+      </div>
+    )
+  },
+  (prev, next) =>
+    prev.row === next.row &&
+    prev.closed === next.closed &&
+    prev.onShowDetail === next.onShowDetail,
+)

--- a/src/components/connection/connection-row-view.ts
+++ b/src/components/connection/connection-row-view.ts
@@ -111,7 +111,6 @@ const sameConnectionRowView = (
   left.download === right.download &&
   left.uploadSpeed === right.uploadSpeed &&
   left.downloadSpeed === right.downloadSpeed &&
-  left.startTime === right.startTime &&
   left.searchableHost === right.searchableHost &&
   left.searchableDestinationIP === right.searchableDestinationIP &&
   left.searchableProcess === right.searchableProcess

--- a/src/components/connection/connection-row-view.ts
+++ b/src/components/connection/connection-row-view.ts
@@ -124,6 +124,7 @@ export const useConnectionRowViews = (
 
   const rows = useMemo(() => {
     const previousRows = previousRowsRef.current
+    const previousConnections = latestConnectionsRef.current
     const nextRows = new Map<string, ConnectionRowView>()
     const latestConnections = new Map<string, IConnectionsItem>()
     const nextList: ConnectionRowView[] = []
@@ -131,12 +132,18 @@ export const useConnectionRowViews = (
     connections.forEach((connection) => {
       latestConnections.set(connection.id, connection)
 
-      const nextRow = createConnectionRowView(connection)
       const previousRow = previousRows.get(connection.id)
-      const row =
-        previousRow && sameConnectionRowView(previousRow, nextRow)
-          ? previousRow
-          : nextRow
+      const previousConnection = previousConnections.get(connection.id)
+      let row: ConnectionRowView
+      if (previousRow && previousConnection === connection) {
+        row = previousRow
+      } else {
+        const nextRow = createConnectionRowView(connection)
+        row =
+          previousRow && sameConnectionRowView(previousRow, nextRow)
+            ? previousRow
+            : nextRow
+      }
 
       nextRows.set(connection.id, row)
       nextList.push(row)

--- a/src/components/connection/connection-row-view.ts
+++ b/src/components/connection/connection-row-view.ts
@@ -1,0 +1,156 @@
+import { useCallback, useMemo, useRef } from 'react'
+
+const TRAFFIC_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+export interface ConnectionRowView {
+  id: string
+  host: string
+  process: string
+  network: string
+  type: string
+  chains: string
+  rule: string
+  time: string
+  source: string
+  destination: string
+  uploadText: string
+  downloadText: string
+  uploadSpeedText: string
+  downloadSpeedText: string
+  upload: number
+  download: number
+  uploadSpeed: number
+  downloadSpeed: number
+  startTime: number
+  searchableHost: string
+  searchableDestinationIP: string
+  searchableProcess: string
+}
+
+export interface ConnectionRowViews {
+  rows: ConnectionRowView[]
+  getConnectionById: (id: string) => IConnectionsItem | undefined
+}
+
+const formatTraffic = (value?: number) => {
+  if (typeof value !== 'number') return 'NaN'
+
+  const exp =
+    value < 1
+      ? 0
+      : Math.min(Math.floor(Math.log2(value) / 10), TRAFFIC_UNITS.length - 1)
+  const data = value / 1024 ** exp
+  const text = data >= 1000 ? data.toFixed(0) : data.toPrecision(3)
+  return `${text} ${TRAFFIC_UNITS[exp]}`
+}
+
+const formatChains = (chains: string[]) => {
+  let value = ''
+  for (let i = chains.length - 1; i >= 0; i -= 1) {
+    if (value) value += ' / '
+    value += chains[i]
+  }
+  return value
+}
+
+const createConnectionRowView = (connection: IConnectionsItem) => {
+  const { metadata, rulePayload } = connection
+  const destination = metadata.destinationIP
+    ? `${metadata.destinationIP}:${metadata.destinationPort}`
+    : `${metadata.remoteDestination}:${metadata.destinationPort}`
+  const host = metadata.host
+    ? `${metadata.host}:${metadata.destinationPort}`
+    : `${metadata.remoteDestination}:${metadata.destinationPort}`
+  const uploadSpeed = connection.curUpload ?? 0
+  const downloadSpeed = connection.curDownload ?? 0
+
+  return {
+    id: connection.id,
+    host,
+    process: metadata.process || metadata.processPath || '',
+    network: metadata.network,
+    type: metadata.type,
+    chains: formatChains(connection.chains),
+    rule: rulePayload ? `${connection.rule}(${rulePayload})` : connection.rule,
+    time: connection.start,
+    source: `${metadata.sourceIP}:${metadata.sourcePort}`,
+    destination,
+    uploadText: formatTraffic(connection.upload),
+    downloadText: formatTraffic(connection.download),
+    uploadSpeedText: `${formatTraffic(uploadSpeed)}/s`,
+    downloadSpeedText: `${formatTraffic(downloadSpeed)}/s`,
+    upload: connection.upload ?? 0,
+    download: connection.download ?? 0,
+    uploadSpeed,
+    downloadSpeed,
+    startTime: Date.parse(connection.start || '') || 0,
+    searchableHost: metadata.host || '',
+    searchableDestinationIP: metadata.destinationIP || '',
+    searchableProcess: metadata.process || '',
+  } satisfies ConnectionRowView
+}
+
+const sameConnectionRowView = (
+  left: ConnectionRowView,
+  right: ConnectionRowView,
+) =>
+  left.host === right.host &&
+  left.process === right.process &&
+  left.network === right.network &&
+  left.type === right.type &&
+  left.chains === right.chains &&
+  left.rule === right.rule &&
+  left.time === right.time &&
+  left.source === right.source &&
+  left.destination === right.destination &&
+  left.uploadText === right.uploadText &&
+  left.downloadText === right.downloadText &&
+  left.uploadSpeedText === right.uploadSpeedText &&
+  left.downloadSpeedText === right.downloadSpeedText &&
+  left.upload === right.upload &&
+  left.download === right.download &&
+  left.uploadSpeed === right.uploadSpeed &&
+  left.downloadSpeed === right.downloadSpeed &&
+  left.startTime === right.startTime &&
+  left.searchableHost === right.searchableHost &&
+  left.searchableDestinationIP === right.searchableDestinationIP &&
+  left.searchableProcess === right.searchableProcess
+
+export const useConnectionRowViews = (
+  connections: IConnectionsItem[],
+): ConnectionRowViews => {
+  const previousRowsRef = useRef(new Map<string, ConnectionRowView>())
+  const latestConnectionsRef = useRef(new Map<string, IConnectionsItem>())
+
+  const rows = useMemo(() => {
+    const previousRows = previousRowsRef.current
+    const nextRows = new Map<string, ConnectionRowView>()
+    const latestConnections = new Map<string, IConnectionsItem>()
+    const nextList: ConnectionRowView[] = []
+
+    connections.forEach((connection) => {
+      latestConnections.set(connection.id, connection)
+
+      const nextRow = createConnectionRowView(connection)
+      const previousRow = previousRows.get(connection.id)
+      const row =
+        previousRow && sameConnectionRowView(previousRow, nextRow)
+          ? previousRow
+          : nextRow
+
+      nextRows.set(connection.id, row)
+      nextList.push(row)
+    })
+
+    previousRowsRef.current = nextRows
+    latestConnectionsRef.current = latestConnections
+    return nextList
+  }, [connections])
+
+  const getConnectionById = useCallback(
+    (id: string) => latestConnectionsRef.current.get(id),
+    [],
+  )
+
+  return { rows, getConnectionById }
+}

--- a/src/components/connection/connection-row-view.ts
+++ b/src/components/connection/connection-row-view.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useMemo, useRef } from 'react'
 
 const TRAFFIC_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
 
@@ -27,12 +27,7 @@ export interface ConnectionRowView {
   searchableProcess: string
 }
 
-export interface ConnectionRowViews {
-  rows: ConnectionRowView[]
-  getConnectionById: (id: string) => IConnectionsItem | undefined
-}
-
-const formatTraffic = (value?: number) => {
+export const formatConnectionTraffic = (value?: number) => {
   if (typeof value !== 'number') return 'NaN'
 
   const exp =
@@ -44,7 +39,7 @@ const formatTraffic = (value?: number) => {
   return `${text} ${TRAFFIC_UNITS[exp]}`
 }
 
-const formatChains = (chains: string[]) => {
+export const formatConnectionChains = (chains: string[]) => {
   let value = ''
   for (let i = chains.length - 1; i >= 0; i -= 1) {
     if (value) value += ' / '
@@ -53,40 +48,70 @@ const formatChains = (chains: string[]) => {
   return value
 }
 
-const createConnectionRowView = (connection: IConnectionsItem) => {
-  const { metadata, rulePayload } = connection
-  const destination = metadata.destinationIP
+export const getConnectionDestination = (connection: IConnectionsItem) => {
+  const { metadata } = connection
+  return metadata.destinationIP
     ? `${metadata.destinationIP}:${metadata.destinationPort}`
     : `${metadata.remoteDestination}:${metadata.destinationPort}`
-  const host = metadata.host
+}
+
+export const getConnectionHost = (connection: IConnectionsItem) => {
+  const { metadata } = connection
+  return metadata.host
     ? `${metadata.host}:${metadata.destinationPort}`
     : `${metadata.remoteDestination}:${metadata.destinationPort}`
+}
+
+export const getConnectionProcess = (connection: IConnectionsItem) => {
+  const { metadata } = connection
+  return metadata.process || metadata.processPath || ''
+}
+
+export const getConnectionRule = (connection: IConnectionsItem) => {
+  const { rulePayload } = connection
+  return rulePayload ? `${connection.rule}(${rulePayload})` : connection.rule
+}
+
+export const getConnectionSource = (connection: IConnectionsItem) => {
+  const { metadata } = connection
+  return `${metadata.sourceIP}:${metadata.sourcePort}`
+}
+
+export const getConnectionTypeLabel = (connection: IConnectionsItem) => {
+  const { metadata } = connection
+  return `${metadata.type}(${metadata.network})`
+}
+
+export const getConnectionStartTime = (connection: IConnectionsItem) =>
+  Date.parse(connection.start || '') || 0
+
+const createConnectionRowView = (connection: IConnectionsItem) => {
   const uploadSpeed = connection.curUpload ?? 0
   const downloadSpeed = connection.curDownload ?? 0
 
   return {
     id: connection.id,
-    host,
-    process: metadata.process || metadata.processPath || '',
-    network: metadata.network,
-    type: metadata.type,
-    chains: formatChains(connection.chains),
-    rule: rulePayload ? `${connection.rule}(${rulePayload})` : connection.rule,
+    host: getConnectionHost(connection),
+    process: getConnectionProcess(connection),
+    network: connection.metadata.network,
+    type: connection.metadata.type,
+    chains: formatConnectionChains(connection.chains),
+    rule: getConnectionRule(connection),
     time: connection.start,
-    source: `${metadata.sourceIP}:${metadata.sourcePort}`,
-    destination,
-    uploadText: formatTraffic(connection.upload),
-    downloadText: formatTraffic(connection.download),
-    uploadSpeedText: `${formatTraffic(uploadSpeed)}/s`,
-    downloadSpeedText: `${formatTraffic(downloadSpeed)}/s`,
+    source: getConnectionSource(connection),
+    destination: getConnectionDestination(connection),
+    uploadText: formatConnectionTraffic(connection.upload),
+    downloadText: formatConnectionTraffic(connection.download),
+    uploadSpeedText: `${formatConnectionTraffic(uploadSpeed)}/s`,
+    downloadSpeedText: `${formatConnectionTraffic(downloadSpeed)}/s`,
     upload: connection.upload ?? 0,
     download: connection.download ?? 0,
     uploadSpeed,
     downloadSpeed,
-    startTime: Date.parse(connection.start || '') || 0,
-    searchableHost: metadata.host || '',
-    searchableDestinationIP: metadata.destinationIP || '',
-    searchableProcess: metadata.process || '',
+    startTime: getConnectionStartTime(connection),
+    searchableHost: connection.metadata.host || '',
+    searchableDestinationIP: connection.metadata.destinationIP || '',
+    searchableProcess: connection.metadata.process || '',
   } satisfies ConnectionRowView
 }
 
@@ -115,24 +140,23 @@ const sameConnectionRowView = (
   left.searchableDestinationIP === right.searchableDestinationIP &&
   left.searchableProcess === right.searchableProcess
 
-export const useConnectionRowViews = (
-  connections: IConnectionsItem[],
-): ConnectionRowViews => {
+export const useConnectionRowViews = (connections: IConnectionsItem[]) => {
   const previousRowsRef = useRef(new Map<string, ConnectionRowView>())
-  const latestConnectionsRef = useRef(new Map<string, IConnectionsItem>())
+  const previousConnectionsRef = useRef(new Map<string, IConnectionsItem>())
 
-  const rows = useMemo(() => {
+  return useMemo(() => {
     const previousRows = previousRowsRef.current
-    const previousConnections = latestConnectionsRef.current
+    const previousConnections = previousConnectionsRef.current
     const nextRows = new Map<string, ConnectionRowView>()
-    const latestConnections = new Map<string, IConnectionsItem>()
-    const nextList: ConnectionRowView[] = []
+    const nextConnections = new Map<string, IConnectionsItem>()
+    const rows: ConnectionRowView[] = []
 
     connections.forEach((connection) => {
-      latestConnections.set(connection.id, connection)
+      nextConnections.set(connection.id, connection)
 
       const previousRow = previousRows.get(connection.id)
       const previousConnection = previousConnections.get(connection.id)
+
       let row: ConnectionRowView
       if (previousRow && previousConnection === connection) {
         row = previousRow
@@ -145,18 +169,11 @@ export const useConnectionRowViews = (
       }
 
       nextRows.set(connection.id, row)
-      nextList.push(row)
+      rows.push(row)
     })
 
     previousRowsRef.current = nextRows
-    latestConnectionsRef.current = latestConnections
-    return nextList
+    previousConnectionsRef.current = nextConnections
+    return rows
   }, [connections])
-
-  const getConnectionById = useCallback(
-    (id: string) => latestConnectionsRef.current.get(id),
-    [],
-  )
-
-  return { rows, getConnectionById }
 }

--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -1,5 +1,4 @@
 import { useTheme } from '@mui/material/styles'
-import dayjs from 'dayjs'
 import { useLocalStorage } from 'foxact/use-local-storage'
 import {
   memo,
@@ -8,7 +7,6 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
   type MouseEvent as ReactMouseEvent,
   type TouchEvent as ReactTouchEvent,
   type UIEvent as ReactUIEvent,
@@ -19,54 +17,12 @@ import {
   ConnectionColumnManager,
   type ConnectionColumnOption,
 } from './connection-column-manager'
+import { RelativeTime } from './connection-relative-time'
 import type { ConnectionRowView } from './connection-row-view'
 
 const ROW_HEIGHT = 40
 const RESIZE_HANDLE_WIDTH = 6
 const OVERSCAN_ROWS = 6
-
-type TickListener = () => void
-let _tickNow = Date.now()
-const _tickListeners = new Set<TickListener>()
-let _tickTimer: number | null = null
-
-const _startTick = () => {
-  if (_tickTimer !== null) return
-  _tickTimer = window.setInterval(() => {
-    _tickNow = Date.now()
-    _tickListeners.forEach((fn) => fn())
-  }, 5000)
-}
-
-const _stopTick = () => {
-  if (_tickListeners.size === 0 && _tickTimer !== null) {
-    window.clearInterval(_tickTimer)
-    _tickTimer = null
-  }
-}
-
-const tickStore = {
-  subscribe: (listener: TickListener) => {
-    _tickListeners.add(listener)
-    _startTick()
-    return () => {
-      _tickListeners.delete(listener)
-      _stopTick()
-    }
-  },
-  getSnapshot: () => _tickNow,
-}
-
-interface RelativeTimeCellProps {
-  start: string
-}
-
-const RelativeTimeCell = memo(function RelativeTimeCell({
-  start,
-}: RelativeTimeCellProps) {
-  const now = useSyncExternalStore(tickStore.subscribe, tickStore.getSnapshot)
-  return <>{dayjs(start).from(now)}</>
-})
 
 const reconcileColumnOrder = (
   storedOrder: string[],
@@ -181,7 +137,7 @@ const compareConnectionCellValue = (
 
 const renderCell = (column: DisplayColumn, row: ConnectionRowView) => {
   if (column.cell) return column.cell(row)
-  if (column.field === 'time') return <RelativeTimeCell start={row.time} />
+  if (column.field === 'time') return <RelativeTime start={row.time} />
   return getConnectionCellValue(column.field, row)
 }
 
@@ -441,7 +397,44 @@ export const ConnectionTable = (props: Props) => {
   }, [columnVisibilityModel, columnWidths, orderedColumns])
 
   const [sorting, setSorting] = useState<SortingState | null>(null)
-  const [viewport, setViewport] = useState({ scrollTop: 0, height: 1200 })
+  const [viewport, setViewport] = useState({ scrollTop: 0, height: 0 })
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+
+  const updateViewport = useCallback((element: HTMLDivElement) => {
+    setViewport((current) => {
+      const next = {
+        scrollTop: element.scrollTop,
+        height: element.clientHeight,
+      }
+      return current.scrollTop === next.scrollTop &&
+        current.height === next.height
+        ? current
+        : next
+    })
+  }, [])
+
+  const setScrollContainer = useCallback(
+    (element: HTMLDivElement | null) => {
+      scrollContainerRef.current = element
+      if (element) updateViewport(element)
+    },
+    [updateViewport],
+  )
+
+  useEffect(() => {
+    const element = scrollContainerRef.current
+    if (!element) return
+
+    if (typeof ResizeObserver === 'undefined') {
+      const handleResize = () => updateViewport(element)
+      window.addEventListener('resize', handleResize)
+      return () => window.removeEventListener('resize', handleResize)
+    }
+
+    const observer = new ResizeObserver(() => updateViewport(element))
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [updateViewport])
 
   const sortedConnections = useMemo(() => {
     if (!sorting) return connections
@@ -457,19 +450,12 @@ export const ConnectionTable = (props: Props) => {
     () => visibleColumns.reduce((total, column) => total + column.size, 0),
     [visibleColumns],
   )
-  const handleScroll = useCallback((event: ReactUIEvent<HTMLDivElement>) => {
-    const element = event.currentTarget
-    setViewport((current) => {
-      const next = {
-        scrollTop: element.scrollTop,
-        height: element.clientHeight,
-      }
-      return current.scrollTop === next.scrollTop &&
-        current.height === next.height
-        ? current
-        : next
-    })
-  }, [])
+  const handleScroll = useCallback(
+    (event: ReactUIEvent<HTMLDivElement>) => {
+      updateViewport(event.currentTarget)
+    },
+    [updateViewport],
+  )
 
   const bodyScrollTop = Math.max(0, viewport.scrollTop - ROW_HEIGHT)
   const firstVisibleRow = Math.min(
@@ -630,6 +616,7 @@ export const ConnectionTable = (props: Props) => {
         }}
       >
         <div
+          ref={setScrollContainer}
           onScroll={handleScroll}
           style={{
             flex: 1,

--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -33,6 +33,7 @@ import {
 const ROW_HEIGHT = 40
 const RESIZE_HANDLE_WIDTH = 6
 const OVERSCAN_ROWS = 6
+const MAX_ROW_SNAPSHOT_CACHE_SIZE = 2_000
 
 const reconcileColumnOrder = (
   storedOrder: string[],
@@ -67,7 +68,7 @@ interface BaseColumn {
   minWidth: number
   maxWidth?: number
   align?: 'left' | 'right'
-  cell?: (row: IConnectionsItem) => string
+  cell?: (row: IConnectionsItem, snapshot: TableRowSnapshot) => string
 }
 
 interface DisplayColumn extends BaseColumn {
@@ -77,6 +78,22 @@ interface DisplayColumn extends BaseColumn {
 interface SortingState {
   id: ColumnField
   desc: boolean
+}
+
+interface TableRowSnapshot {
+  row: IConnectionsItem
+  host: string
+  process: string
+  source: string
+  destination: string
+  chainsText: string
+  ruleText: string
+  typeLabel: string
+  startTime: number
+  uploadText: string
+  downloadText: string
+  uploadSpeedText: string
+  downloadSpeedText: string
 }
 
 const resolveColumnSize = (
@@ -93,32 +110,108 @@ const resolveColumnSize = (
     : Math.min(column.maxWidth, boundedMin)
 }
 
-const getConnectionCellValue = (field: ColumnField, row: IConnectionsItem) => {
+const sameStaticConnection = (
+  left: IConnectionsItem,
+  right: IConnectionsItem,
+) =>
+  left.metadata === right.metadata &&
+  left.chains === right.chains &&
+  left.rule === right.rule &&
+  left.rulePayload === right.rulePayload &&
+  left.start === right.start
+
+const sameTrafficConnection = (
+  left: IConnectionsItem,
+  right: IConnectionsItem,
+) =>
+  left.upload === right.upload &&
+  left.download === right.download &&
+  left.curUpload === right.curUpload &&
+  left.curDownload === right.curDownload
+
+const createTableRowSnapshot = (
+  row: IConnectionsItem,
+  previous?: TableRowSnapshot,
+) => {
+  const previousRow = previous?.row
+  const sameStatic = previousRow && sameStaticConnection(previousRow, row)
+  const sameTraffic = previousRow && sameTrafficConnection(previousRow, row)
+
+  if (sameStatic && sameTraffic && previous) return previous
+
+  const upload = row.upload ?? 0
+  const download = row.download ?? 0
+  const curUpload = row.curUpload ?? 0
+  const curDownload = row.curDownload ?? 0
+
+  return {
+    row,
+    host: sameStatic && previous ? previous.host : getConnectionHost(row),
+    process:
+      sameStatic && previous ? previous.process : getConnectionProcess(row),
+    source: sameStatic && previous ? previous.source : getConnectionSource(row),
+    destination:
+      sameStatic && previous
+        ? previous.destination
+        : getConnectionDestination(row),
+    chainsText:
+      sameStatic && previous
+        ? previous.chainsText
+        : formatConnectionChains(row.chains),
+    ruleText:
+      sameStatic && previous ? previous.ruleText : getConnectionRule(row),
+    typeLabel:
+      sameStatic && previous ? previous.typeLabel : getConnectionTypeLabel(row),
+    startTime:
+      sameStatic && previous ? previous.startTime : getConnectionStartTime(row),
+    uploadText:
+      sameTraffic && previous
+        ? previous.uploadText
+        : formatConnectionTraffic(upload),
+    downloadText:
+      sameTraffic && previous
+        ? previous.downloadText
+        : formatConnectionTraffic(download),
+    uploadSpeedText:
+      sameTraffic && previous
+        ? previous.uploadSpeedText
+        : `${formatConnectionTraffic(curUpload)}/s`,
+    downloadSpeedText:
+      sameTraffic && previous
+        ? previous.downloadSpeedText
+        : `${formatConnectionTraffic(curDownload)}/s`,
+  }
+}
+
+const getConnectionCellValue = (
+  field: ColumnField,
+  snapshot: TableRowSnapshot,
+) => {
   switch (field) {
     case 'host':
-      return getConnectionHost(row)
+      return snapshot.host
     case 'download':
-      return row.download ?? 0
+      return snapshot.row.download ?? 0
     case 'upload':
-      return row.upload ?? 0
+      return snapshot.row.upload ?? 0
     case 'dlSpeed':
-      return row.curDownload ?? 0
+      return snapshot.row.curDownload ?? 0
     case 'ulSpeed':
-      return row.curUpload ?? 0
+      return snapshot.row.curUpload ?? 0
     case 'chains':
-      return formatConnectionChains(row.chains)
+      return snapshot.chainsText
     case 'rule':
-      return getConnectionRule(row)
+      return snapshot.ruleText
     case 'process':
-      return getConnectionProcess(row)
+      return snapshot.process
     case 'time':
-      return row.start
+      return snapshot.startTime
     case 'source':
-      return getConnectionSource(row)
+      return snapshot.source
     case 'remoteDestination':
-      return getConnectionDestination(row)
+      return snapshot.destination
     case 'type':
-      return getConnectionTypeLabel(row)
+      return snapshot.typeLabel
     default:
       return ''
   }
@@ -128,13 +221,10 @@ const compareConnectionCellValue = (
   field: ColumnField,
   left: IConnectionsItem,
   right: IConnectionsItem,
+  getSnapshot: (row: IConnectionsItem) => TableRowSnapshot,
 ) => {
-  if (field === 'time') {
-    return getConnectionStartTime(left) - getConnectionStartTime(right)
-  }
-
-  const leftValue = getConnectionCellValue(field, left)
-  const rightValue = getConnectionCellValue(field, right)
+  const leftValue = getConnectionCellValue(field, getSnapshot(left))
+  const rightValue = getConnectionCellValue(field, getSnapshot(right))
 
   if (typeof leftValue === 'number' || typeof rightValue === 'number') {
     return (Number(leftValue) || 0) - (Number(rightValue) || 0)
@@ -143,16 +233,22 @@ const compareConnectionCellValue = (
   return String(leftValue ?? '').localeCompare(String(rightValue ?? ''))
 }
 
-const renderCell = (column: DisplayColumn, row: IConnectionsItem) => {
-  if (column.cell) return column.cell(row)
-  if (column.field === 'time') return <RelativeTime start={row.start} />
-  return getConnectionCellValue(column.field, row)
+const renderCell = (
+  column: DisplayColumn,
+  row: IConnectionsItem,
+  snapshot: TableRowSnapshot,
+) => {
+  if (column.cell) return column.cell(row, snapshot)
+  if (column.field === 'time')
+    return <RelativeTime start={snapshot.row.start} />
+  return getConnectionCellValue(column.field, snapshot)
 }
 
 interface RowComponentProps {
   row: IConnectionsItem
   columns: DisplayColumn[]
   onShowDetail: (id: string) => void
+  getSnapshot: (row: IConnectionsItem) => TableRowSnapshot
   borderColor: string
   virtualTop: number
 }
@@ -162,6 +258,7 @@ const RowComponent = memo(
     row,
     columns,
     onShowDetail,
+    getSnapshot,
     borderColor,
     virtualTop,
   }: RowComponentProps) {
@@ -169,6 +266,7 @@ const RowComponent = memo(
       () => onShowDetail(row.id),
       [onShowDetail, row.id],
     )
+    const snapshot = getSnapshot(row)
 
     return (
       <div
@@ -203,7 +301,7 @@ const RowComponent = memo(
               textOverflow: 'ellipsis',
             }}
           >
-            {renderCell(column, row)}
+            {renderCell(column, row, snapshot)}
           </div>
         ))}
       </div>
@@ -214,6 +312,7 @@ const RowComponent = memo(
     prev.columns === next.columns &&
     prev.virtualTop === next.virtualTop &&
     prev.onShowDetail === next.onShowDetail &&
+    prev.getSnapshot === next.getSnapshot &&
     prev.borderColor === next.borderColor,
 )
 
@@ -293,7 +392,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => formatConnectionTraffic(row.download),
+        cell: (_, snapshot) => snapshot.downloadText,
       },
       {
         field: 'upload',
@@ -301,7 +400,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => formatConnectionTraffic(row.upload),
+        cell: (_, snapshot) => snapshot.uploadText,
       },
       {
         field: 'dlSpeed',
@@ -309,7 +408,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => `${formatConnectionTraffic(row.curDownload ?? 0)}/s`,
+        cell: (_, snapshot) => snapshot.downloadSpeedText,
       },
       {
         field: 'ulSpeed',
@@ -317,7 +416,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => `${formatConnectionTraffic(row.curUpload ?? 0)}/s`,
+        cell: (_, snapshot) => snapshot.uploadSpeedText,
       },
       {
         field: 'chains',
@@ -407,6 +506,17 @@ export const ConnectionTable = (props: Props) => {
   const [sorting, setSorting] = useState<SortingState | null>(null)
   const [viewport, setViewport] = useState({ scrollTop: 0, height: 0 })
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const rowSnapshotCacheRef = useRef(new Map<string, TableRowSnapshot>())
+  const getRowSnapshot = useCallback((row: IConnectionsItem) => {
+    const cache = rowSnapshotCacheRef.current
+    const snapshot = createTableRowSnapshot(row, cache.get(row.id))
+    cache.set(row.id, snapshot)
+    if (cache.size > MAX_ROW_SNAPSHOT_CACHE_SIZE) {
+      const oldestKey = cache.keys().next().value
+      if (oldestKey && oldestKey !== row.id) cache.delete(oldestKey)
+    }
+    return snapshot
+  }, [])
   const updateViewport = useCallback((element: HTMLDivElement) => {
     setViewport((current) => {
       const next = {
@@ -456,15 +566,29 @@ export const ConnectionTable = (props: Props) => {
     element.scrollTop = maxScrollTop
   }, [connections.length])
 
+  useEffect(() => {
+    const cache = rowSnapshotCacheRef.current
+    if (cache.size <= connections.length + OVERSCAN_ROWS * 4) return
+
+    const activeIds = new Set<string>()
+    for (let i = 0; i < connections.length; i++) {
+      activeIds.add(connections[i].id)
+    }
+    cache.forEach((_, id) => {
+      if (!activeIds.has(id)) cache.delete(id)
+    })
+  }, [connections])
+
   const sortedConnections = useMemo(() => {
     if (!sorting) return connections
 
     const direction = sorting.desc ? -1 : 1
     return [...connections].sort(
       (left, right) =>
-        compareConnectionCellValue(sorting.id, left, right) * direction,
+        compareConnectionCellValue(sorting.id, left, right, getRowSnapshot) *
+        direction,
     )
-  }, [connections, sorting])
+  }, [connections, sorting, getRowSnapshot])
 
   const tableWidth = useMemo(
     () => visibleColumns.reduce((total, column) => total + column.size, 0),
@@ -750,6 +874,7 @@ export const ConnectionTable = (props: Props) => {
                       row={row}
                       columns={visibleColumns}
                       onShowDetail={onShowDetail}
+                      getSnapshot={getRowSnapshot}
                       borderColor={borderColor}
                       virtualTop={index * ROW_HEIGHT}
                     />

--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -119,14 +119,12 @@ const compareConnectionCellValue = (
   left: ConnectionRowView,
   right: ConnectionRowView,
 ) => {
+  if (field === 'time') {
+    return left.startTime - right.startTime
+  }
+
   const leftValue = getConnectionCellValue(field, left)
   const rightValue = getConnectionCellValue(field, right)
-
-  if (field === 'time') {
-    const leftTime = Date.parse(String(leftValue || '')) || 0
-    const rightTime = Date.parse(String(rightValue || '')) || 0
-    return leftTime - rightTime
-  }
 
   if (typeof leftValue === 'number' || typeof rightValue === 'number') {
     return (Number(leftValue) || 0) - (Number(rightValue) || 0)

--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -1,18 +1,4 @@
-import { Box } from '@mui/material'
-import {
-  ColumnDef,
-  ColumnOrderState,
-  ColumnSizingState,
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  Row,
-  SortingState,
-  Updater,
-  useReactTable,
-  VisibilityState,
-} from '@tanstack/react-table'
-import { useVirtualizer } from '@tanstack/react-virtual'
+import { useTheme } from '@mui/material/styles'
 import dayjs from 'dayjs'
 import { useLocalStorage } from 'foxact/use-local-storage'
 import {
@@ -23,25 +9,30 @@ import {
   useRef,
   useState,
   useSyncExternalStore,
-  type ReactNode,
+  type MouseEvent as ReactMouseEvent,
+  type TouchEvent as ReactTouchEvent,
+  type UIEvent as ReactUIEvent,
 } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import parseTraffic from '@/utils/parse-traffic'
-import { truncateStr } from '@/utils/truncate-str'
-
-import { ConnectionColumnManager } from './connection-column-manager'
+import {
+  ConnectionColumnManager,
+  type ConnectionColumnOption,
+} from './connection-column-manager'
+import type { ConnectionRowView } from './connection-row-view'
 
 const ROW_HEIGHT = 40
+const RESIZE_HANDLE_WIDTH = 6
+const OVERSCAN_ROWS = 6
 
 type TickListener = () => void
 let _tickNow = Date.now()
 const _tickListeners = new Set<TickListener>()
-let _tickTimer: ReturnType<typeof setInterval> | null = null
+let _tickTimer: number | null = null
 
 const _startTick = () => {
   if (_tickTimer !== null) return
-  _tickTimer = setInterval(() => {
+  _tickTimer = window.setInterval(() => {
     _tickNow = Date.now()
     _tickListeners.forEach((fn) => fn())
   }, 5000)
@@ -49,7 +40,7 @@ const _startTick = () => {
 
 const _stopTick = () => {
   if (_tickListeners.size === 0 && _tickTimer !== null) {
-    clearInterval(_tickTimer)
+    window.clearInterval(_tickTimer)
     _tickTimer = null
   }
 }
@@ -77,99 +68,6 @@ const RelativeTimeCell = memo(function RelativeTimeCell({
   return <>{dayjs(start).from(now)}</>
 })
 
-const SX_OUTER: React.ComponentProps<typeof Box>['sx'] = {
-  display: 'flex',
-  flexDirection: 'column',
-  flex: 1,
-  minHeight: 0,
-  position: 'relative',
-  fontFamily: (theme) => theme.typography.fontFamily,
-}
-
-const SX_SCROLL_CONTAINER: React.ComponentProps<typeof Box>['sx'] = {
-  flex: 1,
-  minHeight: 0,
-  overflow: 'auto',
-  WebkitOverflowScrolling: 'touch',
-  overscrollBehavior: 'contain',
-  borderRadius: 1,
-  border: 'none',
-  '&::-webkit-scrollbar': {
-    height: 8,
-  },
-}
-
-const SX_HEADER_STICKY: React.ComponentProps<typeof Box>['sx'] = {
-  position: 'sticky',
-  top: 0,
-  zIndex: 2,
-}
-
-const SX_CELL_CONTENT: React.ComponentProps<typeof Box>['sx'] = {
-  flex: 1,
-  display: 'flex',
-  alignItems: 'center',
-  gap: 0.5,
-  px: 1,
-  py: 1,
-}
-
-const SX_RESIZE_HANDLE: React.ComponentProps<typeof Box>['sx'] = {
-  cursor: 'col-resize',
-  position: 'absolute',
-  right: 0,
-  top: 0,
-  width: 4,
-  height: '100%',
-  transform: 'translateX(50%)',
-  '&:hover': {
-    backgroundColor: (theme) => theme.palette.action.active,
-  },
-}
-
-const SX_HEADER_ROW: React.ComponentProps<typeof Box>['sx'] = {
-  display: 'flex',
-  borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
-  backgroundColor: (theme) => theme.palette.background.paper,
-}
-
-const SX_HEADER_CELL_BASE: React.ComponentProps<typeof Box>['sx'] = {
-  display: 'flex',
-  alignItems: 'center',
-  position: 'relative',
-  boxSizing: 'border-box',
-  fontSize: 13,
-  fontWeight: 600,
-  color: 'text.secondary',
-  userSelect: 'none',
-  '&:hover': {
-    backgroundColor: (theme) => theme.palette.action.hover,
-  },
-}
-
-const SX_DATA_CELL_BASE: React.ComponentProps<typeof Box>['sx'] = {
-  boxSizing: 'border-box',
-  px: 1,
-  fontSize: 13,
-  display: 'flex',
-  alignItems: 'center',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-}
-
-const SX_ROW_BASE: React.ComponentProps<typeof Box>['sx'] = {
-  display: 'flex',
-  position: 'absolute',
-  left: 0,
-  right: 0,
-  cursor: 'pointer',
-  borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
-  '&:hover': {
-    backgroundColor: (theme) => theme.palette.action.hover,
-  },
-}
-
 const reconcileColumnOrder = (
   storedOrder: string[],
   baseFields: string[],
@@ -193,108 +91,171 @@ type ColumnField =
   | 'remoteDestination'
   | 'type'
 
-const getConnectionCellValue = (field: ColumnField, each: IConnectionsItem) => {
-  const { metadata, rulePayload } = each
+type ColumnSizingState = Record<string, number>
+type VisibilityState = Record<string, boolean>
 
+interface BaseColumn {
+  field: ColumnField
+  headerName: string
+  width: number
+  minWidth: number
+  maxWidth?: number
+  align?: 'left' | 'right'
+  cell?: (row: ConnectionRowView) => string
+}
+
+interface DisplayColumn extends BaseColumn {
+  size: number
+}
+
+interface SortingState {
+  id: ColumnField
+  desc: boolean
+}
+
+const resolveColumnSize = (
+  column: BaseColumn,
+  storedSize: number | undefined,
+) => {
+  if (typeof storedSize !== 'number' || !Number.isFinite(storedSize)) {
+    return column.width
+  }
+
+  const boundedMin = Math.max(column.minWidth, storedSize)
+  return column.maxWidth === undefined
+    ? boundedMin
+    : Math.min(column.maxWidth, boundedMin)
+}
+
+const getConnectionCellValue = (field: ColumnField, row: ConnectionRowView) => {
   switch (field) {
     case 'host':
-      return metadata.host
-        ? `${metadata.host}:${metadata.destinationPort}`
-        : `${metadata.remoteDestination}:${metadata.destinationPort}`
+      return row.host
     case 'download':
-      return each.download
+      return row.download
     case 'upload':
-      return each.upload
+      return row.upload
     case 'dlSpeed':
-      return each.curDownload
+      return row.downloadSpeed
     case 'ulSpeed':
-      return each.curUpload
+      return row.uploadSpeed
     case 'chains':
-      return [...each.chains].reverse().join(' / ')
+      return row.chains
     case 'rule':
-      return rulePayload ? `${each.rule}(${rulePayload})` : each.rule
+      return row.rule
     case 'process':
-      return truncateStr(metadata.process || metadata.processPath)
+      return row.process
     case 'time':
-      return each.start
+      return row.time
     case 'source':
-      return `${metadata.sourceIP}:${metadata.sourcePort}`
+      return row.source
     case 'remoteDestination':
-      return metadata.destinationIP
-        ? `${metadata.destinationIP}:${metadata.destinationPort}`
-        : `${metadata.remoteDestination}:${metadata.destinationPort}`
+      return row.destination
     case 'type':
-      return `${metadata.type}(${metadata.network})`
+      return `${row.type}(${row.network})`
     default:
       return ''
   }
 }
 
+const compareConnectionCellValue = (
+  field: ColumnField,
+  left: ConnectionRowView,
+  right: ConnectionRowView,
+) => {
+  const leftValue = getConnectionCellValue(field, left)
+  const rightValue = getConnectionCellValue(field, right)
+
+  if (field === 'time') {
+    const leftTime = Date.parse(String(leftValue || '')) || 0
+    const rightTime = Date.parse(String(rightValue || '')) || 0
+    return leftTime - rightTime
+  }
+
+  if (typeof leftValue === 'number' || typeof rightValue === 'number') {
+    return (Number(leftValue) || 0) - (Number(rightValue) || 0)
+  }
+
+  return String(leftValue ?? '').localeCompare(String(rightValue ?? ''))
+}
+
+const renderCell = (column: DisplayColumn, row: ConnectionRowView) => {
+  if (column.cell) return column.cell(row)
+  if (column.field === 'time') return <RelativeTimeCell start={row.time} />
+  return getConnectionCellValue(column.field, row)
+}
+
 interface RowComponentProps {
-  row: Row<IConnectionsItem>
-  virtualStart: number
-  virtualSize: number
-  onShowDetail: (data: IConnectionsItem) => void
+  row: ConnectionRowView
+  columns: DisplayColumn[]
+  onShowDetail: (id: string) => void
+  borderColor: string
+  virtualTop: number
 }
 
 const RowComponent = memo(
   function RowComponent({
     row,
-    virtualStart,
-    virtualSize,
+    columns,
     onShowDetail,
+    borderColor,
+    virtualTop,
   }: RowComponentProps) {
     const handleClick = useCallback(
-      () => onShowDetail(row.original),
-      [onShowDetail, row.original],
+      () => onShowDetail(row.id),
+      [onShowDetail, row.id],
     )
 
     return (
-      <Box
-        sx={[
-          SX_ROW_BASE,
-          {
-            height: virtualSize,
-            transform: `translateY(${virtualStart}px)`,
-          },
-        ]}
+      <div
+        style={{
+          display: 'flex',
+          position: 'absolute',
+          top: virtualTop,
+          left: 0,
+          right: 0,
+          height: ROW_HEIGHT,
+          cursor: 'pointer',
+          borderBottom: `1px solid ${borderColor}`,
+        }}
         onClick={handleClick}
       >
-        {row.getVisibleCells().map((cell) => {
-          const meta = cell.column.columnDef.meta as {
-            align?: 'left' | 'right'
-          }
-          return (
-            <Box
-              key={cell.id}
-              sx={[
-                SX_DATA_CELL_BASE,
-                {
-                  flex: `0 0 ${cell.column.getSize()}px`,
-                  minWidth: cell.column.columnDef.minSize ?? 80,
-                  maxWidth: cell.column.columnDef.maxSize,
-                  justifyContent:
-                    meta?.align === 'right' ? 'flex-end' : 'flex-start',
-                },
-              ]}
-            >
-              {flexRender(cell.column.columnDef.cell, cell.getContext())}
-            </Box>
-          )
-        })}
-      </Box>
+        {columns.map((column) => (
+          <div
+            key={column.field}
+            style={{
+              boxSizing: 'border-box',
+              flex: `0 0 ${column.size}px`,
+              minWidth: column.minWidth,
+              maxWidth: column.maxWidth,
+              padding: '8px',
+              fontSize: 13,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent:
+                column.align === 'right' ? 'flex-end' : 'flex-start',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {renderCell(column, row)}
+          </div>
+        ))}
+      </div>
     )
   },
   (prev, next) =>
     prev.row === next.row &&
-    prev.virtualStart === next.virtualStart &&
-    prev.virtualSize === next.virtualSize &&
-    prev.onShowDetail === next.onShowDetail,
+    prev.columns === next.columns &&
+    prev.virtualTop === next.virtualTop &&
+    prev.onShowDetail === next.onShowDetail &&
+    prev.borderColor === next.borderColor,
 )
 
 interface Props {
-  connections: IConnectionsItem[]
-  onShowDetail: (data: IConnectionsItem) => void
+  connections: ConnectionRowView[]
+  onShowDetail: (id: string) => void
   columnManagerOpen: boolean
   onCloseColumnManager: () => void
 }
@@ -309,10 +270,11 @@ export const ConnectionTable = (props: Props) => {
   const onShowDetailRef = useRef(rawOnShowDetail)
   onShowDetailRef.current = rawOnShowDetail
   const onShowDetail = useCallback(
-    (data: IConnectionsItem) => onShowDetailRef.current(data),
+    (id: string) => onShowDetailRef.current(id),
     [],
   )
   const { t } = useTranslation()
+  const theme = useTheme()
   const [columnWidths, setColumnWidths] = useLocalStorage<ColumnSizingState>(
     'connection-table-widths',
     {},
@@ -353,15 +315,6 @@ export const ConnectionTable = (props: Props) => {
     },
   )
 
-  interface BaseColumn {
-    field: ColumnField
-    headerName: string
-    width?: number
-    minWidth?: number
-    align?: 'left' | 'right'
-    cell?: (row: IConnectionsItem) => ReactNode
-  }
-
   const baseColumns = useMemo<BaseColumn[]>(() => {
     return [
       {
@@ -376,7 +329,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => parseTraffic(row.download).join(' '),
+        cell: (row) => row.downloadText,
       },
       {
         field: 'upload',
@@ -384,7 +337,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => parseTraffic(row.upload).join(' '),
+        cell: (row) => row.uploadText,
       },
       {
         field: 'dlSpeed',
@@ -392,7 +345,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => `${parseTraffic(row.curDownload).join(' ')}/s`,
+        cell: (row) => row.downloadSpeedText,
       },
       {
         field: 'ulSpeed',
@@ -400,7 +353,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => `${parseTraffic(row.curUpload).join(' ')}/s`,
+        cell: (row) => row.uploadSpeedText,
       },
       {
         field: 'chains',
@@ -463,262 +416,343 @@ export const ConnectionTable = (props: Props) => {
     })
   }, [baseColumns, setColumnOrder])
 
-  const handleColumnVisibilityChange = useCallback(
-    (update: Updater<VisibilityState>) => {
+  const orderedColumns = useMemo(() => {
+    const baseFields = baseColumns.map((column) => column.field)
+    const reconciledOrder = reconcileColumnOrder(columnOrder, baseFields)
+    const byField: Partial<Record<ColumnField, BaseColumn>> = {}
+    baseColumns.forEach((column) => {
+      byField[column.field] = column
+    })
+
+    return reconciledOrder
+      .map((field) => byField[field as ColumnField])
+      .filter((column): column is BaseColumn => Boolean(column))
+  }, [baseColumns, columnOrder])
+
+  const visibleColumns = useMemo<DisplayColumn[]>(() => {
+    return orderedColumns
+      .filter(
+        (column) => (columnVisibilityModel?.[column.field] ?? true) !== false,
+      )
+      .map((column) => ({
+        ...column,
+        size: resolveColumnSize(column, columnWidths?.[column.field]),
+      }))
+  }, [columnVisibilityModel, columnWidths, orderedColumns])
+
+  const [sorting, setSorting] = useState<SortingState | null>(null)
+  const [viewport, setViewport] = useState({ scrollTop: 0, height: 1200 })
+
+  const sortedConnections = useMemo(() => {
+    if (!sorting) return connections
+
+    const direction = sorting.desc ? -1 : 1
+    return [...connections].sort(
+      (left, right) =>
+        compareConnectionCellValue(sorting.id, left, right) * direction,
+    )
+  }, [connections, sorting])
+
+  const tableWidth = useMemo(
+    () => visibleColumns.reduce((total, column) => total + column.size, 0),
+    [visibleColumns],
+  )
+  const handleScroll = useCallback((event: ReactUIEvent<HTMLDivElement>) => {
+    const element = event.currentTarget
+    setViewport((current) => {
+      const next = {
+        scrollTop: element.scrollTop,
+        height: element.clientHeight,
+      }
+      return current.scrollTop === next.scrollTop &&
+        current.height === next.height
+        ? current
+        : next
+    })
+  }, [])
+
+  const bodyScrollTop = Math.max(0, viewport.scrollTop - ROW_HEIGHT)
+  const firstVisibleRow = Math.min(
+    sortedConnections.length,
+    Math.max(0, Math.floor(bodyScrollTop / ROW_HEIGHT) - OVERSCAN_ROWS),
+  )
+  const lastVisibleRow = Math.max(
+    firstVisibleRow,
+    Math.min(
+      sortedConnections.length,
+      Math.ceil((bodyScrollTop + viewport.height) / ROW_HEIGHT) + OVERSCAN_ROWS,
+    ),
+  )
+  const totalRowsHeight = sortedConnections.length * ROW_HEIGHT
+
+  const toggleSorting = useCallback((field: ColumnField) => {
+    setSorting((current) => {
+      if (!current || current.id !== field) return { id: field, desc: false }
+      if (!current.desc) return { id: field, desc: true }
+      return null
+    })
+  }, [])
+
+  const setColumnVisibility = useCallback(
+    (field: ColumnField, visible: boolean) => {
       setColumnVisibilityModel((prev) => {
         const current = prev ?? {}
-        const nextState =
-          typeof update === 'function' ? update(current) : update
-
         const visibleCount = baseColumns.reduce((count, column) => {
-          const isVisible = (nextState[column.field] ?? true) !== false
-          return count + (isVisible ? 1 : 0)
+          if (column.field === field) return count + (visible ? 1 : 0)
+          return count + ((current[column.field] ?? true) !== false ? 1 : 0)
         }, 0)
+        if (visibleCount === 0) return current
 
-        if (visibleCount === 0) {
-          return current
-        }
-
-        const sanitized: VisibilityState = {}
+        const next: VisibilityState = {}
         baseColumns.forEach((column) => {
-          if (nextState[column.field] === false) {
-            sanitized[column.field] = false
+          if (column.field === field) {
+            if (!visible) next[column.field] = false
+          } else if (current[column.field] === false) {
+            next[column.field] = false
           }
         })
-        return sanitized
+        return next
       })
     },
     [baseColumns, setColumnVisibilityModel],
   )
 
-  const handleColumnOrderChange = useCallback(
-    (update: Updater<ColumnOrderState>) => {
-      setColumnOrder((prev) => {
-        const current = Array.isArray(prev) ? prev : []
-        const nextState =
-          typeof update === 'function' ? update(current) : update
-        const baseFields = baseColumns.map((col) => col.field)
-        return reconcileColumnOrder(nextState, baseFields)
-      })
+  const handleManagerOrderChange = useCallback(
+    (order: string[]) => {
+      const baseFields = baseColumns.map((col) => col.field)
+      setColumnOrder(reconcileColumnOrder(order, baseFields))
     },
     [baseColumns, setColumnOrder],
   )
 
-  const [sorting, setSorting] = useState<SortingState>([])
+  const handleResetColumns = useCallback(() => {
+    setColumnVisibilityModel({})
+    setColumnOrder(baseColumns.map((column) => column.field))
+    setColumnWidths({})
+    setSorting(null)
+  }, [baseColumns, setColumnOrder, setColumnVisibilityModel, setColumnWidths])
 
-  // columnDefs no longer depends on relativeNow — time column delegates to RelativeTimeCell
-  const columnDefs = useMemo<ColumnDef<IConnectionsItem>[]>(() => {
-    return baseColumns.map((column) => {
-      let cell: ColumnDef<IConnectionsItem>['cell']
-      if (column.field === 'time') {
-        cell = (ctx) => <RelativeTimeCell start={ctx.row.original.start} />
-      } else if (column.cell) {
-        const renderCell = column.cell
-        cell = (ctx) => renderCell(ctx.row.original)
-      } else {
-        cell = (ctx) =>
-          ctx.row.original
-            ? (getConnectionCellValue(
-                column.field,
-                ctx.row.original,
-              ) as ReactNode)
-            : null
+  const managerColumns = useMemo<ConnectionColumnOption[]>(() => {
+    return orderedColumns.map((column) => ({
+      id: column.field,
+      label: column.headerName,
+      visible: (columnVisibilityModel?.[column.field] ?? true) !== false,
+      toggleVisibility: (visible) => setColumnVisibility(column.field, visible),
+    }))
+  }, [columnVisibilityModel, orderedColumns, setColumnVisibility])
+
+  const startResize = useCallback(
+    (
+      field: ColumnField,
+      startClientX: number,
+      startWidth: number,
+      minWidth: number,
+      maxWidth: number | undefined,
+    ) => {
+      const handleMove = (clientX: number) => {
+        const nextWidth = Math.max(
+          minWidth,
+          startWidth + clientX - startClientX,
+        )
+        setColumnWidths((prev) => ({
+          ...(prev ?? {}),
+          [field]: maxWidth ? Math.min(maxWidth, nextWidth) : nextWidth,
+        }))
       }
 
-      return {
-        id: column.field,
-        accessorFn: (row) => getConnectionCellValue(column.field, row),
-        header: column.headerName,
-        size: column.width,
-        minSize: column.minWidth,
-        meta: {
-          align: column.align ?? 'left',
-          field: column.field,
-          label: column.headerName,
-        },
-        cell,
-      } satisfies ColumnDef<IConnectionsItem>
-    })
-  }, [baseColumns])
+      const handleMouseMove = (event: MouseEvent) => handleMove(event.clientX)
+      const handleTouchMove = (event: TouchEvent) => {
+        const touch = event.touches[0]
+        if (touch) handleMove(touch.clientX)
+      }
+      const cleanup = () => {
+        window.removeEventListener('mousemove', handleMouseMove)
+        window.removeEventListener('mouseup', cleanup)
+        window.removeEventListener('touchmove', handleTouchMove)
+        window.removeEventListener('touchend', cleanup)
+        window.removeEventListener('touchcancel', cleanup)
+      }
 
-  const handleColumnSizingChange = useCallback(
-    (updater: Updater<ColumnSizingState>) => {
-      setColumnWidths((prev) => {
-        const prevState = prev ?? {}
-        const nextState =
-          typeof updater === 'function' ? updater(prevState) : updater
-        const sanitized: ColumnSizingState = {}
-        Object.entries(nextState).forEach(([key, size]) => {
-          if (typeof size === 'number' && Number.isFinite(size)) {
-            sanitized[key] = size
-          }
-        })
-        return sanitized
-      })
+      window.addEventListener('mousemove', handleMouseMove)
+      window.addEventListener('mouseup', cleanup)
+      window.addEventListener('touchmove', handleTouchMove, { passive: true })
+      window.addEventListener('touchend', cleanup)
+      window.addEventListener('touchcancel', cleanup)
     },
     [setColumnWidths],
   )
 
-  const table = useReactTable({
-    data: connections,
-    state: {
-      columnVisibility: columnVisibilityModel ?? {},
-      columnSizing: columnWidths,
-      columnOrder,
-      sorting,
+  const handleResizeMouseDown = useCallback(
+    (column: DisplayColumn, event: ReactMouseEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      startResize(
+        column.field,
+        event.clientX,
+        column.size,
+        column.minWidth,
+        column.maxWidth,
+      )
     },
-    initialState: {
-      columnOrder: baseColumns.map((col) => col.field),
-    },
-    defaultColumn: {
-      minSize: 80,
-      enableResizing: true,
-    },
-    columnResizeMode: 'onChange',
-    enableSortingRemoval: true,
-    getRowId: (row) => row.id,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: sorting.length ? getSortedRowModel() : undefined,
-    onSortingChange: setSorting,
-    onColumnSizingChange: handleColumnSizingChange,
-    onColumnVisibilityChange: handleColumnVisibilityChange,
-    onColumnOrderChange: handleColumnOrderChange,
-    columns: columnDefs,
-  })
-
-  const handleManagerOrderChange = useCallback(
-    (order: string[]) => {
-      const baseFields = baseColumns.map((col) => col.field)
-      table.setColumnOrder(reconcileColumnOrder(order, baseFields))
-    },
-    [baseColumns, table],
+    [startResize],
   )
 
-  const handleResetColumns = useCallback(() => {
-    table.resetColumnVisibility()
-    table.resetColumnOrder()
-  }, [table])
+  const handleResizeTouchStart = useCallback(
+    (column: DisplayColumn, event: ReactTouchEvent<HTMLDivElement>) => {
+      event.stopPropagation()
+      const touch = event.touches[0]
+      if (!touch) return
+      startResize(
+        column.field,
+        touch.clientX,
+        column.size,
+        column.minWidth,
+        column.maxWidth,
+      )
+    },
+    [startResize],
+  )
 
-  const rows = table.getRowModel().rows
-  const tableContainerRef = useRef<HTMLDivElement | null>(null)
-  const rowVirtualizer = useVirtualizer({
-    count: rows.length,
-    getScrollElement: () => tableContainerRef.current,
-    estimateSize: () => ROW_HEIGHT,
-    overscan: 4,
-  })
-
-  const virtualRows = rowVirtualizer.getVirtualItems()
-  const totalSize = rowVirtualizer.getTotalSize()
-  const tableWidth = table.getTotalSize()
-  const managerColumns = table.getAllLeafColumns()
+  const borderColor = theme.palette.divider
+  const headerBackground = theme.palette.background.paper
+  const textSecondary = theme.palette.text.secondary
 
   return (
     <>
-      <Box sx={SX_OUTER}>
-        <Box ref={tableContainerRef} sx={SX_SCROLL_CONTAINER}>
-          <Box
-            sx={{
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          minHeight: 0,
+          position: 'relative',
+          fontFamily: theme.typography.fontFamily,
+        }}
+      >
+        <div
+          onScroll={handleScroll}
+          style={{
+            flex: 1,
+            minHeight: 0,
+            overflow: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            overscrollBehavior: 'contain',
+            borderRadius: 8,
+          }}
+        >
+          <div
+            style={{
               minWidth: '100%',
               width: tableWidth,
             }}
           >
-            <Box sx={SX_HEADER_STICKY}>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <Box key={headerGroup.id} sx={SX_HEADER_ROW}>
-                  {headerGroup.headers.map((header) => {
-                    if (header.isPlaceholder) {
-                      return null
-                    }
-                    const meta = header.column.columnDef.meta as {
-                      align?: 'left' | 'right'
-                      field: string
-                    }
-                    return (
-                      <Box
-                        key={header.id}
-                        sx={[
-                          SX_HEADER_CELL_BASE,
-                          {
-                            flex: `0 0 ${header.getSize()}px`,
-                            minWidth: header.column.columnDef.minSize ?? 80,
-                            maxWidth: header.column.columnDef.maxSize,
-                          },
-                        ]}
-                      >
-                        <Box
-                          component="span"
-                          onClick={
-                            header.column.getCanSort()
-                              ? header.column.getToggleSortingHandler()
-                              : undefined
-                          }
-                          sx={[
-                            SX_CELL_CONTENT,
-                            {
-                              justifyContent:
-                                meta?.align === 'right'
-                                  ? 'flex-end'
-                                  : 'flex-start',
-                              cursor: header.column.getCanSort()
-                                ? 'pointer'
-                                : 'default',
-                            },
-                          ]}
-                        >
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                          {{
-                            asc: '▲',
-                            desc: '▼',
-                          }[header.column.getIsSorted() as string] ?? null}
-                        </Box>
-                        {header.column.getCanResize() && (
-                          <Box
-                            onClick={(event) => event.stopPropagation()}
-                            onMouseDown={(event) => {
-                              event.stopPropagation()
-                              header.getResizeHandler()(event)
-                            }}
-                            onTouchStart={(event) => {
-                              event.stopPropagation()
-                              header.getResizeHandler()(event)
-                            }}
-                            sx={SX_RESIZE_HANDLE}
-                          />
-                        )}
-                      </Box>
-                    )
-                  })}
-                </Box>
-              ))}
-            </Box>
-            <Box
-              sx={{
-                position: 'relative',
-                height: totalSize,
+            <div
+              style={{
+                position: 'sticky',
+                top: 0,
+                zIndex: 2,
               }}
             >
-              {virtualRows.map((virtualRow) => {
-                const row = rows[virtualRow.index]
-                if (!row) return null
+              <div
+                style={{
+                  display: 'flex',
+                  borderBottom: `1px solid ${borderColor}`,
+                  backgroundColor: headerBackground,
+                }}
+              >
+                {visibleColumns.map((column) => (
+                  <div
+                    key={column.field}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      position: 'relative',
+                      boxSizing: 'border-box',
+                      flex: `0 0 ${column.size}px`,
+                      minWidth: column.minWidth,
+                      maxWidth: column.maxWidth,
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: textSecondary,
+                      userSelect: 'none',
+                    }}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => toggleSorting(column.field)}
+                      style={{
+                        flex: 1,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent:
+                          column.align === 'right' ? 'flex-end' : 'flex-start',
+                        gap: 4,
+                        padding: 8,
+                        border: 0,
+                        background: 'transparent',
+                        color: 'inherit',
+                        font: 'inherit',
+                        textAlign: column.align === 'right' ? 'right' : 'left',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      {column.headerName}
+                      {sorting?.id === column.field
+                        ? sorting.desc
+                          ? '▼'
+                          : '▲'
+                        : null}
+                    </button>
+                    <div
+                      onMouseDown={(event) =>
+                        handleResizeMouseDown(column, event)
+                      }
+                      onTouchStart={(event) =>
+                        handleResizeTouchStart(column, event)
+                      }
+                      style={{
+                        cursor: 'col-resize',
+                        position: 'absolute',
+                        right: 0,
+                        top: 0,
+                        width: RESIZE_HANDLE_WIDTH,
+                        height: '100%',
+                        transform: 'translateX(50%)',
+                      }}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div
+              style={{
+                position: 'relative',
+                height: totalRowsHeight,
+              }}
+            >
+              {Array.from(
+                { length: lastVisibleRow - firstVisibleRow },
+                (_, offset) => {
+                  const index = firstVisibleRow + offset
+                  const row = sortedConnections[index]
+                  if (!row) return null
 
-                return (
-                  <RowComponent
-                    key={row.id}
-                    row={row}
-                    virtualStart={virtualRow.start}
-                    virtualSize={virtualRow.size}
-                    onShowDetail={onShowDetail}
-                  />
-                )
-              })}
-            </Box>
-          </Box>
-        </Box>
-      </Box>
+                  return (
+                    <RowComponent
+                      key={row.id}
+                      row={row}
+                      columns={visibleColumns}
+                      onShowDetail={onShowDetail}
+                      borderColor={borderColor}
+                      virtualTop={index * ROW_HEIGHT}
+                    />
+                  )
+                },
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
       <ConnectionColumnManager
         open={columnManagerOpen}
         columns={managerColumns}

--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -18,7 +18,17 @@ import {
   type ConnectionColumnOption,
 } from './connection-column-manager'
 import { RelativeTime } from './connection-relative-time'
-import type { ConnectionRowView } from './connection-row-view'
+import {
+  formatConnectionChains,
+  formatConnectionTraffic,
+  getConnectionDestination,
+  getConnectionHost,
+  getConnectionProcess,
+  getConnectionRule,
+  getConnectionSource,
+  getConnectionStartTime,
+  getConnectionTypeLabel,
+} from './connection-row-view'
 
 const ROW_HEIGHT = 40
 const RESIZE_HANDLE_WIDTH = 6
@@ -57,7 +67,7 @@ interface BaseColumn {
   minWidth: number
   maxWidth?: number
   align?: 'left' | 'right'
-  cell?: (row: ConnectionRowView) => string
+  cell?: (row: IConnectionsItem) => string
 }
 
 interface DisplayColumn extends BaseColumn {
@@ -83,32 +93,32 @@ const resolveColumnSize = (
     : Math.min(column.maxWidth, boundedMin)
 }
 
-const getConnectionCellValue = (field: ColumnField, row: ConnectionRowView) => {
+const getConnectionCellValue = (field: ColumnField, row: IConnectionsItem) => {
   switch (field) {
     case 'host':
-      return row.host
+      return getConnectionHost(row)
     case 'download':
-      return row.download
+      return row.download ?? 0
     case 'upload':
-      return row.upload
+      return row.upload ?? 0
     case 'dlSpeed':
-      return row.downloadSpeed
+      return row.curDownload ?? 0
     case 'ulSpeed':
-      return row.uploadSpeed
+      return row.curUpload ?? 0
     case 'chains':
-      return row.chains
+      return formatConnectionChains(row.chains)
     case 'rule':
-      return row.rule
+      return getConnectionRule(row)
     case 'process':
-      return row.process
+      return getConnectionProcess(row)
     case 'time':
-      return row.time
+      return row.start
     case 'source':
-      return row.source
+      return getConnectionSource(row)
     case 'remoteDestination':
-      return row.destination
+      return getConnectionDestination(row)
     case 'type':
-      return `${row.type}(${row.network})`
+      return getConnectionTypeLabel(row)
     default:
       return ''
   }
@@ -116,11 +126,11 @@ const getConnectionCellValue = (field: ColumnField, row: ConnectionRowView) => {
 
 const compareConnectionCellValue = (
   field: ColumnField,
-  left: ConnectionRowView,
-  right: ConnectionRowView,
+  left: IConnectionsItem,
+  right: IConnectionsItem,
 ) => {
   if (field === 'time') {
-    return left.startTime - right.startTime
+    return getConnectionStartTime(left) - getConnectionStartTime(right)
   }
 
   const leftValue = getConnectionCellValue(field, left)
@@ -133,14 +143,14 @@ const compareConnectionCellValue = (
   return String(leftValue ?? '').localeCompare(String(rightValue ?? ''))
 }
 
-const renderCell = (column: DisplayColumn, row: ConnectionRowView) => {
+const renderCell = (column: DisplayColumn, row: IConnectionsItem) => {
   if (column.cell) return column.cell(row)
-  if (column.field === 'time') return <RelativeTime start={row.time} />
+  if (column.field === 'time') return <RelativeTime start={row.start} />
   return getConnectionCellValue(column.field, row)
 }
 
 interface RowComponentProps {
-  row: ConnectionRowView
+  row: IConnectionsItem
   columns: DisplayColumn[]
   onShowDetail: (id: string) => void
   borderColor: string
@@ -208,7 +218,7 @@ const RowComponent = memo(
 )
 
 interface Props {
-  connections: ConnectionRowView[]
+  connections: IConnectionsItem[]
   onShowDetail: (id: string) => void
   columnManagerOpen: boolean
   onCloseColumnManager: () => void
@@ -283,7 +293,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => row.downloadText,
+        cell: (row) => formatConnectionTraffic(row.download),
       },
       {
         field: 'upload',
@@ -291,7 +301,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => row.uploadText,
+        cell: (row) => formatConnectionTraffic(row.upload),
       },
       {
         field: 'dlSpeed',
@@ -299,7 +309,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => row.downloadSpeedText,
+        cell: (row) => `${formatConnectionTraffic(row.curDownload ?? 0)}/s`,
       },
       {
         field: 'ulSpeed',
@@ -307,7 +317,7 @@ export const ConnectionTable = (props: Props) => {
         width: 76,
         minWidth: 60,
         align: 'right',
-        cell: (row) => row.uploadSpeedText,
+        cell: (row) => `${formatConnectionTraffic(row.curUpload ?? 0)}/s`,
       },
       {
         field: 'chains',
@@ -433,6 +443,19 @@ export const ConnectionTable = (props: Props) => {
     observer.observe(element)
     return () => observer.disconnect()
   }, [updateViewport])
+
+  useEffect(() => {
+    const element = scrollContainerRef.current
+    if (!element) return
+
+    const maxScrollTop = Math.max(
+      0,
+      element.scrollHeight - element.clientHeight,
+    )
+    if (element.scrollTop <= maxScrollTop) return
+
+    element.scrollTop = maxScrollTop
+  }, [connections.length])
 
   const sortedConnections = useMemo(() => {
     if (!sorting) return connections

--- a/src/components/connection/connection-table.tsx
+++ b/src/components/connection/connection-table.tsx
@@ -407,7 +407,6 @@ export const ConnectionTable = (props: Props) => {
   const [sorting, setSorting] = useState<SortingState | null>(null)
   const [viewport, setViewport] = useState({ scrollTop: 0, height: 0 })
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
-
   const updateViewport = useCallback((element: HTMLDivElement) => {
     setViewport((current) => {
       const next = {

--- a/src/components/home/enhanced-traffic-stats.tsx
+++ b/src/components/home/enhanced-traffic-stats.tsx
@@ -18,7 +18,7 @@ import { ReactNode, memo, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { TrafficErrorBoundary } from '@/components/shared/traffic-error-boundary'
-import { useConnectionData } from '@/hooks/use-connection-data'
+import { useConnectionSummaryData } from '@/hooks/use-connection-data'
 import { useMemoryData } from '@/hooks/use-memory-data'
 import { useTrafficData } from '@/hooks/use-traffic-data'
 import { useVerge } from '@/hooks/use-verge'
@@ -157,8 +157,8 @@ export const EnhancedTrafficStats = () => {
   } = useMemoryData()
 
   const {
-    response: { data: connections },
-  } = useConnectionData()
+    response: { data: connectionSummary },
+  } = useConnectionSummaryData()
 
   // Canvas组件现在直接从全局Hook获取数据，无需手动添加数据点
 
@@ -168,10 +168,10 @@ export const EnhancedTrafficStats = () => {
     const [down, downUnit] = parseTraffic(traffic?.down || 0)
     const [inuse, inuseUnit] = parseTraffic(memory?.inuse || 0)
     const [uploadTotal, uploadTotalUnit] = parseTraffic(
-      connections?.uploadTotal,
+      connectionSummary?.uploadTotal,
     )
     const [downloadTotal, downloadTotalUnit] = parseTraffic(
-      connections?.downloadTotal,
+      connectionSummary?.downloadTotal,
     )
 
     return {
@@ -185,9 +185,9 @@ export const EnhancedTrafficStats = () => {
       uploadTotalUnit,
       downloadTotal,
       downloadTotalUnit,
-      connectionsCount: connections?.activeConnections.length,
+      connectionsCount: connectionSummary?.activeConnectionCount,
     }
-  }, [traffic, memory, connections])
+  }, [traffic, memory, connectionSummary])
 
   // 渲染流量图表 - 使用useMemo缓存渲染结果
   const trafficGraphComponent = useMemo(() => {

--- a/src/hooks/use-connection-data.ts
+++ b/src/hooks/use-connection-data.ts
@@ -4,6 +4,7 @@ import { MihomoWebSocket } from 'tauri-plugin-mihomo-api'
 import { useMihomoWsSubscription } from './use-mihomo-ws-subscription'
 
 const MAX_CLOSED_CONNS_NUM = 500
+const CONNECTION_UPDATE_THROTTLE_MS = 500
 
 export const initConnData: ConnectionMonitorData = {
   uploadTotal: 0,
@@ -67,6 +68,15 @@ const mergeConnectionSnapshot = (
     }
   }
 
+  if (dropped.length === 0) {
+    return {
+      uploadTotal: payload.uploadTotal ?? 0,
+      downloadTotal: payload.downloadTotal ?? 0,
+      activeConnections,
+      closedConnections: previousClosed,
+    }
+  }
+
   const rawClosedLen = previousClosed.length + dropped.length
   let closedConnections: IConnectionsItem[]
   if (rawClosedLen <= MAX_CLOSED_CONNS_NUM) {
@@ -95,7 +105,7 @@ export const useConnectionData = () => {
       buildSubscriptKey: (date) => `getClashConnection-${date}`,
       fallbackData: initConnData,
       connect: () => MihomoWebSocket.connect_connections(),
-      throttleMs: 16,
+      throttleMs: CONNECTION_UPDATE_THROTTLE_MS,
       setupHandlers: ({ next, scheduleReconnect }) => ({
         handleMessage: (data) => {
           if (data.startsWith('Websocket error')) {

--- a/src/hooks/use-connection-data.ts
+++ b/src/hooks/use-connection-data.ts
@@ -8,6 +8,8 @@ const CONNECTION_RECONNECT_DELAY_MS = 1_000
 type ConnectionMetadata = IConnectionsItem['metadata']
 type ConnectionListener = () => void
 
+const metadataValue = (value?: string) => value || ''
+
 export const initConnData: ConnectionMonitorData = {
   uploadTotal: 0,
   downloadTotal: 0,
@@ -41,7 +43,7 @@ let connectionStarted = false
 let connectionConnecting = false
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 let flushTimer: ReturnType<typeof setTimeout> | null = null
-let pendingPayload: IConnections | null = null
+let pendingMessageData: string | null = null
 let lastFlushAt = 0
 
 const connectionListeners = new Set<ConnectionListener>()
@@ -56,16 +58,18 @@ const notifySummaryListeners = () => {
 }
 
 const sameMetadata = (left: ConnectionMetadata, right: ConnectionMetadata) =>
-  left.network === right.network &&
-  left.type === right.type &&
-  left.host === right.host &&
-  left.sourceIP === right.sourceIP &&
-  left.sourcePort === right.sourcePort &&
-  left.destinationPort === right.destinationPort &&
-  left.destinationIP === right.destinationIP &&
-  left.remoteDestination === right.remoteDestination &&
-  left.process === right.process &&
-  left.processPath === right.processPath
+  metadataValue(left.network) === metadataValue(right.network) &&
+  metadataValue(left.type) === metadataValue(right.type) &&
+  metadataValue(left.host) === metadataValue(right.host) &&
+  metadataValue(left.sourceIP) === metadataValue(right.sourceIP) &&
+  metadataValue(left.sourcePort) === metadataValue(right.sourcePort) &&
+  metadataValue(left.destinationPort) ===
+    metadataValue(right.destinationPort) &&
+  metadataValue(left.destinationIP) === metadataValue(right.destinationIP) &&
+  metadataValue(left.remoteDestination) ===
+    metadataValue(right.remoteDestination) &&
+  metadataValue(left.process) === metadataValue(right.process) &&
+  metadataValue(left.processPath) === metadataValue(right.processPath)
 
 const normalizeMetadata = (
   metadata: ConnectionMetadata,
@@ -206,11 +210,19 @@ const mergeConnectionSummary = (
   activeConnectionCount: payload.connections?.length ?? 0,
 })
 
-const flushPendingPayload = () => {
+const flushPendingMessage = () => {
   flushTimer = null
-  const payload = pendingPayload
-  pendingPayload = null
-  if (!payload) return
+  const messageData = pendingMessageData
+  pendingMessageData = null
+  if (!messageData) return
+
+  let payload: IConnections
+  try {
+    payload = JSON.parse(messageData) as IConnections
+  } catch (err) {
+    console.error('[Connections] Failed to parse websocket payload', err)
+    return
+  }
 
   lastFlushAt = Date.now()
   connectionData = mergeConnectionSnapshot(payload, connectionData)
@@ -219,18 +231,18 @@ const flushPendingPayload = () => {
   notifySummaryListeners()
 }
 
-const enqueueConnectionPayload = (payload: IConnections) => {
-  pendingPayload = payload
+const enqueueConnectionMessage = (messageData: string) => {
+  pendingMessageData = messageData
   if (flushTimer) return
 
   const elapsed = Date.now() - lastFlushAt
   if (elapsed >= CONNECTION_UPDATE_THROTTLE_MS) {
-    flushPendingPayload()
+    flushPendingMessage()
     return
   }
 
   flushTimer = window.setTimeout(
-    flushPendingPayload,
+    flushPendingMessage,
     CONNECTION_UPDATE_THROTTLE_MS - elapsed,
   )
 }
@@ -282,11 +294,7 @@ async function connectConnectionSocket() {
         return
       }
 
-      try {
-        enqueueConnectionPayload(JSON.parse(message.data) as IConnections)
-      } catch (err) {
-        console.error('[Connections] Failed to parse websocket payload', err)
-      }
+      enqueueConnectionMessage(message.data)
     })
   } catch {
     scheduleReconnect()
@@ -321,7 +329,7 @@ const subscribeConnectionSummary = (listener: ConnectionListener) => {
 }
 
 const refreshConnectionData = () => {
-  pendingPayload = null
+  pendingMessageData = null
   if (flushTimer) {
     window.clearTimeout(flushTimer)
     flushTimer = null

--- a/src/hooks/use-connection-data.ts
+++ b/src/hooks/use-connection-data.ts
@@ -232,10 +232,13 @@ const flushPendingMessage = () => {
   }
 
   lastFlushAt = Date.now()
-  connectionData = mergeConnectionSnapshot(payload, connectionData)
   connectionSummary = mergeConnectionSummary(payload)
-  notifyConnectionListeners()
   notifySummaryListeners()
+
+  if (connectionListeners.size === 0) return
+
+  connectionData = mergeConnectionSnapshot(payload, connectionData)
+  notifyConnectionListeners()
 }
 
 const enqueueConnectionMessage = (messageData: string) => {

--- a/src/hooks/use-connection-data.ts
+++ b/src/hooks/use-connection-data.ts
@@ -178,20 +178,27 @@ const mergeConnectionSnapshot = (
     }
   }
 
-  const rawClosedLen = previousClosed.length + previousActiveById.size
-  const closedConnections: IConnectionsItem[] =
-    rawClosedLen <= MAX_CLOSED_CONNS_NUM
-      ? previousClosed.slice()
-      : previousClosed.slice(Math.max(0, rawClosedLen - MAX_CLOSED_CONNS_NUM))
+  const removedConnectionCount = previousActiveById.size
+  const dropFromClosed = Math.max(
+    0,
+    previousClosed.length + removedConnectionCount - MAX_CLOSED_CONNS_NUM,
+  )
+  const closedConnections =
+    dropFromClosed >= previousClosed.length
+      ? []
+      : previousClosed.slice(dropFromClosed)
 
-  previousActive.forEach((connection) => {
-    if (previousActiveById.has(connection.id)) {
-      closedConnections.push(connection)
+  const keepFromRemoved = MAX_CLOSED_CONNS_NUM - closedConnections.length
+  let skipRemoved = Math.max(0, removedConnectionCount - keepFromRemoved)
+
+  for (let i = 0; i < previousActive.length; i++) {
+    const connection = previousActive[i]
+    if (!previousActiveById.has(connection.id)) continue
+    if (skipRemoved > 0) {
+      skipRemoved -= 1
+      continue
     }
-  })
-
-  if (closedConnections.length > MAX_CLOSED_CONNS_NUM) {
-    closedConnections.splice(0, closedConnections.length - MAX_CLOSED_CONNS_NUM)
+    closedConnections.push(connection)
   }
 
   return {

--- a/src/hooks/use-connection-data.ts
+++ b/src/hooks/use-connection-data.ts
@@ -1,11 +1,12 @@
-import { useQueryClient } from '@tanstack/react-query'
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import { MihomoWebSocket } from 'tauri-plugin-mihomo-api'
-
-import { useMihomoWsSubscription } from './use-mihomo-ws-subscription'
 
 const MAX_CLOSED_CONNS_NUM = 500
 const CONNECTION_UPDATE_THROTTLE_MS = 500
-const CONNECTION_QUERY_GC_TIME_MS = 1_000
+const CONNECTION_RECONNECT_DELAY_MS = 1_000
+
+type ConnectionMetadata = IConnectionsItem['metadata']
+type ConnectionListener = () => void
 
 export const initConnData: ConnectionMonitorData = {
   uploadTotal: 0,
@@ -33,6 +34,115 @@ export const initConnSummaryData: ConnectionSummaryData = {
   activeConnectionCount: 0,
 }
 
+let connectionData: ConnectionMonitorData = initConnData
+let connectionSummary: ConnectionSummaryData = initConnSummaryData
+let connectionSocket: MihomoWebSocket | null = null
+let connectionStarted = false
+let connectionConnecting = false
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+let pendingPayload: IConnections | null = null
+let lastFlushAt = 0
+
+const connectionListeners = new Set<ConnectionListener>()
+const summaryListeners = new Set<ConnectionListener>()
+
+const notifyConnectionListeners = () => {
+  connectionListeners.forEach((listener) => listener())
+}
+
+const notifySummaryListeners = () => {
+  summaryListeners.forEach((listener) => listener())
+}
+
+const sameMetadata = (left: ConnectionMetadata, right: ConnectionMetadata) =>
+  left.network === right.network &&
+  left.type === right.type &&
+  left.host === right.host &&
+  left.sourceIP === right.sourceIP &&
+  left.sourcePort === right.sourcePort &&
+  left.destinationPort === right.destinationPort &&
+  left.destinationIP === right.destinationIP &&
+  left.remoteDestination === right.remoteDestination &&
+  left.process === right.process &&
+  left.processPath === right.processPath
+
+const normalizeMetadata = (
+  metadata: ConnectionMetadata,
+  previous?: ConnectionMetadata,
+): ConnectionMetadata => {
+  if (previous && sameMetadata(previous, metadata)) return previous
+
+  return {
+    network: metadata.network || '',
+    type: metadata.type || '',
+    host: metadata.host || '',
+    sourceIP: metadata.sourceIP || '',
+    sourcePort: metadata.sourcePort || '',
+    destinationPort: metadata.destinationPort || '',
+    destinationIP: metadata.destinationIP || '',
+    remoteDestination: metadata.remoteDestination || '',
+    process: metadata.process || '',
+    processPath: metadata.processPath || '',
+  }
+}
+
+const sameChains = (left: string[], right: string[]) => {
+  if (left.length !== right.length) return false
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) return false
+  }
+  return true
+}
+
+const normalizeChains = (chains: string[], previous?: string[]) => {
+  if (previous && sameChains(previous, chains)) return previous
+  return chains.slice()
+}
+
+const normalizeConnection = (
+  connection: IConnectionsItem,
+  previous?: IConnectionsItem,
+): IConnectionsItem => {
+  const metadata = normalizeMetadata(connection.metadata, previous?.metadata)
+  const chains = normalizeChains(connection.chains || [], previous?.chains)
+  const upload = connection.upload ?? 0
+  const download = connection.download ?? 0
+  const curUpload = previous ? upload - previous.upload : 0
+  const curDownload = previous ? download - previous.download : 0
+  const rule = connection.rule || ''
+  const rulePayload = connection.rulePayload || ''
+  const start = connection.start || ''
+
+  if (
+    previous &&
+    previous.metadata === metadata &&
+    previous.chains === chains &&
+    previous.upload === upload &&
+    previous.download === download &&
+    previous.curUpload === curUpload &&
+    previous.curDownload === curDownload &&
+    previous.rule === rule &&
+    previous.rulePayload === rulePayload &&
+    previous.start === start
+  ) {
+    return previous
+  }
+
+  return {
+    id: connection.id,
+    metadata,
+    upload,
+    download,
+    start,
+    chains,
+    rule,
+    rulePayload,
+    curUpload,
+    curDownload,
+  }
+}
+
 const mergeConnectionSnapshot = (
   payload: IConnections,
   previous: ConnectionMonitorData = initConnData,
@@ -40,48 +150,22 @@ const mergeConnectionSnapshot = (
   const nextConnections = payload.connections ?? []
   const previousActive = previous.activeConnections ?? []
   const previousClosed = previous.closedConnections ?? []
-
-  const nextById = new Map<string, IConnectionsItem>()
-  for (let i = 0; i < nextConnections.length; i++) {
-    nextById.set(nextConnections[i].id, nextConnections[i])
-  }
-
-  const carried: IConnectionsItem[] = []
-  const dropped: IConnectionsItem[] = []
+  const previousActiveById = new Map<string, IConnectionsItem>()
 
   for (let i = 0; i < previousActive.length; i++) {
-    const prev = previousActive[i]
-    const next = nextById.get(prev.id)
-    if (next !== undefined) {
-      nextById.delete(prev.id)
-      if (prev.upload === next.upload && prev.download === next.download) {
-        // Reuse prev reference: row identity stability is the contract Stage 2 memo relies on.
-        carried.push(prev)
-      } else {
-        carried.push({
-          ...next,
-          curUpload: next.upload - prev.upload,
-          curDownload: next.download - prev.download,
-        })
-      }
-    } else {
-      dropped.push(prev)
-    }
+    const previousConnection = previousActive[i]
+    previousActiveById.set(previousConnection.id, previousConnection)
   }
 
-  const activeConnections: IConnectionsItem[] = carried
+  const activeConnections: IConnectionsItem[] = []
   for (let i = 0; i < nextConnections.length; i++) {
-    const conn = nextConnections[i]
-    if (nextById.has(conn.id)) {
-      activeConnections.push({
-        ...conn,
-        curUpload: 0,
-        curDownload: 0,
-      })
-    }
+    const connection = nextConnections[i]
+    const previousConnection = previousActiveById.get(connection.id)
+    if (previousConnection) previousActiveById.delete(connection.id)
+    activeConnections.push(normalizeConnection(connection, previousConnection))
   }
 
-  if (dropped.length === 0) {
+  if (previousActiveById.size === 0) {
     return {
       uploadTotal: payload.uploadTotal ?? 0,
       downloadTotal: payload.downloadTotal ?? 0,
@@ -90,16 +174,20 @@ const mergeConnectionSnapshot = (
     }
   }
 
-  const rawClosedLen = previousClosed.length + dropped.length
-  let closedConnections: IConnectionsItem[]
-  if (rawClosedLen <= MAX_CLOSED_CONNS_NUM) {
-    closedConnections = previousClosed.concat(dropped)
-  } else {
-    const skipPrev = rawClosedLen - MAX_CLOSED_CONNS_NUM
-    closedConnections =
-      skipPrev >= previousClosed.length
-        ? dropped.slice(skipPrev - previousClosed.length)
-        : previousClosed.slice(skipPrev).concat(dropped)
+  const rawClosedLen = previousClosed.length + previousActiveById.size
+  const closedConnections: IConnectionsItem[] =
+    rawClosedLen <= MAX_CLOSED_CONNS_NUM
+      ? previousClosed.slice()
+      : previousClosed.slice(Math.max(0, rawClosedLen - MAX_CLOSED_CONNS_NUM))
+
+  previousActive.forEach((connection) => {
+    if (previousActiveById.has(connection.id)) {
+      closedConnections.push(connection)
+    }
+  })
+
+  if (closedConnections.length > MAX_CLOSED_CONNS_NUM) {
+    closedConnections.splice(0, closedConnections.length - MAX_CLOSED_CONNS_NUM)
   }
 
   return {
@@ -118,70 +206,173 @@ const mergeConnectionSummary = (
   activeConnectionCount: payload.connections?.length ?? 0,
 })
 
-export const useConnectionData = () => {
-  const queryClient = useQueryClient()
-  const { response, refresh, subscriptionCacheKey } =
-    useMihomoWsSubscription<ConnectionMonitorData>({
-      storageKey: 'mihomo_connection_date',
-      buildSubscriptKey: (date) => `getClashConnection-${date}`,
-      fallbackData: initConnData,
-      connect: () => MihomoWebSocket.connect_connections(),
-      throttleMs: CONNECTION_UPDATE_THROTTLE_MS,
-      gcTime: CONNECTION_QUERY_GC_TIME_MS,
-      setupHandlers: ({ next, scheduleReconnect }) => ({
-        handleMessage: (data) => {
-          if (data.startsWith('Websocket error')) {
-            next(data)
-            void scheduleReconnect()
-            return
-          }
+const flushPendingPayload = () => {
+  flushTimer = null
+  const payload = pendingPayload
+  pendingPayload = null
+  if (!payload) return
 
-          next(null, (old = initConnData) =>
-            mergeConnectionSnapshot(JSON.parse(data) as IConnections, old),
-          )
-        },
-      }),
-    })
+  lastFlushAt = Date.now()
+  connectionData = mergeConnectionSnapshot(payload, connectionData)
+  connectionSummary = mergeConnectionSummary(payload)
+  notifyConnectionListeners()
+  notifySummaryListeners()
+}
 
-  const clearClosedConnections = () => {
-    if (!subscriptionCacheKey) return
-    queryClient.setQueryData<ConnectionMonitorData>([subscriptionCacheKey], {
-      uploadTotal: response.data?.uploadTotal ?? 0,
-      downloadTotal: response.data?.downloadTotal ?? 0,
-      activeConnections: response.data?.activeConnections ?? [],
-      closedConnections: [],
-    })
+const enqueueConnectionPayload = (payload: IConnections) => {
+  pendingPayload = payload
+  if (flushTimer) return
+
+  const elapsed = Date.now() - lastFlushAt
+  if (elapsed >= CONNECTION_UPDATE_THROTTLE_MS) {
+    flushPendingPayload()
+    return
   }
+
+  flushTimer = window.setTimeout(
+    flushPendingPayload,
+    CONNECTION_UPDATE_THROTTLE_MS - elapsed,
+  )
+}
+
+const clearReconnectTimer = () => {
+  if (!reconnectTimer) return
+  window.clearTimeout(reconnectTimer)
+  reconnectTimer = null
+}
+
+const closeConnectionSocket = async () => {
+  const socket = connectionSocket
+  connectionSocket = null
+  if (!socket) return
+
+  try {
+    await socket.close()
+  } catch (err) {
+    console.warn('Failed to close connection websocket', err)
+  }
+}
+
+const scheduleReconnect = () => {
+  if (reconnectTimer) return
+  reconnectTimer = window.setTimeout(() => {
+    reconnectTimer = null
+    void connectConnectionSocket()
+  }, CONNECTION_RECONNECT_DELAY_MS)
+}
+
+async function reconnectConnectionSocket() {
+  await closeConnectionSocket()
+  scheduleReconnect()
+}
+
+async function connectConnectionSocket() {
+  if (connectionSocket || connectionConnecting) return
+
+  clearReconnectTimer()
+  connectionConnecting = true
+
+  try {
+    const socket = await MihomoWebSocket.connect_connections()
+    connectionSocket = socket
+    socket.addListener((message) => {
+      if (message.type !== 'Text') return
+      if (message.data.startsWith('Websocket error')) {
+        void reconnectConnectionSocket()
+        return
+      }
+
+      try {
+        enqueueConnectionPayload(JSON.parse(message.data) as IConnections)
+      } catch (err) {
+        console.error('[Connections] Failed to parse websocket payload', err)
+      }
+    })
+  } catch {
+    scheduleReconnect()
+  } finally {
+    connectionConnecting = false
+  }
+}
+
+const startConnectionMonitor = () => {
+  if (connectionStarted) return
+  connectionStarted = true
+  void connectConnectionSocket()
+}
+
+const getConnectionSnapshot = () => connectionData
+const getConnectionSummarySnapshot = () => connectionSummary
+
+const subscribeConnectionData = (listener: ConnectionListener) => {
+  startConnectionMonitor()
+  connectionListeners.add(listener)
+  return () => {
+    connectionListeners.delete(listener)
+  }
+}
+
+const subscribeConnectionSummary = (listener: ConnectionListener) => {
+  startConnectionMonitor()
+  summaryListeners.add(listener)
+  return () => {
+    summaryListeners.delete(listener)
+  }
+}
+
+const refreshConnectionData = () => {
+  pendingPayload = null
+  if (flushTimer) {
+    window.clearTimeout(flushTimer)
+    flushTimer = null
+  }
+
+  void reconnectConnectionSocket()
+}
+
+const clearClosedConnectionData = () => {
+  if (connectionData.closedConnections.length === 0) return
+  connectionData = {
+    ...connectionData,
+    closedConnections: [],
+  }
+  notifyConnectionListeners()
+}
+
+export const useConnectionData = () => {
+  const data = useSyncExternalStore(
+    subscribeConnectionData,
+    getConnectionSnapshot,
+    getConnectionSnapshot,
+  )
+  const response = useMemo(() => ({ data }), [data])
+  const refreshGetClashConnection = useCallback(() => {
+    refreshConnectionData()
+  }, [])
+  const clearClosedConnections = useCallback(() => {
+    clearClosedConnectionData()
+  }, [])
 
   return {
     response,
-    refreshGetClashConnection: refresh,
+    refreshGetClashConnection,
     clearClosedConnections,
   }
 }
 
 export const useConnectionSummaryData = () => {
-  const { response, refresh } = useMihomoWsSubscription<ConnectionSummaryData>({
-    storageKey: 'mihomo_connection_summary_date',
-    buildSubscriptKey: (date) => `getClashConnectionSummary-${date}`,
-    fallbackData: initConnSummaryData,
-    connect: () => MihomoWebSocket.connect_connections(),
-    throttleMs: CONNECTION_UPDATE_THROTTLE_MS,
-    setupHandlers: ({ next, scheduleReconnect }) => ({
-      handleMessage: (data) => {
-        if (data.startsWith('Websocket error')) {
-          next(data)
-          void scheduleReconnect()
-          return
-        }
-
-        next(null, mergeConnectionSummary(JSON.parse(data) as IConnections))
-      },
-    }),
-  })
+  const data = useSyncExternalStore(
+    subscribeConnectionSummary,
+    getConnectionSummarySnapshot,
+    getConnectionSummarySnapshot,
+  )
+  const response = useMemo(() => ({ data }), [data])
+  const refreshGetClashConnectionSummary = useCallback(() => {
+    refreshConnectionData()
+  }, [])
 
   return {
     response,
-    refreshGetClashConnectionSummary: refresh,
+    refreshGetClashConnectionSummary,
   }
 }

--- a/src/hooks/use-connection-data.ts
+++ b/src/hooks/use-connection-data.ts
@@ -5,6 +5,7 @@ import { useMihomoWsSubscription } from './use-mihomo-ws-subscription'
 
 const MAX_CLOSED_CONNS_NUM = 500
 const CONNECTION_UPDATE_THROTTLE_MS = 500
+const CONNECTION_QUERY_GC_TIME_MS = 1_000
 
 export const initConnData: ConnectionMonitorData = {
   uploadTotal: 0,
@@ -18,6 +19,18 @@ export interface ConnectionMonitorData {
   downloadTotal: number
   activeConnections: IConnectionsItem[]
   closedConnections: IConnectionsItem[]
+}
+
+export interface ConnectionSummaryData {
+  uploadTotal: number
+  downloadTotal: number
+  activeConnectionCount: number
+}
+
+export const initConnSummaryData: ConnectionSummaryData = {
+  uploadTotal: 0,
+  downloadTotal: 0,
+  activeConnectionCount: 0,
 }
 
 const mergeConnectionSnapshot = (
@@ -97,6 +110,14 @@ const mergeConnectionSnapshot = (
   }
 }
 
+const mergeConnectionSummary = (
+  payload: IConnections,
+): ConnectionSummaryData => ({
+  uploadTotal: payload.uploadTotal ?? 0,
+  downloadTotal: payload.downloadTotal ?? 0,
+  activeConnectionCount: payload.connections?.length ?? 0,
+})
+
 export const useConnectionData = () => {
   const queryClient = useQueryClient()
   const { response, refresh, subscriptionCacheKey } =
@@ -106,6 +127,7 @@ export const useConnectionData = () => {
       fallbackData: initConnData,
       connect: () => MihomoWebSocket.connect_connections(),
       throttleMs: CONNECTION_UPDATE_THROTTLE_MS,
+      gcTime: CONNECTION_QUERY_GC_TIME_MS,
       setupHandlers: ({ next, scheduleReconnect }) => ({
         handleMessage: (data) => {
           if (data.startsWith('Websocket error')) {
@@ -135,5 +157,31 @@ export const useConnectionData = () => {
     response,
     refreshGetClashConnection: refresh,
     clearClosedConnections,
+  }
+}
+
+export const useConnectionSummaryData = () => {
+  const { response, refresh } = useMihomoWsSubscription<ConnectionSummaryData>({
+    storageKey: 'mihomo_connection_summary_date',
+    buildSubscriptKey: (date) => `getClashConnectionSummary-${date}`,
+    fallbackData: initConnSummaryData,
+    connect: () => MihomoWebSocket.connect_connections(),
+    throttleMs: CONNECTION_UPDATE_THROTTLE_MS,
+    setupHandlers: ({ next, scheduleReconnect }) => ({
+      handleMessage: (data) => {
+        if (data.startsWith('Websocket error')) {
+          next(data)
+          void scheduleReconnect()
+          return
+        }
+
+        next(null, mergeConnectionSummary(JSON.parse(data) as IConnections))
+      },
+    }),
+  })
+
+  return {
+    response,
+    refreshGetClashConnectionSummary: refresh,
   }
 }

--- a/src/hooks/use-mihomo-ws-subscription.ts
+++ b/src/hooks/use-mihomo-ws-subscription.ts
@@ -169,6 +169,7 @@ interface UseMihomoWsSubscriptionOptions<T> {
    * when the window is backgrounded or minimized.
    */
   throttleMs?: number
+  gcTime?: number
   setupHandlers: (ctx: HandlerContext<T>) => HandlerResult
 }
 
@@ -181,6 +182,7 @@ export const useMihomoWsSubscription = <T>(
     fallbackData,
     connect,
     throttleMs,
+    gcTime = 30_000,
     setupHandlers,
   } = options
 
@@ -222,7 +224,7 @@ export const useMihomoWsSubscription = <T>(
       queryClient.getQueryData<T>([responseCacheKey ?? '$sub$__disabled__']) ??
       fallbackData,
     staleTime: Infinity,
-    gcTime: 30_000,
+    gcTime,
     enabled: subscriptionCacheKey !== null,
   })
 

--- a/src/hooks/use-mihomo-ws-subscription.ts
+++ b/src/hooks/use-mihomo-ws-subscription.ts
@@ -169,7 +169,6 @@ interface UseMihomoWsSubscriptionOptions<T> {
    * when the window is backgrounded or minimized.
    */
   throttleMs?: number
-  gcTime?: number
   setupHandlers: (ctx: HandlerContext<T>) => HandlerResult
 }
 
@@ -182,7 +181,6 @@ export const useMihomoWsSubscription = <T>(
     fallbackData,
     connect,
     throttleMs,
-    gcTime = 30_000,
     setupHandlers,
   } = options
 
@@ -224,7 +222,7 @@ export const useMihomoWsSubscription = <T>(
       queryClient.getQueryData<T>([responseCacheKey ?? '$sub$__disabled__']) ??
       fallbackData,
     staleTime: Infinity,
-    gcTime,
+    gcTime: 30_000,
     enabled: subscriptionCacheKey !== null,
   })
 

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -24,6 +24,7 @@ import {
   BasePage,
   BaseSearchBox,
   BaseStyledSelect,
+  type SearchState,
   VirtualList,
 } from '@/components/base'
 import {
@@ -31,7 +32,10 @@ import {
   ConnectionDetailRef,
 } from '@/components/connection/connection-detail'
 import { ConnectionRowItem } from '@/components/connection/connection-row-item'
-import { useConnectionRowViews } from '@/components/connection/connection-row-view'
+import {
+  getConnectionStartTime,
+  useConnectionRowViews,
+} from '@/components/connection/connection-row-view'
 import { ConnectionTable } from '@/components/connection/connection-table'
 import { useConnectionData } from '@/hooks/use-connection-data'
 import { useConnectionSetting } from '@/hooks/use-connection-setting'
@@ -45,22 +49,20 @@ const ORDER_OPTIONS = [
     labelKey: 'connections.components.order.default',
     fn: (list: IConnectionsItem[]) =>
       list.sort(
-        (a, b) =>
-          new Date(b.start || '0').getTime()! -
-          new Date(a.start || '0').getTime()!,
+        (a, b) => getConnectionStartTime(b) - getConnectionStartTime(a),
       ),
   },
   {
     id: 'uploadSpeed',
     labelKey: 'connections.components.order.uploadSpeed',
     fn: (list: IConnectionsItem[]) =>
-      list.sort((a, b) => b.curUpload! - a.curUpload!),
+      list.sort((a, b) => (b.curUpload ?? 0) - (a.curUpload ?? 0)),
   },
   {
     id: 'downloadSpeed',
     labelKey: 'connections.components.order.downloadSpeed',
     fn: (list: IConnectionsItem[]) =>
-      list.sort((a, b) => b.curDownload! - a.curDownload!),
+      list.sort((a, b) => (b.curDownload ?? 0) - (a.curDownload ?? 0)),
   },
 ] as const
 
@@ -75,12 +77,12 @@ const orderFunctionMap = ORDER_OPTIONS.reduce<Record<OrderKey, OrderFunc>>(
 )
 
 const EMPTY_CONNECTIONS: IConnectionsItem[] = []
-
 const ConnectionsPage = () => {
   const { t } = useTranslation()
   const [match, setMatch] = useState<(input: string) => boolean>(
     () => () => true,
   )
+  const [hasSearch, setHasSearch] = useState(false)
   const [curOrderOpt, setCurOrderOpt] = useState<OrderKey>('default')
   const [connectionsType, setConnectionsType] = useState<'active' | 'closed'>(
     'active',
@@ -104,17 +106,19 @@ const ConnectionsPage = () => {
 
   const filterConn = useMemo(() => {
     const orderFunc = orderFunctionMap[curOrderOpt]
-    let matchConns = selectedConnections.filter((conn) => {
+
+    if (isTableLayout && !hasSearch) return selectedConnections
+    if (!hasSearch) return orderFunc([...selectedConnections])
+
+    const matchConns = selectedConnections.filter((conn) => {
       const { host, destinationIP, process } = conn.metadata
       return (
         match(host || '') || match(destinationIP || '') || match(process || '')
       )
     })
 
-    if (orderFunc) matchConns = orderFunc(matchConns ?? [])
-
-    return matchConns
-  }, [selectedConnections, match, curOrderOpt])
+    return orderFunc ? orderFunc(matchConns) : matchConns
+  }, [selectedConnections, isTableLayout, hasSearch, match, curOrderOpt])
 
   const displayRows = useConnectionRowViews(
     isTableLayout ? EMPTY_CONNECTIONS : filterConn,
@@ -144,10 +148,13 @@ const ConnectionsPage = () => {
 
   const onCloseAll = useLockFn(closeAllConnections)
 
-  const handleSearch = useCallback((match: (content: string) => boolean) => {
-    setMatch(() => match)
-  }, [])
-
+  const handleSearch = useCallback(
+    (match: (content: string) => boolean, state: SearchState) => {
+      setMatch(() => match)
+      setHasSearch(state.text.length > 0)
+    },
+    [],
+  )
   const hasTableData = filterConn.length > 0
 
   return (

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -74,6 +74,8 @@ const orderFunctionMap = ORDER_OPTIONS.reduce<Record<OrderKey, OrderFunc>>(
   {} as Record<OrderKey, OrderFunc>,
 )
 
+const EMPTY_CONNECTIONS: IConnectionsItem[] = []
+
 const ConnectionsPage = () => {
   const { t } = useTranslation()
   const [match, setMatch] = useState<(input: string) => boolean>(
@@ -95,13 +97,14 @@ const ConnectionsPage = () => {
 
   const [isColumnManagerOpen, setIsColumnManagerOpen] = useState(false)
 
-  const [filterConn] = useMemo(() => {
+  const selectedConnections =
+    connectionsType === 'active'
+      ? (connections?.activeConnections ?? EMPTY_CONNECTIONS)
+      : (connections?.closedConnections ?? EMPTY_CONNECTIONS)
+
+  const filterConn = useMemo(() => {
     const orderFunc = orderFunctionMap[curOrderOpt]
-    const conns =
-      (connectionsType === 'active'
-        ? connections?.activeConnections
-        : connections?.closedConnections) ?? []
-    let matchConns = conns.filter((conn) => {
+    let matchConns = selectedConnections.filter((conn) => {
       const { host, destinationIP, process } = conn.metadata
       return (
         match(host || '') || match(destinationIP || '') || match(process || '')
@@ -110,13 +113,23 @@ const ConnectionsPage = () => {
 
     if (orderFunc) matchConns = orderFunc(matchConns ?? [])
 
-    return [matchConns]
-  }, [connections, connectionsType, match, curOrderOpt])
+    return matchConns
+  }, [selectedConnections, match, curOrderOpt])
 
   const { rows: displayRows, getConnectionById } =
     useConnectionRowViews(filterConn)
 
   const detailRef = useRef<ConnectionDetailRef>(null!)
+
+  const selectConnectionsType = useCallback(
+    (type: 'active' | 'closed') => {
+      if (type === connectionsType) return
+      detailRef.current?.close()
+      setIsColumnManagerOpen(false)
+      setConnectionsType(type)
+    },
+    [connectionsType],
+  )
 
   const showDetailById = useCallback(
     (id: string) => {
@@ -206,7 +219,7 @@ const ConnectionsPage = () => {
           <Button
             size="small"
             variant={connectionsType === 'active' ? 'contained' : 'outlined'}
-            onClick={() => setConnectionsType('active')}
+            onClick={() => selectConnectionsType('active')}
           >
             {t('connections.components.actions.active')}{' '}
             {connections?.activeConnections.length}
@@ -214,7 +227,7 @@ const ConnectionsPage = () => {
           <Button
             size="small"
             variant={connectionsType === 'closed' ? 'contained' : 'outlined'}
-            onClick={() => setConnectionsType('closed')}
+            onClick={() => selectConnectionsType('closed')}
           >
             {t('connections.components.actions.closed')}{' '}
             {connections?.closedConnections.length}
@@ -262,6 +275,7 @@ const ConnectionsPage = () => {
         <BaseEmpty />
       ) : isTableLayout ? (
         <ConnectionTable
+          key={connectionsType}
           connections={displayRows}
           onShowDetail={showDetailById}
           columnManagerOpen={isTableLayout && isColumnManagerOpen}
@@ -269,6 +283,7 @@ const ConnectionsPage = () => {
         />
       ) : (
         <VirtualList
+          key={connectionsType}
           count={filterConn.length}
           estimateSize={56}
           renderItem={(i) => (

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -116,8 +116,9 @@ const ConnectionsPage = () => {
     return matchConns
   }, [selectedConnections, match, curOrderOpt])
 
-  const { rows: displayRows, getConnectionById } =
-    useConnectionRowViews(filterConn)
+  const displayRows = useConnectionRowViews(
+    isTableLayout ? EMPTY_CONNECTIONS : filterConn,
+  )
 
   const detailRef = useRef<ConnectionDetailRef>(null!)
 
@@ -133,12 +134,12 @@ const ConnectionsPage = () => {
 
   const showDetailById = useCallback(
     (id: string) => {
-      const connection = getConnectionById(id)
+      const connection = filterConn.find((item) => item.id === id)
       if (connection) {
         detailRef.current?.open(connection, connectionsType === 'closed')
       }
     },
-    [connectionsType, getConnectionById],
+    [connectionsType, filterConn],
   )
 
   const onCloseAll = useLockFn(closeAllConnections)
@@ -275,7 +276,7 @@ const ConnectionsPage = () => {
         <BaseEmpty />
       ) : isTableLayout ? (
         <ConnectionTable
-          connections={displayRows}
+          connections={filterConn}
           onShowDetail={showDetailById}
           columnManagerOpen={isColumnManagerOpen}
           onCloseColumnManager={() => setIsColumnManagerOpen(false)}
@@ -283,7 +284,7 @@ const ConnectionsPage = () => {
       ) : (
         <VirtualList
           key={connectionsType}
-          count={filterConn.length}
+          count={displayRows.length}
           estimateSize={56}
           renderItem={(i) => (
             <ConnectionRowItem

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -30,7 +30,8 @@ import {
   ConnectionDetail,
   ConnectionDetailRef,
 } from '@/components/connection/connection-detail'
-import { ConnectionItem } from '@/components/connection/connection-item'
+import { ConnectionRowItem } from '@/components/connection/connection-row-item'
+import { useConnectionRowViews } from '@/components/connection/connection-row-view'
 import { ConnectionTable } from '@/components/connection/connection-table'
 import { useConnectionData } from '@/hooks/use-connection-data'
 import { useConnectionSetting } from '@/hooks/use-connection-setting'
@@ -112,9 +113,22 @@ const ConnectionsPage = () => {
     return [matchConns]
   }, [connections, connectionsType, match, curOrderOpt])
 
-  const onCloseAll = useLockFn(closeAllConnections)
+  const { rows: displayRows, getConnectionById } =
+    useConnectionRowViews(filterConn)
 
   const detailRef = useRef<ConnectionDetailRef>(null!)
+
+  const showDetailById = useCallback(
+    (id: string) => {
+      const connection = getConnectionById(id)
+      if (connection) {
+        detailRef.current?.open(connection, connectionsType === 'closed')
+      }
+    },
+    [connectionsType, getConnectionById],
+  )
+
+  const onCloseAll = useLockFn(closeAllConnections)
 
   const handleSearch = useCallback((match: (content: string) => boolean) => {
     setMatch(() => match)
@@ -248,10 +262,8 @@ const ConnectionsPage = () => {
         <BaseEmpty />
       ) : isTableLayout ? (
         <ConnectionTable
-          connections={filterConn}
-          onShowDetail={(detail) =>
-            detailRef.current?.open(detail, connectionsType === 'closed')
-          }
+          connections={displayRows}
+          onShowDetail={showDetailById}
           columnManagerOpen={isTableLayout && isColumnManagerOpen}
           onCloseColumnManager={() => setIsColumnManagerOpen(false)}
         />
@@ -260,15 +272,10 @@ const ConnectionsPage = () => {
           count={filterConn.length}
           estimateSize={56}
           renderItem={(i) => (
-            <ConnectionItem
-              value={filterConn[i]}
+            <ConnectionRowItem
+              row={displayRows[i]}
               closed={connectionsType === 'closed'}
-              onShowDetail={() =>
-                detailRef.current?.open(
-                  filterConn[i],
-                  connectionsType === 'closed',
-                )
-              }
+              onShowDetail={showDetailById}
             />
           )}
           style={{

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -277,7 +277,7 @@ const ConnectionsPage = () => {
         <ConnectionTable
           connections={displayRows}
           onShowDetail={showDetailById}
-          columnManagerOpen={isTableLayout && isColumnManagerOpen}
+          columnManagerOpen={isColumnManagerOpen}
           onCloseColumnManager={() => setIsColumnManagerOpen(false)}
         />
       ) : (

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -275,7 +275,6 @@ const ConnectionsPage = () => {
         <BaseEmpty />
       ) : isTableLayout ? (
         <ConnectionTable
-          key={connectionsType}
           connections={displayRows}
           onShowDetail={showDetailById}
           columnManagerOpen={isTableLayout && isColumnManagerOpen}


### PR DESCRIPTION
## Summary

Fixes long-running frontend memory growth on the Connections page.

The main issue was the `/connections` render hot path retaining and recreating large object graphs on every websocket snapshot. TanStack Table row/cell construction, default ordering/filtering, and Home’s full
 connection subscription together amplified memory pressure during long idle sessions, especially with active churn and capped closed connections.

This PR replaces the heavy table path with lightweight visible-row rendering, stabilizes connection row view models, and scopes full connection snapshots to the Connections route.

## Changes

- Replace TanStack Table row/cell instantiation with lightweight virtualized table rendering.
- Render table/list from stable `ConnectionRowView` display models.
- Keep detail state by connection id instead of retaining old connection objects.
- Scope full active/closed connection snapshots to `/connections`.
- Make Home use a lightweight connection summary for totals and active count.
- Only process/render the selected Active or Closed mode.
- Preserve existing behavior: column order, visibility, resizing, sorting, details, closed cap, and 500ms refresh cadence.

## Related commits

- Introduced table pressure: bf06cbc87d9d4bc7563d2b127de1906e2a6201b6
- Related ordering hot path: 068678135
- Related Home retention path: 7fc238c27b52a46ad6a03a88eb130488f2e3e93c

## How to test

- Launch the app and stay on the Dashboard/Home page for at least 1 hour. Verify that frontend memory usage does not grow abnormally.
- Switch to the Connections page in Table layout and keep it open for at least 1 hour. Verify that frontend memory usage remains stable and does not show abnormal growth.

Assign to GPT-5.5 xhigh

---

<img width="770" height="401" alt="screenshot-1" src="https://github.com/user-attachments/assets/6e4a950b-9621-4a26-aa66-7b5903de25b0" />

