### PR TITLE
fix(macOS): early setup macOS activation policy

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,6 +238,19 @@ pub fn run() {
 
             resolve::init_work_dir_and_logger()?;
 
+            #[cfg(target_os = "macos")]
+            {
+                use crate::config::Config;
+                use crate::core::handle::Handle;
+
+                AsyncHandler::block_on(async {
+                    let is_silent_start = Config::verge().await.data_arc().enable_silent_start.unwrap_or(false);
+                    if is_silent_start {
+                        Handle::global().set_activation_policy_accessory();
+                    }
+                });
+            }
+
             logging!(info, Type::Setup, "开始应用初始化...");
             if let Err(e) = app_init::setup_autostart(app) {
                 logging!(error, Type::Setup, "Failed to setup autostart: {}", e);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,19 +238,6 @@ pub fn run() {
 
             resolve::init_work_dir_and_logger()?;
 
-            #[cfg(target_os = "macos")]
-            {
-                use crate::config::Config;
-                use crate::core::handle::Handle;
-
-                AsyncHandler::block_on(async {
-                    let is_silent_start = Config::verge().await.data_arc().enable_silent_start.unwrap_or(false);
-                    if is_silent_start {
-                        Handle::global().set_activation_policy_accessory();
-                    }
-                });
-            }
-
             logging!(info, Type::Setup, "开始应用初始化...");
             if let Err(e) = app_init::setup_autostart(app) {
                 logging!(error, Type::Setup, "Failed to setup autostart: {}", e);

--- a/src-tauri/src/utils/resolve/mod.rs
+++ b/src-tauri/src/utils/resolve/mod.rs
@@ -198,11 +198,6 @@ pub(super) async fn refresh_tray_menu() {
 
 pub(super) async fn init_window() {
     let is_silent_start = Config::verge().await.data_arc().enable_silent_start.unwrap_or(false);
-    #[cfg(target_os = "macos")]
-    if is_silent_start {
-        use crate::core::handle::Handle;
-        Handle::global().set_activation_policy_accessory();
-    }
     WindowManager::create_window(!is_silent_start).await;
 }
 

--- a/src-tauri/src/utils/resolve/mod.rs
+++ b/src-tauri/src/utils/resolve/mod.rs
@@ -50,6 +50,8 @@ pub fn resolve_setup_async() {
     AsyncHandler::spawn(|| async {
         logging!(info, Type::ClashVergeRev, "Version: {}", env!("CARGO_PKG_VERSION"));
 
+        #[cfg(target_os = "macos")]
+        resolve_dock_show().await;
         init_startup_script().await;
         init_verge_config().await;
         Config::verify_config_initialization().await;
@@ -199,6 +201,14 @@ pub(super) async fn refresh_tray_menu() {
 pub(super) async fn init_window() {
     let is_silent_start = Config::verge().await.data_arc().enable_silent_start.unwrap_or(false);
     WindowManager::create_window(!is_silent_start).await;
+}
+
+#[cfg(target_os = "macos")]
+pub(super) async fn resolve_dock_show() {
+    let is_silent_start = Config::verge().await.data_arc().enable_silent_start.unwrap_or(false);
+    if is_silent_start {
+        Handle::global().set_activation_policy_accessory();
+    }
 }
 
 pub fn resolve_done() {


### PR DESCRIPTION
Closes #7240 

应用启动时尽早设置macOS的激活策略