### PR TITLE
fix: replace toSorted with slice().sort() for macOS 12 compatibility

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 - 修复订阅 URL 使用空密码 Basic Auth 时未发送认证信息的问题
 - Linux 托盘可能与其他 tauri 程序托盘冲突导致图标异常
 - 修复前端连接页面导致的内存泄漏
+- macOS 12(Monterey) 首页 IP 卡兼容性
 
 <details>
 <summary><strong> ✨ 新增功能 </strong></summary>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -145,7 +145,7 @@ export const getIpInfo = async (): Promise<
   const maxRetries = 2
   const serviceTimeout = 5000
 
-  const shuffledServices = IP_CHECK_SERVICES.toSorted(() => Math.random() - 0.5)
+  const shuffledServices = IP_CHECK_SERVICES.slice().sort(() => Math.random() - 0.5)
   let lastError: unknown | null = null
   const userAgent = await getUserAgentPromise()
   console.debug('User-Agent for IP detection:', userAgent)


### PR DESCRIPTION
Fixes #7216

### Problem

On macOS 12 (Monterey), the IP info panel on the dashboard throws:

```ts
ce.toSorted is not a function
```

The system WKWebView uses WebKit versions older than 16, which do not support `Array.prototype.toSorted()`.

The issue comes from:

```ts
const shuffledServices = IP_CHECK_SERVICES.toSorted(() => Math.random() - 0.5)
```

### Solution

Replaced `toSorted()` with `slice().sort()`, which preserves the existing behavior while remaining compatible with older WebKit versions.

```ts
const shuffledServices = IP_CHECK_SERVICES.slice().sort(() => Math.random() - 0.5)
```

### Testing

* verified there are no other `toSorted()` usages in the codebase
* verified the shuffle behavior is preserved and services are still randomized on each call
