### PR TITLE
fix: improve type safety and remove redundant type casts

### DIFF
--- a/src/components/setting/mods/guard-state.tsx
+++ b/src/components/setting/mods/guard-state.tsx
@@ -45,7 +45,7 @@ export function GuardState<T>(props: Props<T>) {
     lockRef.current = true
 
     try {
-      const newValue = onFormat ? (onFormat as any)(...args) : (args[0] as T)
+      const newValue = onFormat ? onFormat(...args) : (args[0] as T)
       // 先在ui上响应操作
       onChange(newValue)
 

--- a/src/components/setting/setting-clash.tsx
+++ b/src/components/setting/setting-clash.tsx
@@ -224,7 +224,7 @@ const SettingClash = ({ onError }: Props) => {
           sx={{ width: 100, input: { py: '7.5px', cursor: 'pointer' } }}
           onClick={(e) => {
             portRef.current?.open()
-            ;(e.target as any).blur()
+            ;(e.target as HTMLElement).blur()
           }}
         />
       </SettingItem>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -145,7 +145,9 @@ export const getIpInfo = async (): Promise<
   const maxRetries = 2
   const serviceTimeout = 5000
 
-  const shuffledServices = IP_CHECK_SERVICES.slice().sort(() => Math.random() - 0.5)
+  const shuffledServices = IP_CHECK_SERVICES.slice().sort(
+    () => Math.random() - 0.5,
+  )
   let lastError: unknown | null = null
   const userAgent = await getUserAgentPromise()
   console.debug('User-Agent for IP detection:', userAgent)

--- a/src/utils/traffic-diagnostics.ts
+++ b/src/utils/traffic-diagnostics.ts
@@ -39,7 +39,7 @@ export function recordTrafficError(error: Error, component: string) {
  */
 function getMemoryUsage(): number {
   if ('memory' in performance) {
-    // @@ts-expect-error - 某些浏览器支持
+    // @ts-expect-error - performance.memory is a non-standard Chrome API
     const memory = (performance as any).memory
     if (memory && memory.usedJSHeapSize) {
       return memory.usedJSHeapSize / 1024 / 1024 // 转换为MB

--- a/src/utils/traffic-diagnostics.ts
+++ b/src/utils/traffic-diagnostics.ts
@@ -39,8 +39,7 @@ export function recordTrafficError(error: Error, component: string) {
  */
 function getMemoryUsage(): number {
   if ('memory' in performance) {
-    // @ts-expect-error - performance.memory is a non-standard Chrome API
-    const memory = performance.memory
+    const memory = (performance as any).memory
     if (memory && memory.usedJSHeapSize) {
       return memory.usedJSHeapSize / 1024 / 1024 // 转换为MB
     }

--- a/src/utils/traffic-diagnostics.ts
+++ b/src/utils/traffic-diagnostics.ts
@@ -40,7 +40,7 @@ export function recordTrafficError(error: Error, component: string) {
 function getMemoryUsage(): number {
   if ('memory' in performance) {
     // @ts-expect-error - performance.memory is a non-standard Chrome API
-    const memory = (performance as any).memory
+    const memory = performance.memory
     if (memory && memory.usedJSHeapSize) {
       return memory.usedJSHeapSize / 1024 / 1024 // 转换为MB
     }


### PR DESCRIPTION
## Summary

Three small type-safety improvements across the frontend codebase.

## Changes

1. Fix `@ts-expect-error` typo in `traffic-diagnostics.ts` (`@@ts-expect-error` → `@ts-expect-error`), restoring the intended TypeScript suppression.
2. Replace `(e.target as any).blur()` with `(e.target as HTMLElement).blur()` in `setting-clash.tsx`.
3. Remove the redundant `(onFormat as any)` cast in `guard-state.tsx`, since `onFormat` is already correctly typed.

## Testing

* Type-level changes only; no runtime behavior changes.
* Verified that the updated typings are consistent with existing patterns in the codebase.
