### PR TITLE
fix: crash on malformed ss:// URI with invalid v2ray-plugin data

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -145,7 +145,9 @@ export const getIpInfo = async (): Promise<
   const maxRetries = 2
   const serviceTimeout = 5000
 
-  const shuffledServices = IP_CHECK_SERVICES.slice().sort(() => Math.random() - 0.5)
+  const shuffledServices = IP_CHECK_SERVICES.slice().sort(
+    () => Math.random() - 0.5,
+  )
   let lastError: unknown | null = null
   const userAgent = await getUserAgentPromise()
   console.debug('User-Agent for IP detection:', userAgent)

--- a/src/utils/uri-parser/ss.ts
+++ b/src/utils/uri-parser/ss.ts
@@ -92,7 +92,12 @@ export function URI_SS(line: string): IProxyShadowsocksConfig {
   const v2rayPluginParam = queryParams['v2ray-plugin']
   if (!proxy.plugin && v2rayPluginParam) {
     proxy.plugin = 'v2ray-plugin'
-    proxy['plugin-opts'] = JSON.parse(decodeBase64OrOriginal(v2rayPluginParam))
+    try {
+      proxy['plugin-opts'] = JSON.parse(decodeBase64OrOriginal(v2rayPluginParam))
+    } catch (e) {
+      console.warn('[URI_SS] v2ray-plugin JSON.parse failed:', e)
+      proxy['plugin-opts'] = {}
+    }
   }
 
   if (

--- a/src/utils/uri-parser/ss.ts
+++ b/src/utils/uri-parser/ss.ts
@@ -93,7 +93,9 @@ export function URI_SS(line: string): IProxyShadowsocksConfig {
   if (!proxy.plugin && v2rayPluginParam) {
     proxy.plugin = 'v2ray-plugin'
     try {
-      proxy['plugin-opts'] = JSON.parse(decodeBase64OrOriginal(v2rayPluginParam))
+      proxy['plugin-opts'] = JSON.parse(
+        decodeBase64OrOriginal(v2rayPluginParam),
+      )
     } catch (e) {
       console.warn('[URI_SS] v2ray-plugin JSON.parse failed:', e)
       proxy['plugin-opts'] = {}


### PR DESCRIPTION
### Problem

  `URI_SS` calls `JSON.parse` on user-supplied base64 data from the `v2ray-plugin` query parameter without a try-catch.
  A malformed or corrupted `ss://` URI throws an unhandled exception that crashes the entire profile import flow.

  The other URI parsers already handle this:
  - `vless.ts:186-192` — try-catch with `console.warn`
  - `vmess.ts:51-55` — try-catch with fallback
  - `ss.ts:95` — **no protection** ← this PR

  ### Solution

  Wrapped the `JSON.parse` call in try-catch with `console.warn`, falling back to empty `plugin-opts`. Matches the
  existing error handling pattern in `vless.ts`.

  ### Testing

  - No unit test infrastructure in this project
  - Verified the fix follows the same pattern as `vless.ts:186-192` and `vmess.ts:51-55`
