### PR TITLE
fix(webdav): resolve upload and download failures

### DIFF
--- a/src-tauri/src/core/backup.rs
+++ b/src-tauri/src/core/backup.rs
@@ -23,8 +23,8 @@ const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const TIMEOUT_UPLOAD: u64 = 300; // 上传超时 5 分钟
 const TIMEOUT_DOWNLOAD: u64 = 300; // 下载超时 5 分钟
-const TIMEOUT_LIST: u64 = 3; // 列表超时 30 秒
-const TIMEOUT_DELETE: u64 = 3; // 删除超时 30 秒
+const TIMEOUT_LIST: u64 = 30; // 列表超时 30 秒
+const TIMEOUT_DELETE: u64 = 30; // 删除超时 30 秒
 
 #[derive(Clone)]
 struct WebDavConfig {
@@ -130,19 +130,35 @@ impl WebDavClient {
             .set_auth(reqwest_dav::Auth::Basic(config.username.into(), config.password.into()))
             .build()?;
 
-        // 尝试检查目录是否存在，如果不存在尝试创建
-        if client
-            .list(dirs::BACKUP_DIR, reqwest_dav::Depth::Number(0))
-            .await
-            .is_err()
         {
+            // 直接尝试创建
             match client.mkcol(dirs::BACKUP_DIR).await {
                 Ok(_) => logging!(info, Type::Backup, "Successfully created backup directory"),
                 Err(e) => {
-                    logging!(warn, Type::Backup, "Warning: Failed to create backup directory: {}", e);
-                    // 清除缓存，强制下次重新尝试
-                    self.reset();
-                    return Err(anyhow::Error::msg(format!("Failed to create backup directory: {}", e)));
+                    // 提取网络状态码
+                    let status_code = match &e {
+                        reqwest_dav::Error::Decode(reqwest_dav::DecodeError::Server(server_err)) => Some(server_err.response_code),
+                        reqwest_dav::Error::Decode(reqwest_dav::DecodeError::StatusMismatched(status_err)) => Some(status_err.response_code),
+                        reqwest_dav::Error::Reqwest(http_err) => http_err.status().map(|s| s.as_u16()),
+                        _ => None,
+                    };
+                    match status_code {
+                        Some(405) => {
+                            // 按照 RFC 4918 的规定：
+                            // 405 代表 如果目标 URI 已经映射到一个资源（集合或非集合），则 MKCOL 必须返回 405（Method Not Allowed）。
+                            logging!(info, Type::Backup, "Backup directory already exists");
+                        }
+                        Some(409) => {
+                            // 按照 RFC 4918 的规定：
+                            // 409 代表 父目录不存在，需要先创建父目录
+                            logging!(warn, Type::Backup, "Backup directory cannot be created because its parent folder does not exist");
+                            return Err(anyhow::Error::msg(format!("Failed to create backup directory: {}", "Parent directory does not exist")));
+                        }
+                        _ => {
+                            logging!(warn, Type::Backup, "Failed to create backup directory: {}", e);
+                            return Err(anyhow::Error::msg(format!("Failed to create backup directory: {}", e)));
+                        }
+                    }
                 }
             }
         }

--- a/src-tauri/src/feat/backup.rs
+++ b/src-tauri/src/feat/backup.rs
@@ -95,6 +95,8 @@ pub async fn create_backup_and_upload_webdav() -> Result<()> {
 pub async fn list_wevdav_backup() -> Result<Vec<ListFile>> {
     backup::WebDavClient::global().list().await.map_err(|err| {
         logging!(error, Type::Backup, "Failed to list WebDAV backup files: {err:#?}");
+        // 列表失败时重置客户端缓存
+        backup::WebDavClient::global().reset();
         err
     })
 }
@@ -103,6 +105,8 @@ pub async fn list_wevdav_backup() -> Result<Vec<ListFile>> {
 pub async fn delete_webdav_backup(filename: String) -> Result<()> {
     backup::WebDavClient::global().delete(filename).await.map_err(|err| {
         logging!(error, Type::Backup, "Failed to delete WebDAV backup file: {err:#?}");
+        // 删除失败时重置客户端缓存
+        backup::WebDavClient::global().reset();
         err
     })
 }
@@ -123,6 +127,8 @@ pub async fn restore_webdav_backup(filename: String) -> Result<()> {
         .await
         .map_err(|err| {
             logging!(error, Type::Backup, "Failed to download WebDAV backup file: {err:#?}");
+            // 下载失败时重置客户端缓存
+            backup::WebDavClient::global().reset();
             err
         })?;
 


### PR DESCRIPTION
Fix WebDAV upload and download failures.

Fixes #7239

## Changes

* Fixed an incorrect timeout constant configuration.
* Optimized remote directory creation logic.
* Optimized the logic for clearing failed requests.
* Added a clearer error message for HTTP 409 responses when the parent directory does not exist.
* Fixed an issue where HTTP 405 responses were incorrectly treated as failures.