### PR TITLE
fix: ensure automatic scroll to bottom when switching to logs page

### DIFF
--- a/src/pages/logs.tsx
+++ b/src/pages/logs.tsx
@@ -61,21 +61,15 @@ const LogPage = () => {
     [filterLogs, isDescending],
   )
 
-  const scrollRef = useRef({ isNearBottom: true, length: 0 })
+  const scrollRef = useRef({ isNearBottom: true })
   const virtuosoRef = useRef<VirtualListHandle>(null)
 
   useEffect(() => {
-    if (
-      !isDescending &&
-      filteredLogs.length > scrollRef.current.length &&
-      scrollRef.current.isNearBottom
-    ) {
+    if (!isDescending && scrollRef.current.isNearBottom) {
       virtuosoRef.current?.scrollToIndex(filteredLogs.length - 1, {
         behavior: 'smooth',
       })
     }
-
-    scrollRef.current.length = filteredLogs.length
   }, [isDescending, filteredLogs.length])
 
   const handleLogLevelChange = (newLevel: LogFilter) => {


### PR DESCRIPTION
close #7251
简化scrollRef, 使只要靠近底部就自动滚动