### PR TITLE
pref(frontend): stop idle connection and traffic streams

### DIFF
--- a/src/components/home/enhanced-traffic-stats.tsx
+++ b/src/components/home/enhanced-traffic-stats.tsx
@@ -148,9 +148,11 @@ export const EnhancedTrafficStats = () => {
   // 是否显示流量图表
   const trafficGraph = verge?.traffic_graph ?? true
 
+  // Gate only on visibility: the speed/total stat cards are always rendered,
+  // so the traffic stream must keep flowing even when the graph is hidden.
   const {
     response: { data: traffic },
-  } = useTrafficData({ enabled: trafficGraph && pageVisible })
+  } = useTrafficData({ enabled: pageVisible })
 
   const {
     response: { data: memory },
@@ -158,7 +160,7 @@ export const EnhancedTrafficStats = () => {
 
   const {
     response: { data: connectionSummary },
-  } = useConnectionSummaryData()
+  } = useConnectionSummaryData({ enabled: pageVisible })
 
   // Canvas组件现在直接从全局Hook获取数据，无需手动添加数据点
 

--- a/src/components/layout/layout-traffic.tsx
+++ b/src/components/layout/layout-traffic.tsx
@@ -28,9 +28,11 @@ export const LayoutTraffic = () => {
   const trafficRef = useRef<TrafficRef>(null)
   const pageVisible = useVisibility()
 
+  // Gate only on visibility: the up/down speed numbers are always shown, so the
+  // traffic stream must keep flowing even when the graph is hidden.
   const {
     response: { data: traffic },
-  } = useTrafficData({ enabled: trafficGraph && pageVisible })
+  } = useTrafficData({ enabled: pageVisible })
   const {
     response: { data: memory },
   } = useMemoryData()

--- a/src/hooks/use-connection-data.ts
+++ b/src/hooks/use-connection-data.ts
@@ -217,6 +217,10 @@ const flushPendingMessage = () => {
   pendingMessageData = null
   if (!messageData) return
 
+  const needsConnectionData = connectionListeners.size > 0
+  const needsSummary = summaryListeners.size > 0
+  if (!needsConnectionData && !needsSummary) return
+
   let payload: IConnections
   try {
     payload = JSON.parse(messageData) as IConnections
@@ -229,7 +233,7 @@ const flushPendingMessage = () => {
   connectionSummary = mergeConnectionSummary(payload)
   notifySummaryListeners()
 
-  if (connectionListeners.size === 0) return
+  if (!needsConnectionData) return
 
   connectionData = mergeConnectionSnapshot(payload, connectionData)
   notifyConnectionListeners()
@@ -290,6 +294,14 @@ async function connectConnectionSocket() {
 
   try {
     const socket = await MihomoWebSocket.connect_connections()
+    // The monitor may have been stopped while we were connecting; discard the
+    // socket instead of holding it open with no listeners.
+    if (!connectionStarted) {
+      void socket.close().catch((err) => {
+        console.warn('Failed to close connection websocket', err)
+      })
+      return
+    }
     connectionSocket = socket
     socket.addListener((message) => {
       if (message.type !== 'Text') return
@@ -301,7 +313,7 @@ async function connectConnectionSocket() {
       enqueueConnectionMessage(message.data)
     })
   } catch {
-    scheduleReconnect()
+    if (connectionStarted) scheduleReconnect()
   } finally {
     connectionConnecting = false
   }
@@ -313,14 +325,34 @@ const startConnectionMonitor = () => {
   void connectConnectionSocket()
 }
 
+const stopConnectionMonitor = () => {
+  if (connectionListeners.size > 0 || summaryListeners.size > 0) return
+  if (!connectionStarted) return
+  // Leave connectionConnecting untouched: an in-flight connect keeps the guard
+  // closed so a quick re-subscribe can't open a second concurrent socket.
+  connectionStarted = false
+  clearReconnectTimer()
+  if (flushTimer) {
+    window.clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  pendingMessageData = null
+  void closeConnectionSocket()
+}
+
 const getConnectionSnapshot = () => connectionData
 const getConnectionSummarySnapshot = () => connectionSummary
+
+// Stable no-op subscriber used when a hook is disabled, so it registers no
+// listener and lets stopConnectionMonitor close the socket.
+const noopSubscribe = () => () => {}
 
 const subscribeConnectionData = (listener: ConnectionListener) => {
   startConnectionMonitor()
   connectionListeners.add(listener)
   return () => {
     connectionListeners.delete(listener)
+    stopConnectionMonitor()
   }
 }
 
@@ -329,6 +361,7 @@ const subscribeConnectionSummary = (listener: ConnectionListener) => {
   summaryListeners.add(listener)
   return () => {
     summaryListeners.delete(listener)
+    stopConnectionMonitor()
   }
 }
 
@@ -351,9 +384,10 @@ const clearClosedConnectionData = () => {
   notifyConnectionListeners()
 }
 
-export const useConnectionData = () => {
+export const useConnectionData = (options?: { enabled?: boolean }) => {
+  const enabled = options?.enabled ?? true
   const data = useSyncExternalStore(
-    subscribeConnectionData,
+    enabled ? subscribeConnectionData : noopSubscribe,
     getConnectionSnapshot,
     getConnectionSnapshot,
   )
@@ -372,9 +406,10 @@ export const useConnectionData = () => {
   }
 }
 
-export const useConnectionSummaryData = () => {
+export const useConnectionSummaryData = (options?: { enabled?: boolean }) => {
+  const enabled = options?.enabled ?? true
   const data = useSyncExternalStore(
-    subscribeConnectionSummary,
+    enabled ? subscribeConnectionSummary : noopSubscribe,
     getConnectionSummarySnapshot,
     getConnectionSummarySnapshot,
   )

--- a/src/hooks/use-traffic-data.ts
+++ b/src/hooks/use-traffic-data.ts
@@ -33,7 +33,7 @@ export const useTrafficData = (options?: { enabled?: boolean }) => {
   } = useTrafficMonitorEnhanced({ subscribe: false, enabled })
   const { response, refresh } = useMihomoWsSubscription<ITrafficItem>({
     storageKey: 'mihomo_traffic_date',
-    buildSubscriptKey: (date) => `getClashTraffic-${date}`,
+    buildSubscriptKey: (date) => (enabled ? `getClashTraffic-${date}` : null),
     fallbackData: FALLBACK_TRAFFIC,
     connect: () => MihomoWebSocket.connect_traffic(),
     throttleMs: 200,

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -40,6 +40,7 @@ import { ConnectionTable } from '@/components/connection/connection-table'
 import { useConnectionData } from '@/hooks/use-connection-data'
 import { useConnectionSetting } from '@/hooks/use-connection-setting'
 import { useTrafficData } from '@/hooks/use-traffic-data'
+import { useVisibility } from '@/hooks/use-visibility'
 import parseTraffic from '@/utils/parse-traffic'
 
 type OrderFunc = (list: IConnectionsItem[]) => IConnectionsItem[]
@@ -89,13 +90,14 @@ const ConnectionsPage = () => {
     'active',
   )
 
+  const pageVisible = useVisibility()
   const {
     response: { data: connections },
     clearClosedConnections,
-  } = useConnectionData()
+  } = useConnectionData({ enabled: pageVisible })
   const {
     response: { data: traffic },
-  } = useTrafficData()
+  } = useTrafficData({ enabled: pageVisible })
 
   const [setting, setSetting] = useConnectionSetting()
 


### PR DESCRIPTION
## Summary

Close the /connections and /traffic websocket streams once nothing is consuming them, instead of keeping them open for the lifetime of the app.

This builds on #7227, which scoped the heavy connection rendering to the /connections route. This PR additionally closes the underlying sockets when no one is listening and pauses them while the window is hidden. 

## Changes
- use-connection-data: stop the connection monitor when the last subscriber unsubscribes (close socket, clear pending
JSON, cancel timers); discard the socket if the monitor was stopped mid-connect; add an enabled flag to the connection
hooks;
- use-traffic-data: return a null subscription key when disabled so the shared traffic socket is actually torn down;
- home/layout/connections: gate the streams on page visibility so hidden windows stop receiving full connections/traffic
payloads, while keeping the always-visible speed/total numbers driven only by visibility.


