### PR TITLE
fix: linux Wayland 下自定义标题栏按钮不响应点击/hover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,7 +2036,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2324,7 +2324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3684,7 +3684,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4245,7 +4245,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4412,7 +4412,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4833,7 +4833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6090,7 +6090,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6149,7 +6149,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6774,7 +6774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7032,9 +7032,8 @@ checksum = "c0e973b34477b7823833469eb0f5a3a60370fef7a453e02d751b59180d0a5a05"
 
 [[package]]
 name = "tao"
-version = "0.35.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
+version = "0.35.2"
+source = "git+https://github.com/dgerhardt/tao?branch=fix-wayland-csd#098cfb363f9c268f0d906a33ac91469330302ae5"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
@@ -7061,7 +7060,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "raw-window-handle",
- "tao-macros",
+ "tao-macros 0.1.3 (git+https://github.com/dgerhardt/tao?branch=fix-wayland-csd)",
  "unicode-segmentation",
  "url",
  "windows 0.61.3",
@@ -7075,6 +7074,16 @@ name = "tao-macros"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tao-macros"
+version = "0.1.3"
+source = "git+https://github.com/dgerhardt/tao?branch=fix-wayland-csd#098cfb363f9c268f0d906a33ac91469330302ae5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7658,7 +7667,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8389,7 +8398,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8491,7 +8500,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9121,7 +9130,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9714,7 +9723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9873,7 +9882,7 @@ dependencies = [
  "raw-window-handle",
  "sha2 0.10.9",
  "soup3",
- "tao-macros",
+ "tao-macros 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.18",
  "tracing",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,13 @@ bitflags = { version = "2.13.0" }
 deelevate = "0.2.0"
 # *********************************
 
+[patch.crates-io]
+# Workaround for tauri-apps/tauri#14597 — tao's Wayland window event
+# propagation is broken, causing custom titlebar buttons to not respond
+# to clicks/hover. Replace with patched tao from tauri-apps/tao#1218.
+# Remove when upstream releases the fix.
+tao = { git = "https://github.com/dgerhardt/tao", branch = "fix-wayland-csd" }
+
 [workspace.lints.clippy]
 # fallible_impl_from = "deny" // 过于激进，暂时不开启
 # implicit_clone = "deny" // 可能会造成额外开销，暂时不开启

--- a/src/components/layout/window-controller.tsx
+++ b/src/components/layout/window-controller.tsx
@@ -41,6 +41,7 @@ export const WindowControls = forwardRef(function WindowControls(props, ref) {
 
   return (
     <Box
+      data-tauri-drag-region="false"
       sx={{
         display: 'flex',
         gap: 1,

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -203,9 +203,12 @@ const Layout = () => {
     void patchVerge({ collapse_navbar: !navCollapsed })
   }, [navCollapsed, patchVerge])
 
+  // On Linux decorations are configured false at build time — the custom
+  // HTML titlebar should always render. The runtime decorated state from
+  // tauri may be unreliable (especially with patched tao on Wayland).
   const customTitlebar = useMemo(
     () =>
-      !decorated ? (
+      OS === 'linux' || !decorated ? (
         <div className="the_titlebar">
           <div
             className="the_titlebar-drag-region"

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -7,7 +7,7 @@ import svgr from 'vite-plugin-svgr'
 
 export default defineConfig({
   root: 'src',
-  server: { port: 3000 },
+  server: { port: 3000, host: '127.0.0.1' },
   plugins: [
     svgr(),
     react(),


### PR DESCRIPTION
fix: linux Wayland 下自定义标题栏按钮不响应点击#6968
修复:
- Cargo.toml: 通过 [patch.crates-io] 将 tao 替换为
  dgerhardt/tao fix-wayland-csd 分支 (https://github.com/tauri-apps/tao/pull/1218)，
  该分支移除了破损的自定义 CSD 并用 GTK 原生 undecorated 窗口
  处理替代，修复了 Wayland 事件传播。
- _layout.tsx: Linux 下始终渲染自绘 HTML 标题栏
  (OS === 'linux' || !decorated)，不依赖 tao 的 isDecorated()
  返回值，因为 patched tao 的 set_titlebar(空EventBox) 会改变
  GTK 窗口布局。
- window-controller.tsx: 显式标记 data-tauri-drag-region="false"
  防止拖拽区域干扰按钮事件。