### PR TITLE
fix(ui): center sidebar item labels

### DIFF
--- a/src/components/layout/layout-item.tsx
+++ b/src/components/layout/layout-item.tsx
@@ -121,7 +121,6 @@ export const LayoutItem = (props: Props) => {
         <ListItemText
           sx={{
             textAlign: 'center',
-            marginLeft: effectiveMenuIcon === 'disable' ? '' : '-35px',
           }}
           primary={children}
         />


### PR DESCRIPTION
## Summary
- Remove the negative left offset from sidebar item labels.
- Keep labels centered within the list item text area.
<img width="599" height="1148" alt="image" src="https://github.com/user-attachments/assets/f2bcac1a-1953-4a32-8054-a7204a0cc20c" />

## Related Issue
Closes #7115

## Test plan
- Ran `pnpm lint`.
- Checked the sidebar item label alignment in dev mode.

<!-- gk-ai-analysis-start:365a559bf596d714de029060515797eb64f5f31f -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiUmVtb3ZlIG5lZ2F0aXZlIGxlZnQgb2Zmc2V0IGZyb20gc2lkZWJhciBpdGVtIGxhYmVscyB0byBjZW50ZXIgdGhlbSBjb3JyZWN0bHkgd2l0aGluIHRoZSBsaXN0IGl0ZW0gdGV4dCBhcmVhLiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IlNpZGViYXIgaXRlbSBsYXlvdXQgYWRqdXN0bWVudCIsImRlc2NyaXB0aW9uIjoiUmVtb3ZlZCBhIGNvbmRpdGlvbmFsIG5lZ2F0aXZlIGBtYXJnaW5MZWZ0YCB0aGF0IHdhcyBwcmV2aW91c2x5IGFwcGxpZWQgdG8gb2Zmc2V0IHRoZSBsYWJlbCB0ZXh0IHdoZW4gdGhlIG1lbnUgaWNvbiB3YXMgbm90IGRpc2FibGVkLiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJzcmMvY29tcG9uZW50cy9sYXlvdXQvbGF5b3V0LWl0ZW0udHN4IiwibGluZVN0YXJ0IjoxMTMsImxpbmVFbmQiOjExNH1dLCJpc3N1ZXMiOltdLCJzdWdnZXN0aW9ucyI6W10sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:365a559bf596d714de029060515797eb64f5f31f -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/clash-verge-rev/clash-verge-rev/pull/7289?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->