### PR TITLE
fix: refresh rules data when clash config is reloaded

### DIFF
--- a/src/pages/_layout/hooks/use-layout-events.ts
+++ b/src/pages/_layout/hooks/use-layout-events.ts
@@ -48,6 +48,8 @@ export const useLayoutEvents = (
           'getVersion',
           'getClashConfig',
           'getProxyProviders',
+          'getRules',
+          'getRuleProviders',
         ])
       }),
     )


### PR DESCRIPTION
Add 'getRules' and 'getRuleProviders' to the revalidation list for the 'verge://refresh-clash-config' event. Without this, saving a Script (or Merge with direct `rules:` override) updates the mihomo core but the frontend never re-fetches rules — the homepage rules count stays stale.

## Original behavior
Editing Merge or Script → Save → mihomo reloads config with updated rules → homepage still shows old rules count

## Behavior after fix
### Script editor
- Add rules (e.g. `config.rules = ["DOMAIN,...", ...config.rules]`) → save → rules count increases
- Remove rules → save → rules count decreases

### Merge editor
- Add/modify `rules:` field → save → rules count reflects the new list
- Note: Merge uses `deep_merge`, which replaces arrays entirely rather than appending. So setting `rules:` with 3 items will result in a total count of 3, not original + 3

Closes #7295