### PR TITLE
fix: improve hide_main_window logic when hotkey pressed

### DIFF
--- a/src-tauri/src/utils/window_manager.rs
+++ b/src-tauri/src/utils/window_manager.rs
@@ -187,7 +187,7 @@ impl WindowManager {
     fn hide_main_window(window: Option<&WebviewWindow<Wry>>) -> WindowOperationResult {
         logging!(info, Type::Window, "窗口可见，将隐藏窗口");
         if let Some(window) = window {
-            match window.hide() {
+            match window.close() {
                 Ok(_) => {
                     logging!(info, Type::Window, "窗口已成功隐藏");
                     WindowOperationResult::Hidden


### PR DESCRIPTION
close #7305

WINDOW_CLOSE_REQUESTED事件会在调用close方法时触发
目前按下快捷键所调用的方法是hide, 只会更改窗口可见性, 不会触发WINDOW_CLOSE_REQUESTED, 而自动进入轻量模式是靠监听WINDOW_CLOSE_REQUESTED实现的, 因此导致使用快捷键不会自动进入轻量模式

通过将调用的方法改为close, 可以解决这一问题