### PR TITLE
fix mihomo pipe startup race

### DIFF
--- a/src/hooks/use-clash.ts
+++ b/src/hooks/use-clash.ts
@@ -22,6 +22,14 @@ const PORT_KEYS = [
   'tproxy-port',
 ] as const
 
+const TQ_MIHOMO = {
+  refetchOnWindowFocus: false,
+  refetchOnReconnect: false,
+  staleTime: 1500,
+  retry: 5,
+  retryDelay: (attempt: number) => Math.min(200 * 2 ** attempt, 3000),
+} as const
+
 type ClashInfoPatch = Partial<
   Pick<
     IConfigData,
@@ -71,6 +79,7 @@ export const useClash = () => {
   const { data: versionData, refetch: mutateVersion } = useQuery({
     queryKey: ['getVersion'],
     queryFn: getVersion,
+    ...TQ_MIHOMO,
   })
 
   const mutateClash = (updater?: MutateClashUpdater, revalidate?: boolean) => {

--- a/src/providers/app-data-provider.tsx
+++ b/src/providers/app-data-provider.tsx
@@ -35,6 +35,9 @@ const TQ_MIHOMO = {
   retryDelay: (attempt: number) => Math.min(200 * 2 ** attempt, 3000),
 } as const
 
+const CORE_READY_RETRY_LIMIT = 15
+const CORE_READY_RETRY_INTERVAL = 1000
+
 const TQ_DEFAULTS = {
   refetchOnWindowFocus: false,
   refetchOnReconnect: false,
@@ -203,6 +206,30 @@ export const AppDataProvider = ({
     refreshSysproxy,
     refreshProxyProviders,
     refreshRuleProviders,
+  ])
+
+  useEffect(() => {
+    if (proxiesData && clashConfig) return
+
+    let attempts = 0
+    const timer = window.setInterval(() => {
+      attempts += 1
+      refreshProxy().catch(() => {})
+      refreshClashConfig().catch(() => {})
+      refreshProxyProviders().catch(() => {})
+
+      if (attempts >= CORE_READY_RETRY_LIMIT) {
+        window.clearInterval(timer)
+      }
+    }, CORE_READY_RETRY_INTERVAL)
+
+    return () => window.clearInterval(timer)
+  }, [
+    clashConfig,
+    proxiesData,
+    refreshClashConfig,
+    refreshProxy,
+    refreshProxyProviders,
   ])
 
   const proxiesValue = useMemo(


### PR DESCRIPTION
## Summary

### 中文

修复了一个启动时的竞态问题（Race Condition）。当应用在初始渲染时，如果 mihomo 的本地 Socket（命名管道）尚未准备就绪，会导致 UI 界面永久显示为空白的代理页面。

### English

Fix a startup race where the UI can permanently show an empty proxy page when the mihomo local socket is not ready during initial render.

---

## Root Cause

### 中文

Clash Verge 在启动 mihomo 边车（Sidecar）后，会立即通过 `\\.\pipe\verge-mihomo` 命名管道查询版本、配置、代理以及代理提供商（Proxy Providers）信息。如果此时 mihomo 仍在解析配置文件或尚未创建该管道，首次请求就会失败并抛出 `os error 2` 错误。在这种状态下，部分代理页面的数据无法自动恢复，导致即使核心程序后续正常运行，代理组视图也会一直保持空白。

### English

Clash Verge starts the mihomo sidecar and immediately queries version, config, proxies, and proxy providers over the `\\.\pipe\verge-mihomo` named pipe. If mihomo is still parsing configuration or has not created the pipe yet, the first request can fail with `os error 2`. In that state, some proxy page data may not recover automatically, leaving the proxy groups view blank even though the core is running correctly.

---

## Changes

### 中文

* 为 `getVersion` 查询添加了重试机制（Retry Behavior）。
* 在 `AppDataProvider` 中引入了一个简短的启动恢复循环（Startup Recovery Loop），当核心数据缺失时，会自动重新获取 Clash 配置、代理和代理提供商信息。

### English

* Add retry behavior to the `getVersion` query.
* Add a short startup recovery loop in `AppDataProvider` to refetch clash config, proxies, and proxy providers while core data is still missing.

---

## Validation

### 中文

* 运行了 `corepack pnpm typecheck` 检查类型。
* 在本地搭配自定义的 mihomo 边车成功构建并启动了应用。
* 确认启动后代理组页面能够正常渲染，不再出现空白。

### English

* Ran `corepack pnpm typecheck`.
* Built and launched the app locally with a custom mihomo sidecar.
* Confirmed the proxy groups page renders normally after startup.