### PR TITLE
fix: handle macOS IPC problem

### DIFF
--- a/src-tauri/src/core/service.rs
+++ b/src-tauri/src/core/service.rs
@@ -39,6 +39,97 @@ pub struct ServiceManager {
     operation_done: Notify,
 }
 
+#[cfg(not(target_os = "macos"))]
+fn service_core_path(clash_core: &str, bin_ext: &str) -> Result<PathBuf> {
+    Ok(current_exe()?.with_file_name(format!("{clash_core}{bin_ext}")))
+}
+
+#[cfg(target_os = "macos")]
+fn service_core_path(clash_core: &str, bin_ext: &str) -> Result<PathBuf> {
+    let binary_name = format!("{clash_core}{bin_ext}");
+    let exe_path = current_exe()?;
+    let candidate = exe_path.with_file_name(&binary_name);
+
+    if !is_macos_app_translocated(&exe_path) {
+        return Ok(candidate);
+    }
+
+    if let Some(stable_path) = stable_macos_core_path_for_translocated_app(&exe_path, &binary_name) {
+        logging!(
+            warn,
+            Type::Service,
+            "macOS App Translocation detected for core path {:?}; using stable installed path {:?}",
+            candidate,
+            stable_path
+        );
+        return Ok(stable_path);
+    }
+
+    bail!(
+        "macOS App Translocation detected; refusing to start service with temporary core path {:?}",
+        candidate
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn is_macos_app_translocated(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == "AppTranslocation")
+}
+
+#[cfg(target_os = "macos")]
+fn stable_macos_core_path_for_translocated_app(exe_path: &Path, binary_name: &str) -> Option<PathBuf> {
+    let bundle_name = macos_app_bundle_name(exe_path)?;
+    macos_core_path_in_install_roots(
+        &bundle_name,
+        binary_name,
+        [Path::new("/Applications"), Path::new("/Applications/Utilities")],
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn macos_app_bundle_name(path: &Path) -> Option<std::ffi::OsString> {
+    path.ancestors().find_map(|ancestor| {
+        let is_app_bundle = ancestor
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("app"));
+
+        if is_app_bundle {
+            ancestor.file_name().map(std::ffi::OsString::from)
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn macos_core_path_in_install_roots<'a>(
+    bundle_name: &std::ffi::OsStr,
+    binary_name: &str,
+    install_roots: impl IntoIterator<Item = &'a Path>,
+) -> Option<PathBuf> {
+    install_roots.into_iter().find_map(|root| {
+        let core_path = root
+            .join(Path::new(bundle_name))
+            .join("Contents")
+            .join("MacOS")
+            .join(binary_name);
+
+        core_path.is_file().then_some(core_path)
+    })
+}
+
+#[cfg(target_os = "macos")]
+const fn macos_cleanup_translocated_desired_state_shell() -> &'static str {
+    "for f in '/var/root/.local/state/clash-verge-service/desired-state.json' '/var/lib/clash-verge-service/desired-state.json'; do if [ -f \"$f\" ] && /usr/bin/grep -q AppTranslocation \"$f\"; then backup=\"$f.apptranslocation.bak\"; if [ -e \"$backup\" ]; then backup=\"$f.apptranslocation.$(/bin/date +%s).bak\"; fi; /bin/mv \"$f\" \"$backup\"; fi; done"
+}
+
+#[cfg(target_os = "macos")]
+fn escape_osascript_double_quoted_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 #[cfg(target_os = "windows")]
 fn uninstall_service() -> Result<()> {
     logging!(info, Type::Service, "uninstall service");
@@ -286,9 +377,12 @@ fn install_service() -> Result<()> {
 
     let gid = tauri_plugin_clash_verge_sysinfo::current_gid();
     let prompt = clash_verge_i18n::t!("service.adminInstallPrompt");
-    let command = format!(
-        r#"do shell script "sudo CLASH_VERGE_SERVICE_GID={gid} '{install_shell}'" with administrator privileges with prompt "{prompt}""#
+    let shell = format!(
+        "{}; sudo CLASH_VERGE_SERVICE_GID={gid} '{install_shell}'",
+        macos_cleanup_translocated_desired_state_shell()
     );
+    let shell = escape_osascript_double_quoted_string(&shell);
+    let command = format!(r#"do shell script "{shell}" with administrator privileges with prompt "{prompt}""#);
 
     let output = StdCommand::new("osascript").args(vec!["-e", &command]).output()?;
     if let Some((code, err)) = check_output_error(&output) {
@@ -356,7 +450,7 @@ pub(super) async fn start_with_existing_service(config_file: &PathBuf) -> Result
     drop(verge_config);
 
     let bin_ext = if cfg!(windows) { ".exe" } else { "" };
-    let bin_path = current_exe()?.with_file_name(format!("{clash_core}{bin_ext}"));
+    let bin_path = service_core_path(&clash_core, bin_ext)?;
 
     let payload = clash_verge_service_ipc::ClashConfig {
         core_config: CoreConfig {
@@ -586,3 +680,56 @@ pub static SERVICE_MANAGER: Lazy<ServiceManager> = Lazy::new(|| ServiceManager {
     operation_running: AtomicBool::new(false),
     operation_done: Notify::new(),
 });
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn test_dir(name: &str) -> std::io::Result<PathBuf> {
+        let path = std::env::temp_dir().join(format!("clash-verge-service-path-test-{}-{name}", std::process::id()));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path)?;
+        Ok(path)
+    }
+
+    #[test]
+    fn detects_app_translocation_paths() {
+        let path = Path::new(
+            "/private/var/folders/example/T/AppTranslocation/123/d/Clash Verge.app/Contents/MacOS/Clash Verge",
+        );
+
+        assert!(is_macos_app_translocated(path));
+    }
+
+    #[test]
+    fn extracts_app_bundle_name_from_executable_path() {
+        let path = Path::new("/Applications/Clash Verge.app/Contents/MacOS/Clash Verge");
+
+        assert_eq!(
+            macos_app_bundle_name(path).as_deref(),
+            Some(std::ffi::OsStr::new("Clash Verge.app"))
+        );
+    }
+
+    #[test]
+    fn resolves_existing_core_path_from_install_roots() -> std::io::Result<()> {
+        let root = test_dir("resolve-existing-core-path")?;
+        let core_dir = root.join("Clash Verge.app").join("Contents").join("MacOS");
+        let core_path = core_dir.join("verge-mihomo");
+
+        fs::create_dir_all(&core_dir)?;
+        fs::write(&core_path, b"")?;
+
+        let resolved = macos_core_path_in_install_roots(
+            std::ffi::OsStr::new("Clash Verge.app"),
+            "verge-mihomo",
+            [root.as_path()],
+        );
+
+        assert_eq!(resolved, Some(core_path));
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
尝试修复#7333 的问题，仅仅修复了MacOS平台的问题，已经在我的电脑里面进行了重新安装流程流量接管正常，服务安装正常
<img width="378" height="401" alt="image" src="https://github.com/user-attachments/assets/4f4b2346-f3af-4967-a346-229e9be56d95" />
问题原因是 App 在某些情况下会从 AppTranslocation 临时路径启动，导致 service 记录了一个不稳定的 core路径。
### 相关背景
 在 macOS 上，如果 App 从 AppTranslocation 路径启动，GUI 侧通过 `current_exe()` 推导出来的 core 路径可能会变成类似：
/private/var/folders/.../AppTranslocation/.../Clash Verge.app/Contents/MacOS/verge-mihomo
这个路径是临时的，后续可能消失。如果这个路径被写入 privileged service 的 desired-state，service 之后恢复状态或启动 core 时会继续使用这个失效路径，最终导致：No such file or directory表现上就是 service/TUN 启动失败，或者 IPC 状态异常。
### 主要原因
macOS 下 current_exe() 不一定指向稳定的 /Applications/Clash Verge.app/... 路径。当 App 被系统放进 AppTranslocation 环境运行时，current_exe() 会返回一个临时挂载路径。当前逻辑会基于这个路径生成 core_path，并通过 IPC 交给service。service 又会把这个路径保存到 desired-state，导致后续启动时继续使用已经失效的路径。
### 修复逻辑
本 PR 只修改 macOS service 相关逻辑，但是根据 issue 里面的描述其他平台也出现了类似的情况，怀疑是某些更底层代码修改的问题，但是由于没有相关机器仅仅做了 MacOS 的修复工作
- 检测 current_exe() 得到的路径是否位于 AppTranslocation。
- 如果检测到 AppTranslocation，则优先使用 /Applications/Clash Verge.app/Contents/MacOS/verge-mihomo 这类稳定安装路径。
- 避免把 AppTranslocation 临时路径写入 service desired-state。
- 在 macOS service 安装/重装时，如果发现已有 desired-state 中包含 AppTranslocation，则将旧文件备份，避免 service 继续恢复坏状态
### 影响范围
仅仅修改了一个文件，仅修改 MacOS没有对 Windows/Linux 等平台进行影响
### 验证
本地 macOS 验证：
- service 可以正常安装没有出现相关的报错
- /tmp/verge/clash-verge-service.sock 存在
- desired-state.json 中不再包含 AppTranslocation
- core_path 指向稳定路径：/Applications/Clash Verge.app/Contents/MacOS/verge-mihomo
- TUN 模式流量接管完全成功，终端流量可以直接接管，Codex 的 WebSocket 连接恢复正常，不用走降级相关的逻辑