### PR TITLE
fix(validate): mock console object in validate step

### DIFF
--- a/src-tauri/src/core/validate.rs
+++ b/src-tauri/src/core/validate.rs
@@ -245,12 +245,12 @@ impl CoreConfigValidator {
 
         let mut context = Context::default();
         let _ = context.eval(Source::from_bytes(
-            r#"var console = Object.freeze({
+            "var console = Object.freeze({
               log(...data){},
               info(...data){},
               error(...data){},
               debug(...data){},
-            });"#,
+            });",
         ));
         let result = context.eval(Source::from_bytes(&content));
 

--- a/src-tauri/src/core/validate.rs
+++ b/src-tauri/src/core/validate.rs
@@ -244,6 +244,14 @@ impl CoreConfigValidator {
         use boa_engine::{Context, Source};
 
         let mut context = Context::default();
+        let _ = context.eval(Source::from_bytes(
+            r#"var console = Object.freeze({
+              log(...data){},
+              info(...data){},
+              error(...data){},
+              debug(...data){},
+            });"#,
+        ));
         let result = context.eval(Source::from_bytes(&content));
 
         match result {


### PR DESCRIPTION
Closes #7352 

In validation scripts step, mocking the console object prevents execution errors caused by calls to console methods. However, this mock object performs no actual logging and serves only as a placeholder.