### PR TITLE
fix: use correct pkexec arguments for Linux service install/uninstall

### DIFF
--- a/src-tauri/src/core/service.rs
+++ b/src-tauri/src/core/service.rs
@@ -613,7 +613,10 @@ fn uninstall_service() -> Result<()> {
     let status = if linux_running_as_root() {
         StdCommand::new(&uninstall_path).status()?
     } else {
-        let result = StdCommand::new(&elevator).arg(&uninstall_path).status()?;
+        let result = StdCommand::new(&elevator)
+            .arg("--disable-internal-agent")
+            .arg(&uninstall_path)
+            .status()?;
 
         // 如果 pkexec 执行失败，回退到 sudo
         if !result.success() && elevator.contains("pkexec") {
@@ -661,7 +664,10 @@ fn install_service() -> Result<()> {
     let output = if linux_running_as_root() {
         StdCommand::new(&install_path).output()?
     } else {
-        let result = StdCommand::new(&elevator).arg(&install_path).output()?;
+        let result = StdCommand::new(&elevator)
+            .arg("--disable-internal-agent")
+            .arg(&install_path)
+            .output()?;
 
         // 如果 pkexec 执行失败，回退到 sudo
         if !result.status.success() && elevator.contains("pkexec") {


### PR DESCRIPTION
fix #7157

- `--disable-internal-agent` 禁用内部自带的文本模式代理，桌面环境应该使用图形弹窗来处理认证

图形弹窗如果无法弹出，可以从终端启动软件，回退到 sudo 提权