### PR TITLE
fix(windows): increase SERVICE_WAIT_MAX to 30s to fix service startup race condition

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -26,7 +26,7 @@ pub mod timing {
     pub const STARTUP_ERROR_DELAY: Duration = Duration::from_secs(2);
 
     #[cfg(target_os = "windows")]
-    pub const SERVICE_WAIT_MAX: Duration = Duration::from_millis(3000);
+    pub const SERVICE_WAIT_MAX: Duration = Duration::from_millis(30000);
     #[cfg(target_os = "windows")]
     pub const SERVICE_WAIT_INTERVAL: Duration = Duration::from_millis(200);
 }


### PR DESCRIPTION
## 问题

Windows 上开机后，clash_verge_service 无法自动工作，每次需要手动重装服务。已有 11+ 用户反馈（#5989, #6728, #6650, #6512）。

## 根因

`SERVICE_WAIT_MAX` 设置为 3 秒，但 Windows 服务启动需要 20-30 秒。应用在 3 秒超时后直接回退 sidecar 模式，抢占端口 7897，导致服务永久失败。

```
开机 → 服务开始启动（需要 20-30 秒）
     → 用户登录 → 应用启动 → 等待服务 3 秒 → 超时
     → 回退 sidecar → 占用端口 7897
     → 服务启动完成 → 端口被占 → 崩溃
     → 失败恢复重试 → 端口仍被占 → 永久失败
```

## 修改

将 `SERVICE_WAIT_MAX` 从 3000ms（3 秒）增加到 30000ms（30 秒）。

```rust
// Before
pub const SERVICE_WAIT_MAX: Duration = Duration::from_millis(3000);

// After
pub const SERVICE_WAIT_MAX: Duration = Duration::from_millis(30000);
```

- 仅影响 Windows（`#[cfg(target_os = "windows")]`）
- 不改变其他平台行为
- 不改变重试逻辑（仍为 200ms 间隔）

## 测试

已在 Windows 11 Pro 26200 + Clash Verge 2.5.1 上验证：
- 服务在开机 28 秒后就绪
- 应用在登录后 30 秒启动
- 应用成功检测到服务 → Service mode ✅

## 详细分析

完整的根因分析和调试过程见 issue #5989 的评论。

Fixes #5989