### PR TITLE
fix: Linux custom titlebar close button unclickable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 .DS_Store
 dist
 dist-ssr
+builder/
 *.local
 update.json
 scripts/_env.sh

--- a/src/components/layout/window-controller.tsx
+++ b/src/components/layout/window-controller.tsx
@@ -41,12 +41,13 @@ export const WindowControls = forwardRef(function WindowControls(props, ref) {
 
   return (
     <Box
+      data-tauri-drag-region="false"
       sx={{
         display: 'flex',
         gap: 1,
         alignItems: 'center',
         '> button': {
-          cursor: 'default',
+          cursor: 'pointer',
         },
       }}
     >

--- a/src/components/layout/window-controller.tsx
+++ b/src/components/layout/window-controller.tsx
@@ -41,6 +41,8 @@ export const WindowControls = forwardRef(function WindowControls(props, ref) {
 
   return (
     <Box
+      // 必须显式排除拖拽区域，否则 Linux/WebKitGTK 下 Tauri 的拖拽事件
+      // 会渗透到按钮区域，拦截点击事件导致关闭/最小化/最大化按钮无法响应
       data-tauri-drag-region="false"
       sx={{
         display: 'flex',


### PR DESCRIPTION
### 问题
在 Linux (WebKitGTK) 下，窗口自定义标题栏的关闭、最小化、最大化三个按钮无法响应点击事件。
我用的系统是ubuntu 24.04.1。

### 修复
在按钮容器上添加 data-tauri-drag-region="false"，显式排除拖拽区域，确保按钮点击事件正常触发。

同时将按钮鼠标样式从 default 改为 pointer，提升交互体验。

### 测试
 Linux 下窗口拖拽后，关闭/最小化/最大化按钮正常响应。
 Windows/macOS 下没有测试，理论上不会有影响。
 