### PR TITLE
fix: prevent WebKit WebContent memory growth from continuous data pipeline

### DIFF
--- a/src/components/home/enhanced-canvas-traffic-graph.tsx
+++ b/src/components/home/enhanced-canvas-traffic-graph.tsx
@@ -1045,6 +1045,15 @@ export const EnhancedCanvasTrafficGraph = memo(
           cancelAnimationFrame(mouseMoveFrameRef.current)
           mouseMoveFrameRef.current = undefined
         }
+
+        // Release canvas GPU backing stores
+        const releaseCanvas = (canvas: HTMLCanvasElement | null) => {
+          if (!canvas) return
+          canvas.width = 1
+          canvas.height = 1
+        }
+        releaseCanvas(canvasRef.current)
+        releaseCanvas(hoverCanvasRef.current)
       }
     }, [])
 

--- a/src/components/home/enhanced-traffic-stats.tsx
+++ b/src/components/home/enhanced-traffic-stats.tsx
@@ -158,7 +158,7 @@ export const EnhancedTrafficStats = () => {
 
   const {
     response: { data: connectionSummary },
-  } = useConnectionSummaryData()
+  } = useConnectionSummaryData({ enabled: pageVisible })
 
   // Canvas组件现在直接从全局Hook获取数据，无需手动添加数据点
 

--- a/src/hooks/use-connection-data.ts
+++ b/src/hooks/use-connection-data.ts
@@ -257,6 +257,25 @@ const clearReconnectTimer = () => {
   reconnectTimer = null
 }
 
+const hasConnectionSubscribers = () =>
+  connectionListeners.size > 0 || summaryListeners.size > 0
+
+const stopConnectionMonitorIfIdle = () => {
+  if (hasConnectionSubscribers()) return
+
+  connectionStarted = false
+  clearReconnectTimer()
+
+  if (flushTimer) {
+    window.clearTimeout(flushTimer)
+    flushTimer = null
+  }
+
+  pendingMessageData = null
+  connectionData = initConnData
+  void closeConnectionSocket()
+}
+
 const closeConnectionSocket = async () => {
   const socket = connectionSocket
   connectionSocket = null
@@ -270,6 +289,7 @@ const closeConnectionSocket = async () => {
 }
 
 const scheduleReconnect = () => {
+  if (!hasConnectionSubscribers()) return
   if (reconnectTimer) return
   reconnectTimer = window.setTimeout(() => {
     reconnectTimer = null
@@ -317,18 +337,20 @@ const getConnectionSnapshot = () => connectionData
 const getConnectionSummarySnapshot = () => connectionSummary
 
 const subscribeConnectionData = (listener: ConnectionListener) => {
-  startConnectionMonitor()
   connectionListeners.add(listener)
+  startConnectionMonitor()
   return () => {
     connectionListeners.delete(listener)
+    stopConnectionMonitorIfIdle()
   }
 }
 
 const subscribeConnectionSummary = (listener: ConnectionListener) => {
-  startConnectionMonitor()
   summaryListeners.add(listener)
+  startConnectionMonitor()
   return () => {
     summaryListeners.delete(listener)
+    stopConnectionMonitorIfIdle()
   }
 }
 
@@ -372,9 +394,11 @@ export const useConnectionData = () => {
   }
 }
 
-export const useConnectionSummaryData = () => {
+export const useConnectionSummaryData = (options?: { enabled?: boolean }) => {
+  const enabled = options?.enabled ?? true
+
   const data = useSyncExternalStore(
-    subscribeConnectionSummary,
+    enabled ? subscribeConnectionSummary : () => () => {},
     getConnectionSummarySnapshot,
     getConnectionSummarySnapshot,
   )

--- a/src/hooks/use-traffic-data.ts
+++ b/src/hooks/use-traffic-data.ts
@@ -32,11 +32,12 @@ export const useTrafficData = (options?: { enabled?: boolean }) => {
     graphData: { appendData },
   } = useTrafficMonitorEnhanced({ subscribe: false, enabled })
   const { response, refresh } = useMihomoWsSubscription<ITrafficItem>({
-    storageKey: 'mihomo_traffic_date',
-    buildSubscriptKey: (date) => `getClashTraffic-${date}`,
+    storageKey: enabled ? 'mihomo_traffic_date' : '__disabled__',
+    buildSubscriptKey: (date) =>
+      enabled ? `getClashTraffic-${date}` : null,
     fallbackData: FALLBACK_TRAFFIC,
     connect: () => MihomoWebSocket.connect_traffic(),
-    throttleMs: 200,
+    throttleMs: 1000,
     setupHandlers: ({ next, scheduleReconnect }) => ({
       handleMessage: (data) => {
         if (data.startsWith('Websocket error')) {

--- a/src/hooks/use-traffic-monitor.ts
+++ b/src/hooks/use-traffic-monitor.ts
@@ -51,7 +51,7 @@ const WORKER_CONFIG = {
   rawDataMinutes: 10,
   compressedDataMinutes: 60,
   compressionRatio: 5,
-  snapshotIntervalMs: 200,
+  snapshotIntervalMs: 1000,
   defaultRangeMinutes: 10,
 }
 


### PR DESCRIPTION
## Problem

After running Clash Verge for 10+ days with the window open, the macOS `com.apple.WebKit.WebContent` XPC process (WKWebView rendering engine) grows to **2.4GB physical footprint** (peak 2.6GB). A healthy process should be 200-400MB.

Root cause: the frontend data pipeline runs continuously regardless of visibility state.

## Root Cause Analysis

1. **Connection WebSocket never stops** (`src/hooks/use-connection-data.ts`): Module-level singleton with `connectionStarted=true` set once, never reset. Even when no component is subscribed (all listeners unsubscribed), the WebSocket stays connected, JSON parsing continues, and summary data keeps flowing.

2. **Traffic WebSocket does not pause on blur** (`src/hooks/use-traffic-data.ts`): `pause_render_traffic_stats_on_blur` only skips canvas drawing — it does not stop WebSocket data flow, sampler processing, or React re-renders.

3. **Connection summary is always-on** (`src/components/home/enhanced-traffic-stats.tsx`): `useConnectionSummaryData()` subscribes unconditionally, keeping the connection WebSocket alive even when all other components have unsubscribed.

4. **Excessive allocation rate**: Traffic snapshot processing at 200ms creates ~432,000 frames over 10 days. While individually bounded, the allocation churn causes JS heap fragmentation that WKWebView does not reclaim.

5. **Canvas GPU backing stores not released on unmount**: When `EnhancedCanvasTrafficGraph` unmounts, canvas width/height are not reset, potentially leaving GPU memory allocated.

## Changes

### `src/hooks/use-connection-data.ts`
- Add `stopConnectionMonitorIfIdle()`: closes WebSocket, clears timers, resets `connectionStarted`, drops pending data when all subscribers disconnect
- `scheduleReconnect()` now checks `hasConnectionSubscribers()` before reconnecting
- `subscribeConnectionData()` / `subscribeConnectionSummary()` call `stopConnectionMonitorIfIdle()` on unsubscribe
- `useConnectionSummaryData()` accepts optional `{ enabled }` — returns no-op subscription when disabled
### `src/components/home/enhanced-traffic-stats.tsx`
- Gate `useConnectionSummaryData` by `pageVisible` — connection WS can go idle when page is hidden

### `src/hooks/use-traffic-data.ts`
- `buildSubscriptKey` returns `null` when `enabled=false`, preventing traffic WebSocket from connecting
- Reduce `throttleMs` from 200ms to 1000ms

### `src/hooks/use-traffic-monitor.ts`
- Reduce `snapshotIntervalMs` from 200ms to 1000ms

### `src/components/home/enhanced-canvas-traffic-graph.tsx`
- On unmount, reset canvas width/height to 1 to release GPU backing stores

## Testing

- [ ] Connection WS disconnects when navigating away from Connections page and home page
- [ ] Connection WS reconnects when returning to Connections page
- [ ] Traffic WS disconnects when window is hidden/minimized
- [ ] Traffic WS reconnects when window is focused again
- [ ] Traffic graph at 1s intervals still provides smooth visual
- [ ] Canvas cleanup on unmount does not cause errors

## Verification

Tested locally on macOS 26.5.1 with Clash Verge dev branch (commit af0518d). All changes are compile-time verified (TypeScript).

Closes: N/A (memory leak fix, not tracked in issues)
