### PR TITLE
feat: show proxy chain in website tests

### DIFF
--- a/src-tauri/src/cmd/clash.rs
+++ b/src-tauri/src/cmd/clash.rs
@@ -121,12 +121,15 @@ pub async fn restart_core() -> CmdResult {
 
 /// 测试URL延迟
 #[tauri::command]
-pub async fn test_delay(url: String) -> CmdResult<u32> {
+pub async fn test_delay(url: String) -> CmdResult<feat::TestDelayResult> {
     let result = match feat::test_delay(url).await {
-        Ok(delay) => delay,
+        Ok(result) => result,
         Err(e) => {
             logging!(error, Type::Cmd, "{}", e);
-            10000u32
+            feat::TestDelayResult {
+                delay: 10000,
+                chains: vec![],
+            }
         }
     };
     Ok(result)

--- a/src-tauri/src/feat/clash.rs
+++ b/src-tauri/src/feat/clash.rs
@@ -116,9 +116,70 @@ pub async fn change_clash_mode(mode: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Test delay result with the proxy chain actually used for the request.
+///
+/// `chains` follows mihomo's convention: exit node first, top-level group last.
+/// Empty when the request did not go through mihomo (system proxy & TUN both off)
+/// or the connection could not be matched.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestDelayResult {
+    pub delay: u32,
+    pub chains: Vec<String>,
+}
+
+/// Look up the proxy chain of the mihomo connection whose source port matches
+/// the given local port. The test request from `test_delay` reaches mihomo via
+/// the mixed port, so mihomo records our local source port as `sourcePort`.
+/// Matching by port (not host) avoids misattributing a stale same-host connection.
+async fn chains_by_source_port(source_port: u16, mixed_port: u16) -> anyhow::Result<Vec<String>> {
+    let mihomo = handle::Handle::mihomo().await;
+    let conns = mihomo.get_connections().await?;
+    drop(mihomo);
+    // plugin returns `Vec<std::string::String>` (it doesn't use smartstring);
+    // convert into this crate's `SmartString` alias to match the rest of the file.
+    //
+    // Match on (sourcePort, sourceIP, inboundPort), not sourcePort alone:
+    // sourcePort isn't globally unique across TUN/mixed/other inbounds, so under
+    // TUN traffic or concurrency a bare port match could surface another connection.
+    // Our test reaches mihomo over loopback (sourceIP 127.0.0.1) at the mixed
+    // inbound (inboundPort == mixed_port), which uniquely identifies it.
+    let chains = conns
+        .connections
+        .unwrap_or_default()
+        .into_iter()
+        .find(|c| {
+            let m = &c.metadata;
+            m.source_port.trim().parse::<u16>().ok() == Some(source_port)
+                && m.source_ip == "127.0.0.1"
+                && m.inbound_port.trim().parse::<u16>().ok() == Some(mixed_port)
+        })
+        .map(|c| c.chains.into_iter().map(Into::into).collect())
+        .unwrap_or_default();
+    Ok(chains)
+}
+
+/// Resolve the proxy chain for the test connection. Returns `["DIRECT"]` for
+/// direct connections (no source port — request bypassed mihomo). Wrapped in a
+/// 1s timeout so a slow /connections lookup never affects the already-measured
+/// delay; any failure degrades to an empty/`DIRECT` chain.
+async fn chains_for_source_port(source_port: Option<u16>, mixed_port: Option<u16>) -> Vec<String> {
+    match (source_port, mixed_port) {
+        (Some(src), Some(mixed)) => tokio::time::timeout(
+            std::time::Duration::from_millis(1000),
+            chains_by_source_port(src, mixed),
+        )
+        .await
+        .ok()
+        .and_then(|r| r.ok())
+        .unwrap_or_default(),
+        _ => vec![String::from("DIRECT")],
+    }
+}
+
 /// Test delay to a URL through proxy.
 /// HTTPS: measures TLS handshake time. HTTP: measures HEAD round-trip time.
-pub async fn test_delay(url: String) -> anyhow::Result<u32> {
+pub async fn test_delay(url: String) -> anyhow::Result<TestDelayResult> {
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -147,6 +208,11 @@ pub async fn test_delay(url: String) -> anyhow::Result<u32> {
     tokio::time::timeout(Duration::from_secs(10), async {
         let start = Instant::now();
         let mut buf = BytesMut::with_capacity(1024);
+        // Local source port of the connection to mihomo's mixed port. Used to
+        // match the exact connection in /connections after the handshake, so the
+        // resolved chain cannot be confused with a stale same-host connection.
+        // None for direct connections (proxy & TUN off) — those bypass mihomo.
+        let mut source_port: Option<u16> = None;
 
         if is_https {
             let stream = match proxy_port {
@@ -158,6 +224,8 @@ pub async fn test_delay(url: String) -> anyhow::Result<u32> {
                     if !buf.windows(3).any(|w| w == b"200") {
                         return Err(anyhow::anyhow!("Proxy CONNECT failed"));
                     }
+                    // Capture before handing `s` to the TLS connector (which moves it).
+                    source_port = s.local_addr().ok().map(|a| a.port());
                     s
                 }
                 None => TcpStream::connect(format!("{host}:{port}")).await?,
@@ -166,13 +234,27 @@ pub async fn test_delay(url: String) -> anyhow::Result<u32> {
             let server_name = rustls::pki_types::ServerName::try_from(host.as_str())
                 .map_err(|_| anyhow::anyhow!("Invalid DNS name: {host}"))?
                 .to_owned();
-            connector.connect(server_name, stream).await?;
+            // Keep the TLS stream alive until after we query /connections: the
+            // connection must still be in mihomo's manager when we look it up.
+            let _tls = connector.connect(server_name, stream).await?;
+
+            // frontend treats 0 as timeout
+            let delay = (start.elapsed().as_millis() as u32).max(1);
+            // Local round-trip to mihomo (unix socket / loopback), only a few ms —
+            // negligible vs the 10s timeout, so it won't flip a slow success into a
+            // timeout in practice.
+            let chains = chains_for_source_port(source_port, proxy_port).await;
+            Ok(TestDelayResult { delay, chains })
         } else {
             let (mut stream, req) = match proxy_port {
-                Some(pp) => (
-                    TcpStream::connect(format!("127.0.0.1:{pp}")).await?,
-                    format!("HEAD {url} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n"),
-                ),
+                Some(pp) => {
+                    let s = TcpStream::connect(format!("127.0.0.1:{pp}")).await?;
+                    source_port = s.local_addr().ok().map(|a| a.port());
+                    (
+                        s,
+                        format!("HEAD {url} HTTP/1.1\r\nHost: {host}\r\nConnection: keep-alive\r\n\r\n"),
+                    )
+                }
                 None => (
                     TcpStream::connect(format!("{host}:{port}")).await?,
                     format!("HEAD / HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n"),
@@ -180,11 +262,19 @@ pub async fn test_delay(url: String) -> anyhow::Result<u32> {
             };
             stream.write_all(req.as_bytes()).await?;
             let _ = stream.read(&mut buf).await?;
-        }
 
-        // frontend treats 0 as timeout
-        Ok((start.elapsed().as_millis() as u32).max(1))
+            // frontend treats 0 as timeout
+            let delay = (start.elapsed().as_millis() as u32).max(1);
+            // Local round-trip to mihomo (unix socket / loopback), only a few ms —
+            // negligible vs the 10s timeout, so it won't flip a slow success into a
+            // timeout in practice.
+            let chains = chains_for_source_port(source_port, proxy_port).await;
+            Ok(TestDelayResult { delay, chains })
+        }
     })
     .await
-    .unwrap_or(Ok(10000u32))
+    .unwrap_or(Ok(TestDelayResult {
+        delay: 10000,
+        chains: vec![],
+    }))
 }

--- a/src/components/test/test-item.tsx
+++ b/src/components/test/test-item.tsx
@@ -1,7 +1,15 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { LanguageRounded } from '@mui/icons-material'
-import { Box, Divider, MenuItem, Menu, styled, alpha } from '@mui/material'
+import {
+  Box,
+  Divider,
+  MenuItem,
+  Menu,
+  Tooltip,
+  styled,
+  alpha,
+} from '@mui/material'
 import { UnlistenFn } from '@tauri-apps/api/event'
 import { useLockFn } from 'ahooks'
 import { useCallback, useEffect, useState } from 'react'
@@ -45,14 +53,17 @@ export const TestItem = ({
   const [anchorEl, setAnchorEl] = useState<any>(null)
   const [position, setPosition] = useState({ left: 0, top: 0 })
   const [delay, setDelay] = useState(-1)
+  const [chains, setChains] = useState<string[]>([])
   const { uid, name, icon, url } = itemData
   const iconCachePath = useIconCache({ icon, cacheKey: uid })
   const { addListener } = useListen()
 
   const onDelay = useCallback(async () => {
     setDelay(-2)
+    setChains([])
     const result = await cmdTestDelay(url)
-    setDelay(result)
+    setDelay(result.delay)
+    setChains(result.chains)
   }, [url])
 
   const onEditTest = () => {
@@ -73,6 +84,18 @@ export const TestItem = ({
     { label: 'Edit', handler: onEditTest },
     { label: 'Delete', handler: onDelete },
   ]
+
+  // mihomo chains: exit node first, top-level group last.
+  // chains[0] = actual exit node; chains[last] = top-level group.
+  const exitNode = chains[0]
+  const isDirect = !exitNode || exitNode === 'DIRECT' || exitNode === 'DIRECT-'
+  // top-level group = the outermost selector the user picked (skip DIRECT).
+  const group = isDirect
+    ? ''
+    : ([...chains].reverse().find((n) => n !== 'DIRECT' && n !== 'DIRECT-') ??
+      '')
+  const showGroup = !!group && group !== exitNode
+  const fullChainText = [...chains].reverse().join(' / ')
 
   useEffect(() => {
     let unlistenFn: UnlistenFn | null = null
@@ -198,6 +221,46 @@ export const TestItem = ({
             </Widget>
           )}
         </Box>
+        {delay >= 0 && exitNode && (
+          <Tooltip
+            title={isDirect ? '' : fullChainText}
+            arrow
+            disableHoverListener={isDirect || !fullChainText}
+          >
+            <Box
+              sx={{
+                marginTop: '2px',
+                minHeight: '40px',
+                px: 0.5,
+                textAlign: 'center',
+                fontSize: 12,
+                lineHeight: '18px',
+                color: isDirect ? 'text.disabled' : 'text.secondary',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                overflow: 'hidden',
+              }}
+            >
+              {isDirect ? (
+                <Box component="span" sx={chainLineSx}>
+                  {t('tests.components.item.direct')}
+                </Box>
+              ) : (
+                <>
+                  {showGroup && (
+                    <Box component="span" sx={chainLineSx}>
+                      {group}
+                    </Box>
+                  )}
+                  <Box component="span" sx={chainLineSx}>
+                    {exitNode}
+                  </Box>
+                </>
+              )}
+            </Box>
+          </Tooltip>
+        )}
       </TestBox>
 
       <Menu
@@ -233,3 +296,10 @@ const Widget = styled(Box)(({ theme: { typography } }) => ({
   fontFamily: typography.fontFamily,
   borderRadius: '4px',
 }))
+
+const chainLineSx = {
+  width: '100%',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+} as const

--- a/src/locales/ar/tests.json
+++ b/src/locales/ar/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "اختبار"
-      }
+      },
+      "direct": "مباشر"
     }
   },
   "modals": {

--- a/src/locales/de/tests.json
+++ b/src/locales/de/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "Testen"
-      }
+      },
+      "direct": "Direkt"
     }
   },
   "modals": {

--- a/src/locales/en/tests.json
+++ b/src/locales/en/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "Test"
-      }
+      },
+      "direct": "Direct"
     }
   },
   "modals": {

--- a/src/locales/es/tests.json
+++ b/src/locales/es/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "Prueba"
-      }
+      },
+      "direct": "Directo"
     }
   },
   "modals": {

--- a/src/locales/fa/tests.json
+++ b/src/locales/fa/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "آزمون"
-      }
+      },
+      "direct": "مستقیم"
     }
   },
   "modals": {

--- a/src/locales/id/tests.json
+++ b/src/locales/id/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "Tes"
-      }
+      },
+      "direct": "Langsung"
     }
   },
   "modals": {

--- a/src/locales/jp/tests.json
+++ b/src/locales/jp/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "テスト"
-      }
+      },
+      "direct": "直接"
     }
   },
   "modals": {

--- a/src/locales/ko/tests.json
+++ b/src/locales/ko/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "테스트"
-      }
+      },
+      "direct": "직접"
     }
   },
   "modals": {

--- a/src/locales/ru/tests.json
+++ b/src/locales/ru/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "Проверить"
-      }
+      },
+      "direct": "Напрямую"
     }
   },
   "modals": {

--- a/src/locales/tr/tests.json
+++ b/src/locales/tr/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "Test"
-      }
+      },
+      "direct": "Doğrudan"
     }
   },
   "modals": {

--- a/src/locales/tt/tests.json
+++ b/src/locales/tt/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "Тест"
-      }
+      },
+      "direct": "Турыдан"
     }
   },
   "modals": {

--- a/src/locales/zh/tests.json
+++ b/src/locales/zh/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "测试"
-      }
+      },
+      "direct": "直连"
     }
   },
   "modals": {

--- a/src/locales/zhtw/tests.json
+++ b/src/locales/zhtw/tests.json
@@ -9,7 +9,8 @@
     "item": {
       "actions": {
         "test": "測試"
-      }
+      },
+      "direct": "直連"
     }
   },
   "modals": {

--- a/src/services/cmds.ts
+++ b/src/services/cmds.ts
@@ -384,8 +384,13 @@ export async function cmdGetProxyDelay(
   }
 }
 
-export async function cmdTestDelay(url: string) {
-  return invoke<number>('test_delay', { url })
+export interface TestDelayResult {
+  delay: number
+  chains: string[]
+}
+
+export async function cmdTestDelay(url: string): Promise<TestDelayResult> {
+  return invoke<TestDelayResult>('test_delay', { url })
 }
 
 export async function invoke_uwp_tool() {

--- a/src/types/generated/i18n-keys.ts
+++ b/src/types/generated/i18n-keys.ts
@@ -785,6 +785,7 @@ export const translationKeys = [
   'tests.page.actions.testAll',
   'tests.page.title',
   'tests.components.item.actions.test',
+  'tests.components.item.direct',
   'tests.modals.test.title.create',
   'tests.modals.test.title.edit',
   'tests.modals.test.fields.url',

--- a/src/types/generated/i18n-resources.ts
+++ b/src/types/generated/i18n-resources.ts
@@ -1361,6 +1361,7 @@ export interface TranslationResources {
           actions: {
             test: string
           }
+          direct: string
         }
       }
       modals: {


### PR DESCRIPTION
## Summary

The Website Tests card on the Home page now shows the proxy node actually used for each test connection, alongside its top-level group. Hover shows the full chain.

## Motivation

`test_delay` previously returned only a delay number — no way to see which exit node mihomo picked for a given test. Node selection happens inside mihomo and isn't exposed at the proxy-protocol layer (mixed-port CONNECT only yields `200`).

## Implementation

- **Rust** (`feat/clash.rs`): `test_delay` returns `{ delay, chains }`. Right after measuring the delay (before the stream drops), it queries mihomo's `/connections` snapshot and matches the exact test connection by `(sourcePort, sourceIP=127.0.0.1, inboundPort=mixed_port)`. Matching on all three — not just port — avoids misattributing a stale or unrelated connection under TUN/concurrency.
- **Frontend** (`test-item.tsx`): shows `group + exit node` (mihomo `chains` convention: exit node first, top-level group last), full chain in a tooltip, `Direct` for direct/unmatched.
- **i18n**: adds `tests.components.item.direct` across all locales.

The chain lookup is a local round-trip to mihomo (loopback, a few ms), done after the delay is measured so it never affects the measurement.

## Compatibility

Works in system-proxy / TUN / direct — relies only on mihomo's mixed-port, which verge always keeps listening (guarded non-zero). Caveat: inbound-aware rules (`INBOUND`/`PROCESS-NAME`) could make the test's node differ from real TUN traffic — rare.

## Screenshot
<img width="1178" height="560" alt="image" src="https://github.com/user-attachments/assets/1d9588d4-ec19-4d1b-9156-2aa73567718c" />


## Test plan

- [x] Apple → `Direct`; GitHub/Google/YouTube → group + node
- [x] Switching the selected node updates the displayed node
- [x] `cargo fmt` + `cargo check` clean; pre-commit hook passes

Resolves #7401
