### PR TITLE
fix: preserve profile route exclusions

### DIFF
--- a/src-tauri/src/enhance/mod.rs
+++ b/src-tauri/src/enhance/mod.rs
@@ -412,6 +412,10 @@ async fn merge_default_config(
             });
             let patch_tun = value.as_mapping().cloned().unwrap_or_else(Mapping::new);
             for (key, value) in patch_tun.into_iter() {
+                // 将全局空列表视为未配置，避免覆盖 Profile 中的排除路由。
+                if is_empty_route_exclude_override(&tun, &key, &value) {
+                    continue;
+                }
                 tun.insert(key, value);
             }
             config.insert("tun".into(), tun.into());
@@ -472,6 +476,15 @@ async fn merge_default_config(
     }
 
     config
+}
+
+fn is_empty_route_exclude_override(tun: &Mapping, key: &Value, value: &Value) -> bool {
+    key.as_str() == Some("route-exclude-address")
+        && matches!(value.as_sequence(), Some(seq) if seq.is_empty())
+        && matches!(
+            tun.get(key).and_then(Value::as_sequence),
+            Some(seq) if !seq.is_empty()
+        )
 }
 
 async fn apply_builtin_scripts(mut config: Mapping, clash_core: Option<String>, enable_builtin: bool) -> Mapping {
@@ -816,6 +829,38 @@ mod tests {
             Some("profile-script")
         );
         assert!(!exists_keys.contains(&"application-only".into()));
+    }
+
+    #[tokio::test]
+    async fn empty_global_tun_route_exclude_does_not_override_profile_values() {
+        let config = mapping(
+            r#"{tun: {enable: true, route-exclude-address: ["100.64.0.0/10", "fd7a:115c:a1e0::/48"]}}"#,
+        );
+        let clash_config = mapping(
+            r#"{tun: {auto-route: true, route-exclude-address: []}}"#,
+        );
+
+        let config = super::merge_default_config(
+            config,
+            clash_config,
+            false,
+            false,
+            #[cfg(not(target_os = "windows"))]
+            false,
+            #[cfg(target_os = "linux")]
+            false,
+        )
+        .await;
+
+        let route_exclude = config
+            .get("tun")
+            .and_then(|value| value.get("route-exclude-address"))
+            .and_then(serde_yaml_ng::Value::as_sequence)
+            .expect("route-exclude-address should be preserved");
+
+        assert_eq!(route_exclude.len(), 2);
+        assert_eq!(route_exclude.first().and_then(serde_yaml_ng::Value::as_str), Some("100.64.0.0/10"));
+        assert_eq!(route_exclude.get(1).and_then(serde_yaml_ng::Value::as_str), Some("fd7a:115c:a1e0::/48"));
     }
 
     #[test]


### PR DESCRIPTION
## 说明

修复 #7421。

当前全局 TUN 配置里的空值：

```yaml
tun:
  route-exclude-address: []
```

会覆盖订阅/Profile 中的非空配置，导致最终运行配置里的 `route-exclude-address` 变为空，影响 Tailscale、VPN、内网等场景。

本 PR 调整为：当全局 `route-exclude-address` 为空数组时，视为未配置，不覆盖订阅/Profile 中的值。

## 行为

```yaml
# 全局为空，Profile 非空
Global:  []
Profile: [C, D]
Final:   [C, D]

# 全局非空，Profile 非空
Global:  [A, B]
Profile: [C, D]
Final:   [A, B]
```

## 测试

已测试。
