### PR TITLE
docs: fix Telegram channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Supports Windows (x64/x86), Linux (x64/arm64) and macOS 11+ (intel/apple).
 
 #### 安装说明和常见问题，请到 [文档页](https://clash-verge-rev.github.io/) 查看
 
-### TG 频道: [@clash_verge_rev](https://t.me/clash_verge_re)
+### TG 频道: [@clash_verge_rev](https://t.me/clash_verge_rev)
 
 ---
 

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -45,7 +45,7 @@ Read the [project documentation](https://clash-verge-rev.github.io/) for install
 
 ### Telegram Channel
 
-Join [@clash_verge_rev](https://t.me/clash_verge_re) for update announcements.
+Join [@clash_verge_rev](https://t.me/clash_verge_rev) for update announcements.
 
 ---
 

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -45,7 +45,7 @@ Consulta la [documentación del proyecto](https://clash-verge-rev.github.io/) pa
 
 ### Canal de Telegram
 
-Únete a [@clash_verge_rev](https://t.me/clash_verge_re) para enterarte de las novedades.
+Únete a [@clash_verge_rev](https://t.me/clash_verge_rev) para enterarte de las novedades.
 
 ---
 

--- a/docs/README_fa.md
+++ b/docs/README_fa.md
@@ -44,7 +44,7 @@
 
 ### کانال تلگرام
 
-برای اطلاع از آخرین اخبار به [@clash_verge_rev](https://t.me/clash_verge_re) بپیوندید.
+برای اطلاع از آخرین اخبار به [@clash_verge_rev](https://t.me/clash_verge_rev) بپیوندید.
 
 ---
 

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -45,7 +45,7 @@ Windows (x64/x86)、Linux (x64/arm64)、macOS 10.15+ (Intel/Apple) をサポー�
 
 ### Telegram チャンネル
 
-更新情報は [@clash_verge_rev](https://t.me/clash_verge_re) をフォローしてください。
+更新情報は [@clash_verge_rev](https://t.me/clash_verge_rev) をフォローしてください。
 
 ---
 

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -45,7 +45,7 @@ Windows (x64/x86), Linux (x64/arm64), macOS 10.15+ (Intel/Apple)을 지원합니
 
 ### 텔레그램 채널
 
-업데이트 공지는 [@clash_verge_rev](https://t.me/clash_verge_re)에서 확인하세요.
+업데이트 공지는 [@clash_verge_rev](https://t.me/clash_verge_rev)에서 확인하세요.
 
 ---
 

--- a/docs/README_ru.md
+++ b/docs/README_ru.md
@@ -41,7 +41,7 @@ Clash Meta GUI базируется на <a href="https://github.com/tauri-apps/
 
 #### Инструкции по установке и ответы на часто задаваемые вопросы можно найти на [странице документации](https://clash-verge-rev.github.io/)
 
-### TG канал: [@clash_verge_rev](https://t.me/clash_verge_re)
+### TG канал: [@clash_verge_rev](https://t.me/clash_verge_rev)
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix the Clash Verge Rev Telegram channel URL in the main README.
- Apply the same correction to all localized README files.
- Keep the link destination consistent with the displayed `@clash_verge_rev` handle.

## Why

The displayed channel handle was `@clash_verge_rev`, but the underlying URL still pointed to `https://t.me/clash_verge_re`, missing the final `v`.

## Impact

Readers of every README language variant are now directed to the intended Telegram channel URL.

## Verification

- Ran `git diff --check`.
- Confirmed the old `https://t.me/clash_verge_re` target is absent from all README files.
- Confirmed all seven README files use `https://t.me/clash_verge_rev`.
- No application tests were run because this is a documentation-only link correction.
