### PR TITLE
fix(macos): prevent system hotkeys remaining registered after focus loss

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,46 @@ use tauri_plugin_deep_link::DeepLinkExt as _;
 use tauri_plugin_mihomo::RejectPolicy;
 
 pub static APP_HANDLE: OnceCell<AppHandle> = OnceCell::new();
+
+#[cfg(target_os = "macos")]
+mod window_focus_generation {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    pub(super) struct FocusGeneration(AtomicU64);
+
+    impl FocusGeneration {
+        pub(super) const fn new() -> Self {
+            Self(AtomicU64::new(0))
+        }
+
+        pub(super) fn advance(&self) -> u64 {
+            self.0.fetch_add(1, Ordering::AcqRel) + 1
+        }
+
+        pub(super) fn is_current(&self, generation: u64) -> bool {
+            generation == self.0.load(Ordering::Acquire)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::FocusGeneration;
+
+        #[test]
+        fn advancing_focus_invalidates_older_work() {
+            let generations = FocusGeneration::new();
+            let focused = generations.advance();
+
+            assert!(generations.is_current(focused));
+
+            let unfocused = generations.advance();
+
+            assert!(!generations.is_current(focused));
+            assert!(generations.is_current(unfocused));
+        }
+    }
+}
+
 /// Application initialization helper functions
 mod app_init {
     use super::*;
@@ -299,6 +339,8 @@ pub fn run() {
         #[cfg(target_os = "macos")]
         use crate::module::lightweight;
         use crate::utils::window_manager::WindowManager;
+        #[cfg(target_os = "macos")]
+        use crate::window_focus_generation::FocusGeneration;
         use crate::{
             config::Config,
             core::{self, handle, hotkey},
@@ -308,6 +350,17 @@ pub fn run() {
         use tauri::AppHandle;
         #[cfg(target_os = "macos")]
         use tauri::Manager as _;
+
+        #[cfg(target_os = "macos")]
+        static WINDOW_FOCUS_GENERATION: FocusGeneration = FocusGeneration::new();
+
+        #[cfg(target_os = "macos")]
+        fn unregister_system_hotkeys() {
+            use crate::core::hotkey::SystemHotkey;
+
+            let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdQ);
+            let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdW);
+        }
 
         pub fn handle_ready_resumed(_app_handle: &AppHandle) {
             if handle::Handle::global().is_exiting() {
@@ -338,7 +391,11 @@ pub fn run() {
 
         pub fn handle_window_close(api: &tauri::WindowEvent) {
             #[cfg(target_os = "macos")]
-            handle::Handle::global().set_activation_policy_accessory();
+            {
+                WINDOW_FOCUS_GENERATION.advance();
+                unregister_system_hotkeys();
+                handle::Handle::global().set_activation_policy_accessory();
+            }
 
             if core::handle::Handle::global().is_exiting() {
                 return;
@@ -353,8 +410,21 @@ pub fn run() {
         }
 
         pub fn handle_window_focus(focused: bool) {
+            #[cfg(target_os = "macos")]
+            let focus_generation = WINDOW_FOCUS_GENERATION.advance();
+
+            #[cfg(target_os = "macos")]
+            if !focused {
+                unregister_system_hotkeys();
+            }
+
             AsyncHandler::spawn(move || async move {
                 let is_enable_global_hotkey = Config::verge().await.data_arc().enable_global_hotkey.unwrap_or(true);
+
+                #[cfg(target_os = "macos")]
+                if !WINDOW_FOCUS_GENERATION.is_current(focus_generation) {
+                    return;
+                }
 
                 if focused {
                     #[cfg(target_os = "macos")]
@@ -366,18 +436,17 @@ pub fn run() {
                         let _ = hotkey::Hotkey::global()
                             .register_system_hotkey(SystemHotkey::CmdW)
                             .await;
+
+                        // Focus may change while registration is awaiting the shortcut manager.
+                        if !WINDOW_FOCUS_GENERATION.is_current(focus_generation) {
+                            unregister_system_hotkeys();
+                            return;
+                        }
                     }
                     if !is_enable_global_hotkey {
                         let _ = hotkey::Hotkey::global().init(false).await;
                     }
                     return;
-                }
-
-                #[cfg(target_os = "macos")]
-                {
-                    use crate::core::hotkey::SystemHotkey;
-                    let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdQ);
-                    let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdW);
                 }
 
                 if !is_enable_global_hotkey {
@@ -388,10 +457,10 @@ pub fn run() {
 
         #[cfg(target_os = "macos")]
         pub fn handle_window_destroyed() {
-            use crate::core::hotkey::SystemHotkey;
+            WINDOW_FOCUS_GENERATION.advance();
+            unregister_system_hotkeys();
+
             AsyncHandler::spawn(move || async move {
-                let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdQ);
-                let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdW);
                 let is_enable_global_hotkey = Config::verge().await.data_arc().enable_global_hotkey.unwrap_or(true);
                 if !is_enable_global_hotkey {
                     let _ = hotkey::Hotkey::global().reset();


### PR DESCRIPTION

## Summary

- unregister the macOS-only `Cmd+Q` and `Cmd+W` system hotkeys immediately when the main window loses focus, closes, or is destroyed
- invalidate pending focus work so an older async task cannot register those shortcuts after a newer focus-loss event
- re-check the focus generation after async shortcut registration and clean up if focus changed while registration was in progress

## Root cause

`handle_window_focus` spawns an async task and reads the Verge configuration before updating the system hotkeys. Focus events can therefore complete out of order: a task created for `Focused(true)` may register `Cmd+Q` and `Cmd+W` after a later `Focused(false)` task has already run. The shortcuts then remain globally registered and macOS applications no longer receive them until Clash Verge exits or the stale registration is otherwise cleared.

The same risk exists while shortcut registration itself is awaiting the global shortcut manager, so the generation is checked both before and after registration.

This is consistent with the macOS symptoms reported in #1814, including `Cmd+W` being unavailable in other applications and becoming available again after Clash Verge exits.

## Diagnostic evidence

This change follows a local investigation of a system-wide `Cmd+W` failure on macOS:

1. `Cmd+C`, `Cmd+T`, and other Command shortcuts still worked, while `Cmd+W` failed in Safari, TextEdit, and other applications. Their menus continued to display the expected `Cmd+W` shortcut, which ruled out an application menu remapping.
2. `NSUserKeyEquivalents`, `hidutil` user mappings, Karabiner, and other likely shortcut utilities were checked or disabled without restoring the shortcut.
3. Event-tap diagnostics showed the physical `Cmd+W` event at the HID and session levels, but it did not reach the annotated session/application level. This indicated that a global shortcut registration was consuming the event before applications received it.
4. A controlled probe injected a uniquely tagged `Cmd+W` event and intercepted it before application delivery so that no window could close. The probe reported `CONSUMED` while the stale state was active.
5. Fully exiting Clash Verge changed the same probe result to `PASS`, and the real `Cmd+W` shortcut immediately worked again. Restarting Clash Verge did not immediately reproduce the stale state, which is consistent with an event-ordering race rather than a persistent shortcut configuration.

The diagnosis identifies Clash Verge as the owner of the stale registration. The generation guard in this patch addresses the async ordering path in the current focus handler that can produce that state.

## Validation

- `cargo test -p clash-verge --lib advancing_focus_invalidates_older_work`
- `cargo clippy-all`
- `cargo check -p clash-verge --lib`
- `cargo fmt --all -- --check`
- `pnpm exec vite build`
- local macOS event-tap probe described above

Refs #1814