### PR TITLE
fix(macos): prevent system hotkeys remaining registered after focus loss

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -344,8 +344,17 @@ pub fn run() -> std::process::ExitCode {
         fn unregister_system_hotkeys() {
             use crate::core::hotkey::SystemHotkey;
 
-            let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdQ);
-            let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdW);
+            for system_hotkey in [SystemHotkey::CmdQ, SystemHotkey::CmdW] {
+                if let Err(err) = hotkey::Hotkey::global().unregister_system_hotkey(system_hotkey) {
+                    logging!(
+                        warn,
+                        Type::Hotkey,
+                        "Failed to unregister system hotkey {}: {:?}",
+                        system_hotkey,
+                        err
+                    );
+                }
+            }
         }
 
         pub fn handle_ready_resumed(_app_handle: &AppHandle) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -328,9 +328,25 @@ pub fn run() -> std::process::ExitCode {
             process::AsyncHandler,
         };
         use clash_verge_logging::{Type, logging};
+        #[cfg(target_os = "macos")]
+        use std::sync::atomic::{AtomicBool, Ordering};
         use tauri::AppHandle;
         #[cfg(target_os = "macos")]
         use tauri::Manager as _;
+
+        #[cfg(target_os = "macos")]
+        static MAIN_WINDOW_FOCUSED: AtomicBool = AtomicBool::new(false);
+        // Serialize async updates so stale focus work cannot overwrite the latest state.
+        #[cfg(target_os = "macos")]
+        static SYSTEM_HOTKEY_UPDATE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+        #[cfg(target_os = "macos")]
+        fn unregister_system_hotkeys() {
+            use crate::core::hotkey::SystemHotkey;
+
+            let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdQ);
+            let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdW);
+        }
 
         pub fn handle_ready_resumed(_app_handle: &AppHandle) {
             if handle::Handle::global().is_exiting() {
@@ -362,7 +378,11 @@ pub fn run() -> std::process::ExitCode {
 
         pub fn handle_window_close(api: &tauri::WindowEvent) {
             #[cfg(target_os = "macos")]
-            handle::Handle::global().set_activation_policy_accessory();
+            {
+                MAIN_WINDOW_FOCUSED.store(false, Ordering::Release);
+                unregister_system_hotkeys();
+                handle::Handle::global().set_activation_policy_accessory();
+            }
 
             if core::handle::Handle::global().is_exiting() {
                 return;
@@ -377,8 +397,45 @@ pub fn run() -> std::process::ExitCode {
         }
 
         pub fn handle_window_focus(focused: bool) {
+            #[cfg(target_os = "macos")]
+            MAIN_WINDOW_FOCUSED.store(focused, Ordering::Release);
+
+            #[cfg(target_os = "macos")]
+            if !focused {
+                unregister_system_hotkeys();
+            }
+
             AsyncHandler::spawn(move || async move {
                 let is_enable_global_hotkey = Config::verge().await.data_arc().enable_global_hotkey.unwrap_or(true);
+
+                #[cfg(target_os = "macos")]
+                let _update_guard = {
+                    let guard = SYSTEM_HOTKEY_UPDATE_LOCK.lock().await;
+                    if focused != MAIN_WINDOW_FOCUSED.load(Ordering::Acquire) {
+                        return;
+                    }
+                    guard
+                };
+
+                #[cfg(target_os = "macos")]
+                let cleanup_stale_update = || {
+                    if MAIN_WINDOW_FOCUSED.load(Ordering::Acquire) {
+                        return false;
+                    }
+
+                    unregister_system_hotkeys();
+                    if !is_enable_global_hotkey {
+                        let _ = hotkey::Hotkey::global().reset();
+                    }
+                    true
+                };
+
+                #[cfg(not(target_os = "macos"))]
+                let cleanup_stale_update = || false;
+
+                if cleanup_stale_update() {
+                    return;
+                }
 
                 if focused {
                     #[cfg(target_os = "macos")]
@@ -390,18 +447,18 @@ pub fn run() -> std::process::ExitCode {
                         let _ = hotkey::Hotkey::global()
                             .register_system_hotkey(SystemHotkey::CmdW)
                             .await;
+
+                        if cleanup_stale_update() {
+                            return;
+                        }
                     }
                     if !is_enable_global_hotkey {
                         let _ = hotkey::Hotkey::global().init(false).await;
                     }
+                    if cleanup_stale_update() {
+                        return;
+                    }
                     return;
-                }
-
-                #[cfg(target_os = "macos")]
-                {
-                    use crate::core::hotkey::SystemHotkey;
-                    let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdQ);
-                    let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdW);
                 }
 
                 if !is_enable_global_hotkey {
@@ -412,10 +469,10 @@ pub fn run() -> std::process::ExitCode {
 
         #[cfg(target_os = "macos")]
         pub fn handle_window_destroyed() {
-            use crate::core::hotkey::SystemHotkey;
+            MAIN_WINDOW_FOCUSED.store(false, Ordering::Release);
+            unregister_system_hotkeys();
+
             AsyncHandler::spawn(move || async move {
-                let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdQ);
-                let _ = hotkey::Hotkey::global().unregister_system_hotkey(SystemHotkey::CmdW);
                 let is_enable_global_hotkey = Config::verge().await.data_arc().enable_global_hotkey.unwrap_or(true);
                 if !is_enable_global_hotkey {
                     let _ = hotkey::Hotkey::global().reset();


### PR DESCRIPTION

## Summary

- unregister the macOS-only `Cmd+Q` and `Cmd+W` system hotkeys immediately when the main window loses focus, closes, or is destroyed
- track whether the main window should currently own those shortcuts and ignore async work for an outdated focus state
- serialize shortcut updates so older focus work cannot overwrite a newer registration, then re-check the desired state after awaited operations

## User impact

This failure escapes the Clash Verge window and affects the entire macOS session. Once a stale registration is left behind, standard shortcuts such as `Cmd+W` no longer reach the foreground application. Users can lose the normal close-tab/close-window action in browsers, editors, terminals, and other applications, while the affected application's menu still displays the shortcut as available.

The failure is also difficult to attribute: there is no visible Clash Verge window or warning when the event is consumed, and application shortcut settings remain correct. The stale registration can survive application switching and continues until Clash Verge releases it or exits. Because `Cmd+Q` follows the same window-scoped registration lifecycle, the fix covers both macOS system shortcuts currently managed by this path.

## Root cause

`handle_window_focus` spawns an async task and reads the Verge configuration before updating the system hotkeys. Focus events can therefore complete out of order: a task created for `Focused(true)` may register `Cmd+Q` and `Cmd+W` after a later `Focused(false)` task has already run. The shortcuts then remain globally registered and macOS applications no longer receive them until Clash Verge exits or the stale registration is otherwise cleared.

The focus state can also change while shortcut registration itself is awaiting the global shortcut manager. The update lock prevents overlapping tasks from cleaning up or replacing each other's registrations, while the atomic focus state lets each task verify that its intended state is still current before and after awaited operations.

This is consistent with the macOS symptoms reported in #1814, including `Cmd+W` being unavailable in other applications and becoming available again after Clash Verge exits.

## Diagnostic evidence

This change follows a local investigation of a system-wide `Cmd+W` failure on macOS:

1. `Cmd+C`, `Cmd+T`, and other Command shortcuts still worked, while `Cmd+W` failed in Safari, TextEdit, and other applications. Their menus continued to display the expected `Cmd+W` shortcut, which ruled out an application menu remapping.
2. `NSUserKeyEquivalents`, `hidutil` user mappings, Karabiner, and other likely shortcut utilities were checked or disabled without restoring the shortcut.
3. Event-tap diagnostics showed the physical `Cmd+W` event at the HID and session levels, but it did not reach the annotated session/application level. This indicated that a global shortcut registration was consuming the event before applications received it.
4. A controlled probe injected a uniquely tagged `Cmd+W` event and intercepted it before application delivery so that no window could close. The probe reported `CONSUMED` while the stale state was active.
5. Fully exiting Clash Verge changed the same probe result to `PASS`, and the real `Cmd+W` shortcut immediately worked again. Restarting Clash Verge did not immediately reproduce the stale state, which is consistent with an event-ordering race rather than a persistent shortcut configuration.

The diagnosis identifies Clash Verge as the owner of the stale registration. The serialized state update in this patch addresses the async ordering path in the current focus handler that can produce that state.

## Validation

- `cargo clippy-all`
- `cargo check -p clash-verge --lib`
- `cargo fmt --all -- --check`
- `pnpm exec vite build`
- local macOS event-tap probe described above
- patched debug build: 30 confirmed focus-to-blur transitions, with the tagged `Cmd+W` probe reaching the annotated-session tap after every blur (`30/30`, zero release failures)
- deterministic race test: a test-only 200 ms delay was added to focused work in separate unpatched and patched builds, followed by a focus-to-blur transition after 30 ms. The unpatched build returned `CONSUMED` on the first attempt; the patched build returned `PASS` in all five attempts. The delay was removed after the test and is not part of this change.

The unmodified installed build did not naturally reproduce the intermittent stale state during 500 additional focus transitions. The delayed test above is therefore a controlled reproduction of the identified ordering bug, not a claim that the original timing occurs on every focus change.

Refs #1814