### PR TITLE
fix(signal): use default runtime

### DIFF
--- a/crates/clash-verge-signal/src/lib.rs
+++ b/crates/clash-verge-signal/src/lib.rs
@@ -14,20 +14,18 @@ where
     F: Fn() -> Fut + Send + Sync + 'static,
     Fut: Future + Send + 'static,
 {
-    RUNTIME.get_or_init(
-        || match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-            Ok(rt) => Some(rt),
-            Err(e) => {
-                logging!(
-                    info,
-                    Type::SystemSignal,
-                    "register shutdown signal failed, create tokio runtime error: {}",
-                    e
-                );
-                None
-            }
-        },
-    );
+    RUNTIME.get_or_init(|| match tokio::runtime::Runtime::new() {
+        Ok(rt) => Some(rt),
+        Err(e) => {
+            logging!(
+                info,
+                Type::SystemSignal,
+                "register shutdown signal failed, create tokio runtime error: {}",
+                e
+            );
+            None
+        }
+    });
 
     #[cfg(unix)]
     unix::register(f);


### PR DESCRIPTION
Related docs: https://docs.rs/tokio/latest/tokio/runtime/index.html#driving-the-runtime
> A current-thread runtime does not spawn any worker threads, so it can only execute tasks when you provide a thread by calling [Runtime::block_on](https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.block_on).

Related commit: c3f7ff7aa2261f8c70563e21613b764cebd1a261