### PR TITLE
chore(ci): Explicitly limit token permissions

### DIFF
--- a/.github/workflows/autobuild-check-test.yml
+++ b/.github/workflows/autobuild-check-test.yml
@@ -3,6 +3,9 @@ name: Autobuild Check Logic Test
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check_autobuild_logic:
     name: Check Autobuild Should Run Logic

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -3,6 +3,9 @@ name: Cargo Audit
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   HUSKY: 0
 

--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   HUSKY: 0
 

--- a/.github/workflows/lint-clippy.yml
+++ b/.github/workflows/lint-clippy.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
 env:
   HUSKY: 0
+permissions:
+  contents: read
 
 jobs:
   clippy:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -7,6 +7,9 @@ name: Check Formatting
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   HUSKY: 0
 


### PR DESCRIPTION
### ℹ️ 改了什么？

- 显式声明 `secrets.GITHUB_TOKEN` 的权限
- 避免 `secrets.GITHUB_TOKEN` 在未声明时默认权限过高
- 符合 GitHub 官方提供的 [最佳实践](https://docs.github.com/zh/actions/tutorials/authenticate-with-github_token#modifying-the-permissions-for-the-github_token)
