### PR TITLE
refactor(scripts): optimizes file permission changes

### DIFF
--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execFileSync, execSync } from 'child_process'
 import { createHash } from 'crypto'
 import fs from 'fs'
 import fsp from 'fs/promises'
@@ -409,7 +409,7 @@ async function resolveSidecar(binInfo) {
           throw new Error(`Expected binary not found in ${tempDir}`)
         await fsp.rename(path.join(tempDir, candidate), sidecarPath)
       }
-      if (platform !== 'win32') execSync(`chmod 755 ${sidecarPath}`)
+      if (platform !== 'win32') await fsp.chmod(sidecarPath, 0o755)
       log_success(`unzip finished: "${name}"`)
     } else if (zipFile.endsWith('.tgz')) {
       await extract({ cwd: tempDir, file: tempZip })
@@ -425,7 +425,7 @@ async function resolveSidecar(binInfo) {
       if (!extracted) extracted = files[0]
       if (!extracted) throw new Error(`Expected file not found in ${tempDir}`)
       await fsp.rename(path.join(tempDir, extracted), sidecarPath)
-      execSync(`chmod 755 ${sidecarPath}`)
+      await fsp.chmod(sidecarPath, 0o755)
       log_success(`tgz processed: "${name}"`)
     } else {
       // .gz
@@ -440,7 +440,8 @@ async function resolveSidecar(binInfo) {
           })
           .pipe(writeStream)
           .on('finish', () => {
-            if (platform !== 'win32') execSync(`chmod 755 ${sidecarPath}`)
+            if (platform !== 'win32')
+              execFileSync('chmod', ['755', sidecarPath])
             resolve()
           })
           .on('error', (e) => {


### PR DESCRIPTION
### ℹ️ 改了什么？

- 用 Nodejs 原生 `fsp` API 实现文件权限变更
- 对于无法使用 `await fsp` 的部分，切换使用 `execFileSync` 执行命令
  - 避免在 `execSync` 中使用字符串插值构造命令
