### PR TITLE
fix(macos): keep DNS state outside app bundle

### DIFF
--- a/src-tauri/src/utils/resolve/dns.rs
+++ b/src-tauri/src/utils/resolve/dns.rs
@@ -1,4 +1,12 @@
 use clash_verge_logging::{Type, logging};
+use std::path::PathBuf;
+
+fn dns_state_dir() -> anyhow::Result<PathBuf> {
+    // The DNS scripts persist .original_dns.txt relative to their working directory.
+    let dir = crate::utils::dirs::app_home_dir()?;
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
 
 pub async fn set_public_dns(dns_server: String) {
     use crate::{core::handle, utils::dirs};
@@ -19,11 +27,18 @@ pub async fn set_public_dns(dns_server: String) {
         return;
     }
     let script = script.to_string_lossy().into_owned();
+    let state_dir = match dns_state_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            logging!(error, Type::Config, "Failed to get DNS state directory: {}", e);
+            return;
+        }
+    };
     match app_handle
         .shell()
         .command("bash")
         .args([script, dns_server])
-        .current_dir(resource_dir)
+        .current_dir(state_dir)
         .status()
         .await
     {
@@ -60,11 +75,18 @@ pub async fn restore_public_dns() {
         return;
     }
     let script = script.to_string_lossy().into_owned();
+    let state_dir = match dns_state_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            logging!(error, Type::Config, "Failed to get DNS state directory: {}", e);
+            return;
+        }
+    };
     match app_handle
         .shell()
         .command("bash")
         .args([script])
-        .current_dir(resource_dir)
+        .current_dir(state_dir)
         .status()
         .await
     {

--- a/src-tauri/src/utils/resolve/dns.rs
+++ b/src-tauri/src/utils/resolve/dns.rs
@@ -1,11 +1,21 @@
 use clash_verge_logging::{Type, logging};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+const DNS_STATE_FILE: &str = ".original_dns.txt";
 
 fn dns_state_dir() -> anyhow::Result<PathBuf> {
     // The DNS scripts persist .original_dns.txt relative to their working directory.
     let dir = crate::utils::dirs::app_home_dir()?;
     std::fs::create_dir_all(&dir)?;
     Ok(dir)
+}
+
+fn restore_dns_state_dir(resource_dir: &Path, state_dir: PathBuf) -> PathBuf {
+    if resource_dir.join(DNS_STATE_FILE).exists() {
+        resource_dir.to_path_buf()
+    } else {
+        state_dir
+    }
 }
 
 pub async fn set_public_dns(dns_server: String) {
@@ -82,6 +92,7 @@ pub async fn restore_public_dns() {
             return;
         }
     };
+    let state_dir = restore_dns_state_dir(&resource_dir, state_dir);
     match app_handle
         .shell()
         .command("bash")
@@ -101,5 +112,26 @@ pub async fn restore_public_dns() {
         Err(err) => {
             logging!(error, Type::Config, "unset system dns failed: {err}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::restore_dns_state_dir;
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn restore_dns_state_dir_defaults_to_app_data_but_honors_legacy_file() {
+        let root = std::env::temp_dir().join(format!("clash-verge-dns-{}", nanoid::nanoid!()));
+        let resource_dir = root.join("resources");
+        let state_dir = root.join("app-data");
+        std::fs::create_dir_all(&resource_dir).expect("create test resource directory");
+
+        assert_eq!(restore_dns_state_dir(&resource_dir, state_dir.clone()), state_dir);
+
+        std::fs::write(resource_dir.join(".original_dns.txt"), "empty").expect("create legacy DNS state");
+        assert_eq!(restore_dns_state_dir(&resource_dir, state_dir), resource_dir);
+
+        std::fs::remove_dir_all(root).expect("remove test directory");
     }
 }


### PR DESCRIPTION
## Summary

- run the macOS DNS scripts with the application data directory as their working directory
- create that directory before invoking the scripts
- keep `.original_dns.txt` outside the signed application bundle

## Problem

`set_dns.sh` stores `.original_dns.txt` relative to its working directory. The Rust caller currently uses the bundled resource directory as that working directory, so enabling the macOS DNS override adds a runtime file under `Contents/Resources`. This invalidates the sealed application resources and can make strict code-signature verification fail.

This change keeps the scripts in the resource bundle but runs them from `app_home_dir()`, which is the writable application data directory. Both setting and restoring DNS use the same directory, so the existing persistence and restoration behavior is preserved without modifying the signed bundle.

Fixes #7341
Fixes #7407

## Validation

- `cargo fmt --all -- --check`
- `pnpm web:build`
- `cargo check -p clash-verge --lib`
- `cargo clippy-all`
- `cargo test -p clash-verge --lib` (85 passed)
- repository pre-commit and pre-push hooks
