### PR TITLE
fix(enhance): use a lenient timeout for ipc service invoking.

### DIFF
--- a/src-tauri/src/core/service.rs
+++ b/src-tauri/src/core/service.rs
@@ -596,8 +596,8 @@ pub fn is_service_ipc_path_exists() -> bool {
 impl ServiceManager {
     pub const fn config() -> clash_verge_service_ipc::IpcConfig {
         clash_verge_service_ipc::IpcConfig {
-            default_timeout: Duration::from_millis(150),
-            retry_delay: Duration::from_millis(250),
+            default_timeout: Duration::from_millis(1000),
+            retry_delay: Duration::from_millis(500),
             max_retries: 20,
         }
     }


### PR DESCRIPTION
This PR set a longer timeout value for some strange, rare pipe latency. (Idk why for now; maybe something about cool-launching of clash-verge-service-ipc, but works with 1000ms.)  
With this PR, no regression is expected. And 1000ms timeout + 500ms retry delay should be fair in general.  
Alternative solution: Get some RPC request before the client to warm it up.
