### PR TITLE
fix(config): apply runtime configuration on initialization

### DIFF
--- a/src-tauri/src/config/config.rs
+++ b/src-tauri/src/config/config.rs
@@ -101,6 +101,8 @@ impl Config {
             handle::Handle::notice_message(msg_type, msg_content);
         }
 
+        Self::runtime().await.apply();
+
         {
             let profiles = Self::profiles().await.data_arc();
             // Logging error internally


### PR DESCRIPTION
Related: #7554 

During the initialization runtime configuration phases, calling the `apply` function officially makes the runtime draft effective. This ensures that when other configurations are changed or the configuration is re-activated, the `data_arc` method will no longer be None.