### PR TITLE
feat(updater): skip installer language prompt during auto-update

### DIFF
--- a/crates/clash-verge-i18n/src/lib.rs
+++ b/crates/clash-verge-i18n/src/lib.rs
@@ -39,7 +39,7 @@ fn resolve_supported_language(language: &str) -> Option<Cow<'static, str>> {
 }
 
 #[inline]
-fn current_language(language: Option<&str>) -> Cow<'static, str> {
+pub fn current_language(language: Option<&str>) -> Cow<'static, str> {
     language
         .filter(|lang| !lang.is_empty())
         .and_then(resolve_supported_language)

--- a/src-tauri/packages/windows/installer.nsi
+++ b/src-tauri/packages/windows/installer.nsi
@@ -484,7 +484,13 @@ Function .onInit
     ; See `src-tauri/src/core/updater.rs` (`nsis_language_id`).
     ${GetOptions} $CMDLINE "/LANG=" $0
     ${IfNot} ${Errors}
-      StrCpy $LANGUAGE $0
+      ${If} $0 == "1033"
+      ${OrIf} $0 == "1049"
+      ${OrIf} $0 == "2052"
+        StrCpy $LANGUAGE $0
+      ${Else}
+        !insertmacro MUI_LANGDLL_DISPLAY
+      ${EndIf}
     ${Else}
       !insertmacro MUI_LANGDLL_DISPLAY
     ${EndIf}

--- a/src-tauri/packages/windows/installer.nsi
+++ b/src-tauri/packages/windows/installer.nsi
@@ -478,7 +478,16 @@ Function .onInit
   ${EndIf}
 
   !if "${DISPLAYLANGUAGESELECTOR}" == "true"
-    !insertmacro MUI_LANGDLL_DISPLAY
+    ; Auto-update forwards the app's UI language as `/LANG=<NSIS-lang-id>` so
+    ; the installer uses it directly and skips the interactive language
+    ; selector, letting the update start without prompting the user.
+    ; See `src-tauri/src/core/updater.rs` (`nsis_language_id`).
+    ${GetOptions} $CMDLINE "/LANG=" $0
+    ${IfNot} ${Errors}
+      StrCpy $LANGUAGE $0
+    ${Else}
+      !insertmacro MUI_LANGDLL_DISPLAY
+    ${EndIf}
   !endif
 
   !insertmacro SetContext

--- a/src-tauri/src/core/updater.rs
+++ b/src-tauri/src/core/updater.rs
@@ -130,9 +130,9 @@ fn version_lte(a: &str, b: &str) -> bool {
 /// Map the app's resolved UI language code to an NSIS installer language ID.
 ///
 /// The Windows installer only ships SimpChinese, English and Russian
-/// (`tauri.windows.conf.json` `nsis.languages`), so app languages without a
-/// matching NSIS translation fall back to English (a common default) instead
-/// of leaving the installer to prompt for a language.
+/// (`tauri.windows.conf.json` `nsis.languages`). Languages without a matching
+/// NSIS translation fall back to English; Traditional Chinese ("zhtw") is
+/// mapped to SimpChinese so Chinese users don't get an English installer.
 #[cfg(target_os = "windows")]
 fn nsis_language_id(app_language: &str) -> &'static str {
     match app_language {

--- a/src-tauri/src/core/updater.rs
+++ b/src-tauri/src/core/updater.rs
@@ -127,6 +127,21 @@ fn version_lte(a: &str, b: &str) -> bool {
     true // equal
 }
 
+/// Map the app's resolved UI language code to an NSIS installer language ID.
+///
+/// The Windows installer only ships SimpChinese, English and Russian
+/// (`tauri.windows.conf.json` `nsis.languages`), so app languages without a
+/// matching NSIS translation fall back to English (a common default) instead
+/// of leaving the installer to prompt for a language.
+#[cfg(target_os = "windows")]
+fn nsis_language_id(app_language: &str) -> &'static str {
+    match app_language {
+        "zh" | "zhtw" => "2052", // SimpChinese
+        "ru" => "1049",          // Russian
+        _ => "1033",             // English
+    }
+}
+
 // ─── Startup Install & Cache Management ─────────────────────────────────────
 
 impl SilentUpdater {
@@ -186,7 +201,20 @@ impl SilentUpdater {
 
         // Need a fresh Update object from the server to call install().
         // This is a lightweight HTTP request (< 1s), not a re-download.
-        let update = match app_handle.updater() {
+        //
+        // The updater is built with the app's current language forwarded as
+        // `/LANG=<NSIS-lang-id>`. On Windows the NSIS installer parses this in
+        // `.onInit` (see `packages/windows/installer.nsi`) and sets `$LANGUAGE`
+        // directly, skipping its language-selection dialog so the update starts
+        // without prompting. Other platforms don't run an installer.
+        let updater_builder = app_handle.updater_builder();
+        #[cfg(target_os = "windows")]
+        let updater_builder = {
+            let verge_lang = Config::verge().await.latest_arc().language.clone();
+            let lang_id = nsis_language_id(&clash_verge_i18n::current_language(verge_lang.as_deref()));
+            updater_builder.installer_arg(format!("/LANG={lang_id}"))
+        };
+        let update = match updater_builder.build() {
             Ok(updater) => match updater.check().await {
                 Ok(Some(u)) => u,
                 Ok(None) => {


### PR DESCRIPTION
## 背景

在自动更新过程中，NSIS 安装程序以被动模式 (`/P`) 运行，而 `MUI_LANGDLL_DISPLAY` 会在 `.onInit` 阶段弹出语言选择对话框，导致更新进程阻塞，直到用户选择语言为止。

我自己之前就遇到过，cvr 出现更新弹窗，我点击确定后就切去别的窗口，过一段时间再按 alt + tab 才发现原来更新程序还在等我选语言=。=

## 解决方案

通过 `/LANG=<NSIS-lang-id>` 命令行参数将应用程序当前的 UI 语言传递给安装程序。安装程序在 `.onInit` 中直接设置 `$LANGUAGE` 变量并跳过对话框，从而实现立即更新。通过命令行传递参数，可以保持安装程序与应用程序配置格式的解耦。

## 变更内容

- **`src-tauri/packages/windows/installer.nsi`** — `.onInit`：从 `$CMDLINE` 解析 `/LANG=` 参数；若存在，则执行 `StrCpy $LANGUAGE <id>` 并跳过 `MUI_LANGDLL_DISPLAY`；否则保留交互式对话框（手动安装流程保持不变）。
- **`src-tauri/src/core/updater.rs`** — `try_install_on_startup`：使用 `app_handle.updater_builder().installer_arg("/LANG=<id>").build()` 构建更新程序，而非使用 `app_handle.updater()`（仅限 Windows，受 `#[cfg]` 条件编译控制）。添加了 `nsis_language_id()` 映射逻辑：`zh`/`zhtw` → 2052 (简体中文)，`ru` → 1049，其他 → 1033 (英语) —— 对应 `tauri.windows.conf.json` 中的三种语言。
- **`crates/clash-verge-i18n/src/lib.rs`** — 将 `current_language` 设为 `pub`（公开），以便更新程序复用其区域设置标准化逻辑（处理 `zh-CN`/`ja-JP` 等变体，并回退至系统语言）。

## 工作原理（Windows 平台）

后台下载 → 下次启动时 `try_install_on_startup` 使用 `/LANG=` 参数重建更新程序 → `install()` 执行 `installer.exe /P /UPDATE /R /ARGS … /LANG=2052` → NSIS 脚本中的 `.onInit` 设置 `$LANGUAGE` 变量并跳过对话框 → 直接进行安装。

`/ARGS`（重新启动参数）不受影响：`${GetOptions}` 将 `/` 视为选项分隔符，因此 `/ARGS` 的值在 `/LANG=` 处截断，而 `/LANG=` 被独立解析。重新启动后的应用程序不会接收到 `/LANG=` 参数。

## 适用范围

- ✅ 静默自动更新程序 (`SilentUpdater`) —— 即“自动更新”流程。
- ⚠️ 手动安装（不带 `/LANG=` 参数）及非 Windows 平台不受影响。