### PR TITLE
fix(profile): prevent crash when editing proxies with empty name

### DIFF
--- a/src/components/profile/proxies-editor-viewer.tsx
+++ b/src/components/profile/proxies-editor-viewer.tsx
@@ -73,16 +73,25 @@ export const ProxiesEditorViewer = (props: Props) => {
   const [appendSeq, setAppendSeq] = useState<IProxyConfig[]>([])
   const [deleteSeq, setDeleteSeq] = useState<string[]>([])
 
+  // 节点的 name 会被用作 SortableContext 的 item id、React key 以及拖拽排序的
+  // 依据。当 name 为空/null（例如高级模式下粘贴了缺少 name 的节点）时，
+  // @dnd-kit 的 SortableContext 会对 null 执行 `'id' in item` 从而崩溃
+  // （Cannot use 'in' operator to search for 'id' in null）。
+  // 这里统一过滤掉没有有效 name 的节点，避免可视化编辑页崩溃；原始 YAML
+  // 数据仍然保留，用户可在高级(文本)模式中查看并修正这些节点。
+  const hasValidName = (proxy: IProxyConfig) =>
+    typeof proxy?.name === 'string' && proxy.name.length > 0
   const filteredPrependSeq = useMemo(
-    () => prependSeq.filter((proxy) => match(proxy.name)),
+    () =>
+      prependSeq.filter((proxy) => hasValidName(proxy) && match(proxy.name)),
     [prependSeq, match],
   )
   const filteredProxyList = useMemo(
-    () => proxyList.filter((proxy) => match(proxy.name)),
+    () => proxyList.filter((proxy) => hasValidName(proxy) && match(proxy.name)),
     [proxyList, match],
   )
   const filteredAppendSeq = useMemo(
-    () => appendSeq.filter((proxy) => match(proxy.name)),
+    () => appendSeq.filter((proxy) => hasValidName(proxy) && match(proxy.name)),
     [appendSeq, match],
   )
 


### PR DESCRIPTION
## 问题 / Problem

Fixes #7580

订阅「编辑节点」可视化模式下，若 prepend/append 序列中存在 `name` 为空的节点（YAML `name:` 解析为 `null`），保存后重新打开编辑节点页面会直接崩溃：

```
TypeError: Cannot use 'in' operator to search for 'id' in null
    at sortable.esm.js:308
```

## 根因 / Root cause

`ProxiesEditorViewer` 将 `filteredPrependSeq/filteredAppendSeq.map(x => x.name)` 直接作为 `SortableContext` 的 `items`。当节点 name 为 `null` 时，items 数组中出现 `null`，而 @dnd-kit/sortable v10 内部执行：

```js
typeof item === 'object' && 'id' in item
```

由于 `typeof null === 'object'`，随后对 `null` 执行 `'id' in null` 抛出异常导致页面崩溃。同时 `ProxyItem` 的 `useSortable({ id: proxy.name })` 与 React `key` 也存在同样隐患。

## 修复 / Fix

新增 `hasValidName` 守卫，在 `filteredPrependSeq` / `filteredProxyList` / `filteredAppendSeq` 三处 `useMemo` 中过滤掉没有有效 name（非空字符串）的节点，避免 `null` 进入 SortableContext / useSortable / React key。

原始 YAML 数据不受影响，用户仍可在高级（文本）模式中查看并修正这些节点。

## 验证 / Verification

- [x] `pnpm typecheck` 通过
- [x] `pnpm exec lint-staged`（eslint --fix + biome format）通过
- [x] `pnpm web:build` 完整前端构建通过
- [x] 用 issue 中的节点配置复现：修复前抛出与 issue 完全一致的报错，修复后正常渲染