### PR TITLE
fix(config): prevent cleanup_orphaned_files from deleting active profiles

### DIFF
--- a/src-tauri/src/config/profiles.rs
+++ b/src-tauri/src/config/profiles.rs
@@ -424,6 +424,19 @@ impl IProfiles {
             return Ok(());
         }
 
+        // 如果 items 为空（例如 profiles.yaml 解析失败导致
+        // IProfiles::new() 返回 default），此时无法判断哪些文件是活跃的，
+        // 跳过清理以避免误删用户正在使用的订阅配置文件。
+        // See: https://github.com/clash-verge-rev/clash-verge-rev/issues/7577
+        if self.items.as_ref().map_or(true, |v| v.is_empty()) {
+            logging!(
+                warn,
+                Type::Config,
+                "Profile items 为空，跳过孤儿文件清理以避免误删活跃的配置文件"
+            );
+            return Ok(());
+        }
+
         // 获取所有 active profile 的文件名集合
         let active_files = self.get_all_active_files();
 


### PR DESCRIPTION
## 问题 / Problem

Fixes #7577

启动时 `cleanup_orphaned_files()` 误删当前正在使用的订阅配置文件。用户日志显示 profiles/ 目录下 32 个文件被删除了 30 个。

## 根因 / Root cause

`IProfiles::new()` 加载 `profiles.yaml` 时若解析失败，返回 `Self::default()`（`items: None`）。该值成为 `Draft` 的已提交数据。随后 `init_runtime_config()` 调用 `cleanup_orphaned_files()` 时：

1. `get_all_active_files()` 遍历 `self.items`（`None`），返回空 `HashSet`
2. 除 `Merge.yaml` 和 `Script.js` 两个硬编码保护文件外，所有 profile 文件被当作孤儿删除

## 修复 / Fix

在 `cleanup_orphaned_files()` 开头检查 `self.items` 是否为 `None` 或空。当 items 不可用时说明无法可靠判断哪些文件是活跃的，跳过清理并记录警告日志，避免盲删用户数据。

## 验证 / Verification

- [x] `cargo check` 编译通过
- [x] `cargo fmt`（pre-commit 钩子）通过