### PR TITLE
fix: enable shell option for child_process.spawn on Windows

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -336,6 +336,7 @@ export async function runDevCommand(mode, dependencies = {}) {
   let child
   try {
     child = spawnChild(invocation.command, invocation.args, {
+      shell: platform === 'win32',
       env: invocation.env,
       detached: invocation.detached,
       stdio:

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -191,6 +191,7 @@ export async function runDevAnchor(mode, dependencies = {}) {
   let inner
   try {
     inner = spawnChild(invocation.command, invocation.args, {
+      shell: platform === 'win32',
       env: invocation.env,
       detached: false,
       stdio: 'inherit',


### PR DESCRIPTION
close #7618
- 当平台为win时, 调用 [child_process.spawn()](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options) 添加 shell 选项