### PR TITLE
chore: update tauri-plugin-mihomo deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,6 +1263,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "clashcore"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "facfbc410a385e0b0cbca8179dd9e363ed70e8455960bf7545137e90ca753b66"
+dependencies = [
+ "crossbeam-utils",
+ "lock_api",
+ "parking_lot_core",
+ "polonius-the-crab",
+]
+
+[[package]]
+name = "clashmap"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e195164ef44aa7de78676cce561134365dec78761db2959e55d22bb8d4ffce16"
+dependencies = [
+ "clashcore",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "polonius-the-crab",
+ "replace_with",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,6 +3155,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "higher-kinded-types"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e690f8474c6c5d8ff99656fcbc195a215acc3949481a8b0b3351c838972dc776"
+dependencies = [
+ "macro_rules_attribute",
+ "never-say-never",
+ "paste",
+]
+
+[[package]]
 name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4041,6 +4077,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "pastey",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,6 +4334,12 @@ dependencies = [
  "thiserror 2.0.18",
  "winapi",
 ]
+
+[[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -4870,6 +4928,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "path-tree"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5181,6 +5245,16 @@ dependencies = [
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polonius-the-crab"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec242d7eccbb2fd8b3b5b6e3cf89f94a91a800f469005b44d154359609f8af72"
+dependencies = [
+ "higher-kinded-types",
+ "never-say-never",
 ]
 
 [[package]]
@@ -5725,6 +5799,12 @@ name = "rend"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
+
+[[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "reqwest"
@@ -7372,9 +7452,10 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-mihomo"
 version = "0.5.5"
-source = "git+https://github.com/clash-verge-rev/tauri-plugin-mihomo?branch=refactor-use-reqwest-ipc#3a5cd67b01d7b9e49e6526d15de5e28e5a551df4"
+source = "git+https://github.com/clash-verge-rev/tauri-plugin-mihomo?branch=refactor-use-reqwest-ipc#cdb2b88c5bb17949264b4e67d237896d407261ea"
 dependencies = [
  "arc-swap",
+ "clashmap",
  "fast-uuid-v7",
  "futures-util",
  "http 1.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
         version: 2.4.2(react@19.2.8)
       tauri-plugin-mihomo-api:
         specifier: github:clash-verge-rev/tauri-plugin-mihomo#refactor-use-reqwest-ipc
-        version: https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/a5ec60e8a36054c11abe2e8b4d2371ed3481afe1
+        version: https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/cdb2b88c5bb17949264b4e67d237896d407261ea
       types-pac:
         specifier: ^1.0.3
         version: 1.0.3
@@ -3783,8 +3783,8 @@ packages:
     resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
-  tauri-plugin-mihomo-api@https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/a5ec60e8a36054c11abe2e8b4d2371ed3481afe1:
-    resolution: {gitHosted: true, integrity: sha512-Et7x+ZIQUX07pAbErcMc0K32Hd846nE5a5cxMrW/gRU+OODe5hdAhOddO1Vx8DxW6zXA1m9Cx2u1IoVxd3AIUA==, tarball: https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/a5ec60e8a36054c11abe2e8b4d2371ed3481afe1}
+  tauri-plugin-mihomo-api@https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/cdb2b88c5bb17949264b4e67d237896d407261ea:
+    resolution: {gitHosted: true, integrity: sha512-bAgE669PfLIX0K8Q3D0pniGDSPV6D+C5xNb+7bj6DUJXC4o+s7xEaZglwkadbElY56YGj+A+8QIoNURy6pRG7Q==, tarball: https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/cdb2b88c5bb17949264b4e67d237896d407261ea}
     version: 0.5.5
 
   terser@5.49.0:
@@ -7956,7 +7956,7 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  tauri-plugin-mihomo-api@https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/a5ec60e8a36054c11abe2e8b4d2371ed3481afe1:
+  tauri-plugin-mihomo-api@https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/cdb2b88c5bb17949264b4e67d237896d407261ea:
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/src-tauri/src/utils/resolve/dns.rs
+++ b/src-tauri/src/utils/resolve/dns.rs
@@ -1,6 +1,9 @@
 use clash_verge_logging::{Type, logging};
-use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::path::Path;
+use std::path::PathBuf;
 
+#[cfg(target_os = "macos")]
 const DNS_STATE_FILE: &str = ".original_dns.txt";
 
 fn dns_state_dir() -> anyhow::Result<PathBuf> {
@@ -10,6 +13,7 @@ fn dns_state_dir() -> anyhow::Result<PathBuf> {
     Ok(dir)
 }
 
+#[cfg(target_os = "macos")]
 fn restore_dns_state_dir(resource_dir: &Path, state_dir: PathBuf) -> PathBuf {
     if resource_dir.join(DNS_STATE_FILE).exists() {
         resource_dir.to_path_buf()
@@ -117,11 +121,13 @@ pub async fn restore_public_dns() {
 
 #[cfg(test)]
 mod tests {
-    use super::restore_dns_state_dir;
 
     #[test]
     #[allow(clippy::expect_used)]
+    #[cfg(target_os = "macos")]
     fn restore_dns_state_dir_defaults_to_app_data_but_honors_legacy_file() {
+        use super::restore_dns_state_dir;
+
         let root = std::env::temp_dir().join(format!("clash-verge-dns-{}", nanoid::nanoid!()));
         let resource_dir = root.join("resources");
         let state_dir = root.join("app-data");


### PR DESCRIPTION
Using the `clashmap` library instead of `RwLock<HashMap>` to manage mihomo WebSocket connections, lock operations are no longer needed