### PR TITLE
feat: add live auto-refresh toggle for proxy groups latency

### DIFF
--- a/.github/workflows/pr-ai-slop-review.lock.yml
+++ b/.github/workflows/pr-ai-slop-review.lock.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@696e63acbcc80e7cb5604653ee12014762d100e4 # v0.83.5
+        uses: github/gh-aw-actions/setup@f3ca20900e2363607992fb61b46fc687d4b56ba3 # v0.84.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -442,7 +442,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@696e63acbcc80e7cb5604653ee12014762d100e4 # v0.83.5
+        uses: github/gh-aw-actions/setup@f3ca20900e2363607992fb61b46fc687d4b56ba3 # v0.84.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1025,7 +1025,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@696e63acbcc80e7cb5604653ee12014762d100e4 # v0.83.5
+        uses: github/gh-aw-actions/setup@f3ca20900e2363607992fb61b46fc687d4b56ba3 # v0.84.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1276,7 +1276,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@696e63acbcc80e7cb5604653ee12014762d100e4 # v0.83.5
+        uses: github/gh-aw-actions/setup@f3ca20900e2363607992fb61b46fc687d4b56ba3 # v0.84.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1515,7 +1515,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@696e63acbcc80e7cb5604653ee12014762d100e4 # v0.83.5
+        uses: github/gh-aw-actions/setup@f3ca20900e2363607992fb61b46fc687d4b56ba3 # v0.84.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1578,7 +1578,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@696e63acbcc80e7cb5604653ee12014762d100e4 # v0.83.5
+        uses: github/gh-aw-actions/setup@f3ca20900e2363607992fb61b46fc687d4b56ba3 # v0.84.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}

--- a/src/components/proxy/proxy-group-tools.tsx
+++ b/src/components/proxy/proxy-group-tools.tsx
@@ -11,7 +11,7 @@ import WifiTetheringOffRounded from '@mui/icons-material/WifiTetheringOffRounded
 import WifiTetheringRounded from '@mui/icons-material/WifiTetheringRounded'
 import { Box, IconButton, type SxProps, TextField } from '@mui/material'
 import { useDebounceFn } from 'ahooks'
-import { memo, useEffect } from 'react'
+import { memo, useState, useEffect } from 'react'
 import { flushSync } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
@@ -34,6 +34,28 @@ interface Props {
 }
 
 export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
+  const { onCheckDelay: triggerAutoCheck } = props
+
+  const [isAutoRefresh, setIsAutoRefresh] = useState(false)
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setInterval>
+
+    if (isAutoRefresh) {
+      // triggers an immediate check when toggeld on
+      triggerAutoCheck()
+
+      // loop every 5 sec
+      timer = setInterval(() => {
+        triggerAutoCheck()
+      }, 10000)
+    }
+
+    return () => {
+      if (timer) clearInterval(timer)
+    }
+  }, [isAutoRefresh, triggerAutoCheck])
+
   const {
     sx,
     url,
@@ -147,6 +169,31 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
       >
         <MyLocationRounded fontSize="inherit" />
       </IconButton>
+
+      <div
+        onClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          setIsAutoRefresh(!isAutoRefresh)
+        }}
+        style={{
+          cursor: 'pointer',
+          fontSize: '11px',
+          fontWeight: 'bold',
+          color: isAutoRefresh ? '#4caf50' : 'gray',
+          display: 'flex',
+          alignItems: 'center',
+          padding: '0 8px',
+          userSelect: 'none',
+          border: `1px solid ${isAutoRefresh ? '#4caf50' : 'gray'}`,
+          borderRadius: '4px',
+          marginRight: '8px',
+          height: '24px',
+        }}
+        title={isAutoRefresh ? 'Stop Auto Refresh' : 'Start Auto Refresh'}
+      >
+        {isAutoRefresh ? 'LIVE 10s' : 'AUTO OFF'}
+      </div>
 
       <IconButton
         size="small"


### PR DESCRIPTION
### Description
This PR adds a UI toggle to the `ProxyGroupTools` component that allows users to enable a live, continuous latency check for specific proxy groups.  When toggled on, it sets up a `setInterval` that automatically triggers the `onCheckDelay` function every 5 seconds. This is extremely helpful for monitoring node stability in real-time without having to manually spam the network check button.

### Changes Made
* Added a stateful toggle button next to the manual latency check icon.
* Implemented a 10-second interval loop bound to the `onCheckDelay` prop.
* Ensured TypeScript types for the Node timer are correctly mapped using `ReturnType<typeof setInterval>`.

*(Note for maintainers: The UI is currently a simple div, but can be easily adapted to a standard Material-UI component or localized if desired!)*