### PR TITLE
fix(ws): close socket when subscription setup fails

### DIFF
--- a/src/hooks/use-mihomo-ws-subscription.test.tsx
+++ b/src/hooks/use-mihomo-ws-subscription.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react'
+import type { MihomoWebSocket } from 'tauri-plugin-mihomo-api'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('foxact/use-local-storage', () => ({
+  useLocalStorage: (_key: string, initialValue: number) => [
+    initialValue,
+    vi.fn(),
+  ],
+}))
+
+vi.mock('@/services/query-client', () => ({
+  getCacheData: vi.fn(),
+  removeCacheData: vi.fn(),
+  setCacheData: vi.fn(),
+  useQuery: vi.fn(() => ({ data: [] })),
+}))
+
+import { useMihomoWsSubscription } from './use-mihomo-ws-subscription'
+
+const createSocket = () => {
+  const close = vi.fn(async () => {})
+  const addListener = vi.fn()
+
+  return {
+    socket: { close, addListener } as unknown as MihomoWebSocket,
+    close,
+    addListener,
+  }
+}
+
+const renderSubscription = (
+  connect: () => Promise<MihomoWebSocket>,
+  onConnected?: (ws: MihomoWebSocket) => Promise<void> | void,
+) => {
+  const subscriptionKey = crypto.randomUUID()
+
+  return renderHook(() =>
+    useMihomoWsSubscription<string[]>({
+      storageKey: `ws-cleanup-storage-${subscriptionKey}`,
+      buildSubscriptKey: () => `ws-cleanup-${subscriptionKey}`,
+      fallbackData: [],
+      connect,
+      setupHandlers: () => ({
+        handleMessage: () => {},
+        onConnected,
+      }),
+    }),
+  )
+}
+
+describe('useMihomoWsSubscription connection setup', () => {
+  it('closes the candidate socket when onConnected fails', async () => {
+    const { socket, close, addListener } = createSocket()
+    const connect = vi.fn(async () => socket)
+    const onConnected = vi.fn(async () => {
+      throw new Error('initial state unavailable')
+    })
+
+    const { unmount } = renderSubscription(connect, onConnected)
+
+    await waitFor(() => expect(close).toHaveBeenCalledOnce())
+    expect(addListener).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('closes the candidate socket when listener setup fails', async () => {
+    const { socket, close, addListener } = createSocket()
+    addListener.mockImplementationOnce(() => {
+      throw new Error('listener setup failed')
+    })
+    const connect = vi.fn(async () => socket)
+
+    const { unmount } = renderSubscription(connect)
+
+    await waitFor(() => expect(close).toHaveBeenCalledOnce())
+    unmount()
+  })
+})

--- a/src/hooks/use-mihomo-ws-subscription.ts
+++ b/src/hooks/use-mihomo-ws-subscription.ts
@@ -90,9 +90,12 @@ const createSharedSubscriptionEntry = (
     if (entry.closed || entry.connecting || entry.ws) return
 
     entry.connecting = true
+    let candidateWs: MihomoWebSocket | null = null
     try {
       const ws = await connect()
+      candidateWs = ws
       if (entry.closed) {
+        candidateWs = null
         await ws.close()
         return
       }
@@ -100,6 +103,7 @@ const createSharedSubscriptionEntry = (
       const owner = pickActiveOwner(entry)
       await owner?.onConnected?.(ws)
       if (entry.closed) {
+        candidateWs = null
         await ws.close()
         return
       }
@@ -113,9 +117,18 @@ const createSharedSubscriptionEntry = (
       })
 
       entry.ws = ws
+      candidateWs = null
       syncSharedWsRefs(entry)
       clearReconnectTimer()
     } catch (ignoreError) {
+      const abandonedWs = candidateWs
+      if (abandonedWs) {
+        try {
+          await abandonedWs.close()
+        } catch (closeError) {
+          console.warn('Failed to close abandoned websocket', closeError)
+        }
+      }
       if (!entry.closed && !entry.ws) {
         clearReconnectTimer()
         entry.reconnectTimer = setTimeout(entry.connectWs, RECONNECT_DELAY_MS)


### PR DESCRIPTION
## Summary

- close a newly connected WebSocket when subscription initialization fails before ownership is recorded
- preserve reconnect behavior even if closing the abandoned socket fails
- add regression coverage for `onConnected` and listener setup failures

## Testing

- `pnpm test` (56 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip:check`
- `pnpm test:dev-control` (56 tests)
