### PR TITLE
feat(runstate): retry service version probing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3391,7 +3391,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4840,7 +4840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5523,7 +5523,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5561,7 +5561,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7452,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-mihomo"
 version = "0.5.5"
-source = "git+https://github.com/clash-verge-rev/tauri-plugin-mihomo?branch=refactor-use-reqwest-ipc#cdb2b88c5bb17949264b4e67d237896d407261ea"
+source = "git+https://github.com/clash-verge-rev/tauri-plugin-mihomo?branch=refactor-use-reqwest-ipc#d9398bf8e862c0cd613b79ada45cc5d893820ed6"
 dependencies = [
  "arc-swap",
  "clashmap",
@@ -9093,7 +9093,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
         version: 2.4.2(react@19.2.8)
       tauri-plugin-mihomo-api:
         specifier: github:clash-verge-rev/tauri-plugin-mihomo#refactor-use-reqwest-ipc
-        version: https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/cdb2b88c5bb17949264b4e67d237896d407261ea
+        version: https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/d9398bf8e862c0cd613b79ada45cc5d893820ed6
       types-pac:
         specifier: ^1.0.3
         version: 1.0.3
@@ -3783,8 +3783,8 @@ packages:
     resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
-  tauri-plugin-mihomo-api@https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/cdb2b88c5bb17949264b4e67d237896d407261ea:
-    resolution: {gitHosted: true, integrity: sha512-bAgE669PfLIX0K8Q3D0pniGDSPV6D+C5xNb+7bj6DUJXC4o+s7xEaZglwkadbElY56YGj+A+8QIoNURy6pRG7Q==, tarball: https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/cdb2b88c5bb17949264b4e67d237896d407261ea}
+  tauri-plugin-mihomo-api@https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/d9398bf8e862c0cd613b79ada45cc5d893820ed6:
+    resolution: {gitHosted: true, integrity: sha512-WKt2/wTD35M+yTGRB5fk1zjLqvFuDQFihrkZgUNNclZGA9uSc5ui4bJ0wuDghBYdmeM0QsU+GudxW/kwF7syHg==, tarball: https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/d9398bf8e862c0cd613b79ada45cc5d893820ed6}
     version: 0.5.5
 
   terser@5.49.0:
@@ -7956,7 +7956,7 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  tauri-plugin-mihomo-api@https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/cdb2b88c5bb17949264b4e67d237896d407261ea:
+  tauri-plugin-mihomo-api@https://codeload.github.com/clash-verge-rev/tauri-plugin-mihomo/tar.gz/d9398bf8e862c0cd613b79ada45cc5d893820ed6:
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/src-tauri/src/core/runstate/mod.rs
+++ b/src-tauri/src/core/runstate/mod.rs
@@ -24,8 +24,9 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context as _, Result, bail};
+use anyhow::{Context as _, Error, Result, bail};
 use arc_swap::ArcSwap;
+use backon::{ConstantBuilder, Retryable as _};
 use clash_verge_logging::{Type, logging};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
@@ -221,8 +222,27 @@ impl<E: RunStateEnv> RunStateStore<E> {
             return classify_service_health(CurrentServiceProbe::Missing, false, "");
         }
 
-        match self.env.probe_service_version().await {
-            Ok(reply) => classify_service_health(probe_outcome(&reply), has_marker, ""),
+        let result = (|| async {
+            let reply = self.env.probe_service_version().await?;
+            let service_health = classify_service_health(probe_outcome(&reply), has_marker, "");
+            anyhow::Ok(service_health)
+        })
+        .retry(
+            ConstantBuilder::default()
+                .with_delay(Duration::from_millis(500))
+                .with_max_times(10),
+        )
+        .notify(|err, dur| {
+            logging!(
+                warn,
+                Type::Service,
+                "get service version failed: {err}, retrying in {dur:?}"
+            );
+        })
+        .await;
+
+        match result {
+            Ok(service_health) => service_health,
             Err(error) => {
                 logging!(warn, Type::Service, "current service IPC is unavailable: {error:#}");
                 classify_service_health(

--- a/src-tauri/src/core/runstate/mod.rs
+++ b/src-tauri/src/core/runstate/mod.rs
@@ -230,7 +230,7 @@ impl<E: RunStateEnv> RunStateStore<E> {
         .retry(
             ConstantBuilder::default()
                 .with_delay(Duration::from_millis(500))
-                .with_max_times(10),
+                .with_max_times(6),
         )
         .notify(|err, dur| {
             logging!(

--- a/src-tauri/src/core/runstate/mod.rs
+++ b/src-tauri/src/core/runstate/mod.rs
@@ -24,7 +24,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context as _, Error, Result, bail};
+use anyhow::{Context as _, Result, bail};
 use arc_swap::ArcSwap;
 use backon::{ConstantBuilder, Retryable as _};
 use clash_verge_logging::{Type, logging};


### PR DESCRIPTION
Closes #7622

- 为 `probe_service_version` 增加重试机制 (最多重试6次，每次间隔 500ms)
- 对启动阶段的临时 IPC 不可用情况进行容错
- 重试耗尽后仍正常返回错误
- 升级 tauri-plugin-mihomo 依赖