### PR TITLE
fix: app freeze when emit refresh proxy config event

### DIFF
--- a/src-tauri/src/core/handle.rs
+++ b/src-tauri/src/core/handle.rs
@@ -47,6 +47,10 @@ impl Handle {
         Self::send_event(FrontendEvent::RefreshProfiles);
     }
 
+    pub fn refresh_proxy_config() {
+        Self::send_event(FrontendEvent::RefreshProxyConfig);
+    }
+
     /// Push a Run State snapshot to the frontend.
     ///
     /// Sent on every transition, so the frontend does not have to poll to notice that the Core

--- a/src-tauri/src/core/notification.rs
+++ b/src-tauri/src/core/notification.rs
@@ -9,6 +9,7 @@ pub enum FrontendEvent<'a> {
     RefreshClash,
     RefreshVerge,
     RefreshProfiles,
+    RefreshProxyConfig,
     NoticeMessage { status: &'a str, message: String },
     ProfileChanged { current_profile_id: &'a String },
     TimerUpdated { profile_index: &'a String },
@@ -32,6 +33,7 @@ impl NotificationSystem {
             FrontendEvent::RefreshClash => ("verge://refresh-clash-config", Ok(json!("yes"))),
             FrontendEvent::RefreshVerge => ("verge://refresh-verge-config", Ok(json!("yes"))),
             FrontendEvent::RefreshProfiles => ("verge://refresh-profiles", Ok(json!("yes"))),
+            FrontendEvent::RefreshProxyConfig => ("verge://refresh-proxy-config", Ok(serde_json::Value::Null)),
             FrontendEvent::NoticeMessage { status, message } => {
                 ("verge://notice-message", serde_json::to_value((status, message)))
             }

--- a/src-tauri/src/feat/profile.rs
+++ b/src-tauri/src/feat/profile.rs
@@ -7,7 +7,6 @@ use crate::{
 use anyhow::{Result, bail};
 use clash_verge_logging::{Type, logging, logging_error};
 use smartstring::alias::String;
-use tauri::Emitter as _;
 
 /// Toggle proxy profile
 pub async fn toggle_proxy_profile(profile_index: String) {
@@ -42,7 +41,7 @@ pub async fn switch_proxy_node(group_name: &str, proxy_name: &str) {
         Ok(_) => {
             logging!(info, Type::Tray, "切换代理成功: {} -> {}", group_name, proxy_name);
             record_switched_node(group_name, proxy_name).await;
-            let _ = handle::Handle::app_handle().emit("verge://refresh-proxy-config", ());
+            handle::Handle::refresh_proxy_config();
             let _ = tray::Tray::global().update_menu().await;
             return;
         }


### PR DESCRIPTION
Closes #7659 

将 `verge://refresh-proxy-config` 事件纳入统一事件通道进行发送，避免 webview 锁竞争导致主线程死锁，应用界面冻结