### PR TITLE
fix(proxy): restore chain group after page navigation

### DIFF
--- a/src/components/proxy/proxy-groups.tsx
+++ b/src/components/proxy/proxy-groups.tsx
@@ -41,6 +41,7 @@ import {
   ProxyGroupNavigator,
 } from './proxy-group-navigator'
 import { ProxyRender } from './proxy-render'
+import { resolveActiveChainGroup } from './resolve-chain-group'
 import {
   hasRenderableItems,
   type IRenderItem,
@@ -188,7 +189,13 @@ function ChainProxyGroups(props: {
 }) {
   const { mode, chainConfigData } = props
   const { proxyView } = useProxiesData()
-  const [selectedGroup, setSelectedGroup] = useState<string | null>(null)
+  const [selectedGroup, setSelectedGroup] = useState<string | null>(() => {
+    try {
+      return localStorage.getItem('proxy-chain-group')
+    } catch {
+      return null
+    }
+  })
 
   const availableGroups = useMemo(() => {
     const groups = proxyView?.groups
@@ -198,14 +205,10 @@ function ChainProxyGroups(props: {
     )
   }, [proxyView?.groups])
 
-  const defaultRuleGroup = useMemo(() => {
-    if (mode === 'rule' && availableGroups.length > 0) {
-      return availableGroups[0].name
-    }
-    return null
-  }, [availableGroups, mode])
-
-  const activeSelectedGroup = selectedGroup ?? defaultRuleGroup
+  const activeSelectedGroup = useMemo(
+    () => resolveActiveChainGroup(mode, selectedGroup, availableGroups),
+    [availableGroups, mode, selectedGroup],
+  )
   const {
     renderList,
     onHeadState,

--- a/src/components/proxy/resolve-chain-group.test.ts
+++ b/src/components/proxy/resolve-chain-group.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest'
+
+import { resolveActiveChainGroup } from './resolve-chain-group'
+
+test('restores valid preferred group in rule mode', () => {
+  const groups = [{ name: 'Group1' }, { name: 'Auto' }]
+  const result = resolveActiveChainGroup('rule', 'Auto', groups)
+  expect(result).toBe('Auto')
+})
+
+test('falls back to first group if preferred group is invalid or deleted', () => {
+  const groups = [{ name: 'Group1' }, { name: 'Group2' }]
+  const result = resolveActiveChainGroup('rule', 'DeletedGroup', groups)
+  expect(result).toBe('Group1')
+})
+
+test('returns null in non-rule modes (e.g. global)', () => {
+  const groups = [{ name: 'Group1' }, { name: 'Auto' }]
+  const result = resolveActiveChainGroup('global', 'Auto', groups)
+  expect(result).toBe(null)
+})
+
+test('returns null when available groups is empty', () => {
+  const result = resolveActiveChainGroup('rule', 'Auto', [])
+  expect(result).toBe(null)
+})

--- a/src/components/proxy/resolve-chain-group.ts
+++ b/src/components/proxy/resolve-chain-group.ts
@@ -1,0 +1,22 @@
+export interface MinimalGroup {
+  name: string
+}
+
+export function resolveActiveChainGroup(
+  mode: string,
+  preferredGroupName: string | null | undefined,
+  availableGroups: readonly MinimalGroup[],
+): string | null {
+  if (mode !== 'rule' || availableGroups.length === 0) {
+    return null
+  }
+
+  if (
+    preferredGroupName &&
+    availableGroups.some((group) => group.name === preferredGroupName)
+  ) {
+    return preferredGroupName
+  }
+
+  return availableGroups[0].name
+}


### PR DESCRIPTION
## TL;DR
修复 #6734：规则模式下连接代理链后，切换页面再回来时，已选节点组不再被重置。

## 改动点
- 重新进入代理页时恢复上次成功连接使用的节点组。
- 保存的组不存在时，回退到当前第一个可用组。
- 全局模式不读取规则模式的组选项。

## 测试
- `pnpm test`（58 passed）
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip:check`

Fixes #6734