### PR TITLE
feat: add live auto-refresh toggle for proxy groups latency

### DIFF
--- a/src/components/proxy/proxy-group-tools.tsx
+++ b/src/components/proxy/proxy-group-tools.tsx
@@ -11,7 +11,7 @@ import WifiTetheringOffRounded from '@mui/icons-material/WifiTetheringOffRounded
 import WifiTetheringRounded from '@mui/icons-material/WifiTetheringRounded'
 import { Box, IconButton, type SxProps, TextField } from '@mui/material'
 import { useDebounceFn } from 'ahooks'
-import { memo, useEffect } from 'react'
+import { memo, useEffect, useState } from 'react'
 import { flushSync } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
@@ -56,11 +56,30 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
   } = headState
 
   const { t } = useTranslation()
-
   const { verge } = useVerge()
   const defaultLatencyUrl =
     verge?.default_latency_test?.trim() ||
     'http://cp.cloudflare.com/generate_204'
+
+  // auto refresh state, when enabled, will trigger onCheckDelay every 10 seconds
+  const [isAutoRefresh, setIsAutoRefresh] = useState(false)
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setInterval>
+
+    if (isAutoRefresh) {
+      onCheckDelay()
+
+      timer = setInterval(() => {
+        onCheckDelay()
+      }, 10000)
+    }
+
+    return () => {
+      if (timer) clearInterval(timer)
+    }
+  }, [isAutoRefresh, onCheckDelay])
+  // ----------------------------------
 
   useEffect(() => {
     delayManager.setUrl(groupName, testUrl?.trim() || url || defaultLatencyUrl)
@@ -132,6 +151,7 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
           sx={{ flex: '1 1 auto', input: { py: 0.65, px: 1 } }}
         />
       )}
+      
       <IconButton
         size="small"
         color="inherit"
@@ -147,6 +167,31 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
       >
         <MyLocationRounded fontSize="inherit" />
       </IconButton>
+
+      <div
+        onClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          setIsAutoRefresh(!isAutoRefresh)
+        }}
+        style={{
+          cursor: 'pointer',
+          fontSize: '11px',
+          fontWeight: 'bold',
+          color: isAutoRefresh ? '#4caf50' : 'gray',
+          display: 'flex',
+          alignItems: 'center',
+          padding: '0 8px',
+          userSelect: 'none',
+          border: `1px solid ${isAutoRefresh ? '#4caf50' : 'gray'}`,
+          borderRadius: '4px',
+          marginRight: '8px',
+          height: '24px',
+        }}
+        title={isAutoRefresh ? 'Stop Auto Refresh' : 'Start Auto Refresh'}
+      >
+        {isAutoRefresh ? 'LIVE 10s' : 'AUTO OFF'}
+      </div>
 
       <IconButton
         size="small"


### PR DESCRIPTION
This PR adds a UI toggle to the ProxyGroupTools component that allows users to enable a live, continuous latency check for specific proxy groups. When toggled on, it sets up a setInterval that automatically triggers the onCheckDelay function every 10 seconds. This is extremely helpful for monitoring node stability in real-time without having to manually spam the network check button.

## Changes Made

- Added a stateful toggle button next to the manual latency check icon.
- Implemented a 10-second interval loop bound to the onCheckDelay prop.
- Ensured TypeScript types for the Node timer are correctly mapped using ReturnType<typeof setInterval>.

(Note for maintainers: The UI is currently a simple div, but can be easily adapted to a standard Material-UI component or localized if desired!)