### PR TITLE
fix: refresh tray after delay tests

### DIFF
--- a/src/services/cmds.ts
+++ b/src/services/cmds.ts
@@ -121,9 +121,11 @@ export async function patchClashMode(payload: string) {
   return invoke<void>('patch_clash_mode', { payload })
 }
 
-export async function syncTrayProxySelection() {
+export async function refreshTrayProxyMenu() {
   return invoke<void>('sync_tray_proxy_selection')
 }
+
+export const syncTrayProxySelection = refreshTrayProxyMenu
 
 /**
  * Record which node a group is on, in the current profile.

--- a/src/services/delay.test.ts
+++ b/src/services/delay.test.ts
@@ -1,14 +1,20 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
+const { refreshTrayProxyMenu } = vi.hoisted(() => ({
+  refreshTrayProxyMenu: vi.fn(async () => {}),
+}))
+
 /**
- * The delay API is the only thing stubbed. What is under test is when the manager announces
- * that a group has settled — the granularity that decides whether a sorted list re-orders
+ * The external delay and tray APIs are stubbed. What is under test is when the manager settles
+ * a group — the granularity that decides whether a sorted list re-orders and the tray refreshes
  * once per test or once per result.
  */
 vi.mock('tauri-plugin-mihomo-api', () => ({
   delayProxyByName: vi.fn(async () => ({ delay: 120 })),
   healthcheckNodeInProvider: vi.fn(async () => ({ delay: 120 })),
 }))
+
+vi.mock('@/services/cmds', () => ({ refreshTrayProxyMenu }))
 
 import type { ResolvedProxyMember } from '@/types/proxy-view'
 
@@ -34,6 +40,7 @@ let unsubscribe: () => void
 
 beforeEach(() => {
   settles = 0
+  refreshTrayProxyMenu.mockClear()
   unsubscribe = delayManager.addGroupListener('g', () => {
     settles += 1
   })
@@ -51,6 +58,7 @@ describe('group settle notifications', () => {
     await nextFrame()
 
     expect(settles).toBe(1)
+    expect(refreshTrayProxyMenu).toHaveBeenCalledTimes(1)
   })
 
   test('a batch settles the group once, however many proxies it covered', async () => {
@@ -63,6 +71,7 @@ describe('group settle notifications', () => {
     await nextFrame()
 
     expect(settles).toBe(1)
+    expect(refreshTrayProxyMenu).toHaveBeenCalledTimes(1)
   })
 
   test('an unsubscribed listener stops being called', async () => {
@@ -100,10 +109,12 @@ describe('group settle notifications', () => {
     await delayManager.checkDelay(node('single') as never, 'g', 5000)
     await nextFrame()
     expect(settles).toBe(0)
+    expect(refreshTrayProxyMenu).not.toHaveBeenCalled()
 
     await batch
     await nextFrame()
     expect(settles).toBe(1)
+    expect(refreshTrayProxyMenu).toHaveBeenCalledTimes(1)
   })
 
   test('unsubscribing one listener leaves the others subscribed', async () => {

--- a/src/services/delay.ts
+++ b/src/services/delay.ts
@@ -4,6 +4,7 @@ import {
   type ProxyDelay,
 } from 'tauri-plugin-mihomo-api'
 
+import { refreshTrayProxyMenu } from '@/services/cmds'
 import {
   memberDetails,
   providerNameOf,
@@ -124,7 +125,7 @@ class DelayManager {
     })
   }
 
-  private queueGroupNotification(group: string) {
+  private settleGroup(group: string) {
     if ((this.activeBatches.get(group) ?? 0) > 0) return
     // Dropped so the next read builds a fresh identity. Only this group's snapshot changes;
     // the set-level map is rebuilt too, but its other entries keep their identities.
@@ -132,6 +133,9 @@ class DelayManager {
     this.groupSetSnapshots.clear()
     this.pendingGroupUpdates.add(group)
     this.scheduleGroupFlush()
+    void refreshTrayProxyMenu().catch((error) => {
+      console.error('[DelayManager] Failed to refresh tray proxy menu', error)
+    })
   }
 
   /**
@@ -308,7 +312,7 @@ class DelayManager {
     timeout: number,
   ): Promise<DelayUpdate> {
     const update = await this.measureDelay(member, group, timeout)
-    this.queueGroupNotification(group)
+    this.settleGroup(group)
     return update
   }
 
@@ -441,7 +445,7 @@ class DelayManager {
         this.activeBatches.set(group, remaining)
       } else {
         this.activeBatches.delete(group)
-        this.queueGroupNotification(group)
+        this.settleGroup(group)
       }
     }
     const totalTime = Date.now() - startTime


### PR DESCRIPTION
## What changed

Refresh the native tray proxy menu when a single or batch delay test settles. The existing coalesced tray refresh command is reused, while its selection call site keeps the old exported name.

## Why

The tray reads proxy latency from Mihomo history only when its native menu is rebuilt. Delay tests updated the history and the GUI cache, but did not invalidate the tray menu, so it could keep showing `-ms` until another action such as switching nodes rebuilt it.

The refresh happens once when each tested group settles, not once per node, to avoid the tray flicker that motivated removing periodic refreshes. Related to #6928; this does not add tray-initiated testing.

## Checks

- `pnpm test` (54 tests)
- `pnpm lint`
- `pnpm format:check`
- `pnpm exec tsc --noEmit`
- macOS arm64 release bundle produced and verified locally (updater artifact signing unavailable without the upstream private key)
