### PR TITLE
chore(renovate): skip typescript 7.0 updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,12 @@
       "description": "Group all GitHub Actions updates into a single PR",
       "matchManagers": ["github-actions"],
       "groupName": "github actions"
+    },
+    {
+      "description": "Skip TypeScript 7.0 series",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7.0.0 || >=7.1.0"
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
- Block #7715 
- Related https://github.com/clash-verge-rev/clash-verge-rev/pull/7704#issuecomment-5232656219 

经本地验证，当前项目使用的 `eslint` 需要调用 TypeScript 编译器对外暴露的特定一组 API 用于实现 Lint Check ，而 TypeScript 7 系列引入了用 Golang 开发的全新原生编译器， `eslint` 必须的 API 由于此 Major Update 引入的 Breaking Changes 无法正常工作。

根据 Microsoft 对于 TypeScript 的计划路线图， `eslint` 依赖的 API 预计在 TypeScript 7.1 中重新提供。故引入 Mend Renovate 设置项以跳过 TypeScript 7.0 系列（当前将保持锁定在 TypeScript 6 ，后续直升 TypeScript 7.1 或更高版本）。