### PR TITLE
chore(renovate): enable supply-chain-attack protection

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,8 @@
     "shared/**"
   ],
   "rangeStrategy": "replace",
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],
@@ -50,6 +52,11 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["typescript"],
       "allowedVersions": "<7.0.0 || >=7.1.0"
+    },
+    {
+      "description": "Prevent project from supply chain attack",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "1 days"
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
## 背景信息

- 参见 [安全和构建默认值 - 破坏性改动 - pnpm 11.0 | pnpm](https://pnpm.io/zh/blog/releases/11.0#%E5%AE%89%E5%85%A8%E5%92%8C%E6%9E%84%E5%BB%BA%E9%BB%98%E8%AE%A4%E5%80%BC)
- 参见 [Suppress branch/PR creation for X days | Configuration Options - Renovate Docs](https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days)
- 参见 [`pnpm-workspace.yaml`](https://github.com/clash-verge-rev/clash-verge-rev/blob/dev/pnpm-workspace.yaml)
- 关联 #7717 

## 概述

自 v11.0 起， `pnpm` 针对潜在的供应链攻击行为做出了破坏性更改，默认 `minimumReleaseAge = 1440` 。所有全新发布的 `npm` 依赖需要至少存活 **1天** 及以上才能通过供应链攻击分析完成 `pnpm install` 。

由于 `renovate.json` 配置项的缺失， Mend Renovate 未遵守此约束，在 `npm` 新版本发布后会立即创建 Pull Request 。在已有 GitHub Workflows 检查出现错误的情况下， Pull Request 仍被意外地合并，导致其他用户无法顺利完成 `pnpm install` 。

本次更改为 `renovate.json` 追加与 `pnpm` 默认配置类似的「门禁」，阻止 Mend Renovate 为尚未满足寿命门禁的依赖创建 Pull Request ，避免因错误的依赖升级破坏项目构建过程。