### PR TITLE
fix(i18n): complete Traditional Chinese backend strings

### DIFF
--- a/crates/clash-verge-i18n/locales/zhtw.yml
+++ b/crates/clash-verge-i18n/locales/zhtw.yml
@@ -8,12 +8,12 @@ notifications:
     body: 已切換至 {mode}。
   systemProxyToggled:
     title: 系統代理
-    'on': System proxy has been enabled.
-    'off': System proxy has been disabled.
+    'on': 系統代理已啟用。
+    'off': 系統代理已關閉。
   tunModeToggled:
     title: 虛擬網路介面卡模式
-    'on': TUN mode has been enabled.
-    'off': TUN mode has been disabled.
+    'on': 虛擬網路介面卡模式已啟用。
+    'off': 虛擬網路介面卡模式已關閉。
   lightweightModeEntered:
     title: 輕量模式
     body: 已進入輕量模式。
@@ -27,13 +27,13 @@ notifications:
     title: 應用已隱藏
     body: Clash Verge 正在背景執行。
   updateReady:
-    title: Clash Verge Update
-    body: A new version (v{version}) has been downloaded and is ready to install.
-    installNow: Install Now
-    later: Later
+    title: Clash Verge 更新
+    body: 新版本（v{version}）已下載完成，是否立即安裝？
+    installNow: 立即安裝
+    later: 稍後
 service:
   adminInstallPrompt: 安裝 Clash Verge 服務需要管理員權限
-  adminUninstallPrompt: 卸载 Clash Verge 服務需要管理員權限
+  adminUninstallPrompt: 解除安裝 Clash Verge 服務需要管理員權限
 launchGuard:
   currentExeError: 無法判斷應用程式位置：{error}
   homeDirError: 無法判斷目前使用者的個人目錄，應用程式將結束：{error}


### PR DESCRIPTION
## Summary

- translate the remaining English backend notifications in the Traditional Chinese locale
- align system proxy, TUN mode, update, and service uninstall wording with the existing zh-TW frontend
- preserve all locale keys and placeholders

## Verification

- node scripts/cleanup-unused-i18n.mjs --align
- YAML parsing for all backend locale files
- en/zhtw key parity and placeholder parity
- git diff --check

The i18n audit reports only the existing English-baseline service.legacy missing-source entry; zhtw has no missing, extra, unused, or missing-source entries.

A desktop runtime preview was not run because the Rust toolchain is unavailable in this environment.