### PR TITLE
fix(core): avoid false mixed-port fallback after quickly relaunching Clash

### DIFF
--- a/src-tauri/src/core/listener.rs
+++ b/src-tauri/src/core/listener.rs
@@ -1,4 +1,6 @@
 use anyhow::{Context as _, Result, anyhow, bail};
+#[cfg(target_os = "macos")]
+use network_interface::{NetworkInterface, NetworkInterfaceConfig as _};
 use serde::{Deserialize, Serialize};
 use serde_yaml_ng::{Mapping, Value};
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
@@ -335,7 +337,7 @@ fn probe_claims(claims: &[BindClaim]) -> ListenerProbeOutcome {
     let mut sockets = Vec::with_capacity(claims.len());
     for claim in claims {
         match bind_claim(claim) {
-            Ok(socket) => sockets.push(socket),
+            Ok(mut bound) => sockets.append(&mut bound),
             Err(error) if is_bind_conflict(&error) => return conflict_outcome(claim),
             Err(error)
                 if matches!(
@@ -366,11 +368,65 @@ fn probe_claims(claims: &[BindClaim]) -> ListenerProbeOutcome {
             }
         }
     }
-    debug_assert_eq!(sockets.len(), claims.len());
+    debug_assert!(sockets.len() >= claims.len());
     ListenerProbeOutcome::Available
 }
 
-fn bind_claim(claim: &BindClaim) -> io::Result<Socket> {
+fn bind_claim(claim: &BindClaim) -> io::Result<Vec<Socket>> {
+    let mut sockets = Vec::new();
+    #[cfg(target_os = "macos")]
+    if claim.transport == ListenerTransport::Tcp {
+        // Darwin permits live wildcard and specific listeners to coexist with SO_REUSEADDR.
+        // Hold every overlapping form while probing so they still report a conflict.
+        let mut guard_addresses = if claim.address.is_unspecified() {
+            NetworkInterface::show()
+                .unwrap_or_default()
+                .into_iter()
+                .flat_map(|interface| interface.addr)
+                .map(|address| address.ip())
+                .filter(|candidate| {
+                    candidate.is_ipv4() == claim.address.is_ipv4()
+                        && match candidate {
+                            IpAddr::V4(address) => !address.is_unspecified(),
+                            IpAddr::V6(address) => !address.is_unspecified() && !address.is_unicast_link_local(),
+                        }
+                })
+                .collect::<Vec<_>>()
+        } else {
+            vec![if claim.address.is_ipv4() {
+                IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+            } else {
+                IpAddr::V6(Ipv6Addr::UNSPECIFIED)
+            }]
+        };
+        if claim.address.is_unspecified() {
+            guard_addresses.push(if claim.address.is_ipv4() {
+                IpAddr::V4(Ipv4Addr::LOCALHOST)
+            } else {
+                IpAddr::V6(Ipv6Addr::LOCALHOST)
+            });
+        }
+        guard_addresses.sort_unstable();
+        guard_addresses.dedup();
+        for address in guard_addresses {
+            sockets.push(bind_socket(&BindClaim::new(
+                claim.name,
+                address,
+                claim.port,
+                claim.transport,
+            ))?);
+        }
+    }
+
+    let socket = bind_socket(claim)?;
+    if claim.transport == ListenerTransport::Tcp {
+        socket.listen(1)?;
+    }
+    sockets.push(socket);
+    Ok(sockets)
+}
+
+fn bind_socket(claim: &BindClaim) -> io::Result<Socket> {
     let domain = if claim.address.is_ipv4() {
         Domain::IPV4
     } else {
@@ -385,20 +441,13 @@ fn bind_claim(claim: &BindClaim) -> io::Result<Socket> {
         socket.set_only_v6(true)?;
     }
     // Unix can retain closed TCP connections after the previous listener exits.
-    // Ignore that transient state without allowing concurrent listeners.
-    // SO_REUSEPORT is intentionally never enabled; Windows stays exclusive below.
-    socket.set_reuse_address(reuse_address_for_probe(claim.transport))?;
+    // Ignore that transient state. SO_REUSEPORT is intentionally never enabled;
+    // Windows stays exclusive below, and macOS guards overlapping address forms above.
+    socket.set_reuse_address(cfg!(unix) && matches!(claim.transport, ListenerTransport::Tcp))?;
     #[cfg(windows)]
     set_exclusive_address_use(&socket)?;
     socket.bind(&SockAddr::from(claim.socket_addr()))?;
-    if claim.transport == ListenerTransport::Tcp {
-        socket.listen(1)?;
-    }
     Ok(socket)
-}
-
-const fn reuse_address_for_probe(transport: ListenerTransport) -> bool {
-    cfg!(unix) && matches!(transport, ListenerTransport::Tcp)
 }
 
 fn is_bind_conflict(error: &io::Error) -> bool {
@@ -464,7 +513,14 @@ mod tests {
     };
     use serde_json::json;
     use serde_yaml_ng::Mapping;
+    #[cfg(unix)]
+    use socket2::{Domain, Protocol, SockAddr, Socket, Type};
     use std::net::{Ipv4Addr, TcpListener, UdpSocket};
+    #[cfg(unix)]
+    use std::{
+        io::Read as _,
+        net::{Shutdown, SocketAddrV4, TcpStream},
+    };
 
     fn mapping(yaml: &str) -> anyhow::Result<Mapping> {
         Ok(serde_yaml_ng::from_str(yaml)?)
@@ -484,6 +540,55 @@ mod tests {
                 port,
                 transport: ListenerTransport::Tcp
             }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn probe_reports_wildcard_tcp_listener_conflicts_for_specific_address() -> anyhow::Result<()> {
+        let listener = TcpListener::bind((Ipv4Addr::UNSPECIFIED, 0))?;
+        let port = listener.local_addr()?.port();
+        let outcome = probe_listener(&ListenerProbe {
+            address: format!("127.0.0.1:{port}"),
+            transports: vec![ListenerTransport::Tcp],
+        });
+        assert_eq!(
+            outcome,
+            ListenerProbeOutcome::Conflict {
+                port,
+                transport: ListenerTransport::Tcp
+            }
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn probe_reuses_port_held_only_by_a_stale_tcp_connection() -> anyhow::Result<()> {
+        let listener = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
+        listener.set_reuse_address(true)?;
+        listener.bind(&SockAddr::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)))?;
+        listener.listen(1)?;
+        let port = listener
+            .local_addr()?
+            .as_socket()
+            .ok_or_else(|| anyhow::anyhow!("TCP listener did not expose an IP socket address"))?
+            .port();
+
+        let mut client = TcpStream::connect((Ipv4Addr::LOCALHOST, port))?;
+        let (connection, _) = listener.accept()?;
+        drop(listener);
+        connection.shutdown(Shutdown::Write)?;
+        let mut eof = [0u8; 1];
+        assert_eq!(client.read(&mut eof)?, 0);
+        drop(connection);
+
+        assert_eq!(
+            probe_listener(&ListenerProbe {
+                address: format!("127.0.0.1:{port}"),
+                transports: vec![ListenerTransport::Tcp],
+            }),
+            ListenerProbeOutcome::Available
         );
         Ok(())
     }

--- a/src-tauri/src/core/listener.rs
+++ b/src-tauri/src/core/listener.rs
@@ -384,7 +384,10 @@ fn bind_claim(claim: &BindClaim) -> io::Result<Socket> {
     if claim.address.is_ipv6() {
         socket.set_only_v6(true)?;
     }
-    socket.set_reuse_address(false)?;
+    // Unix can retain closed TCP connections after the previous listener exits.
+    // Ignore that transient state without allowing concurrent listeners.
+    // SO_REUSEPORT is intentionally never enabled; Windows stays exclusive below.
+    socket.set_reuse_address(reuse_address_for_probe(claim.transport))?;
     #[cfg(windows)]
     set_exclusive_address_use(&socket)?;
     socket.bind(&SockAddr::from(claim.socket_addr()))?;
@@ -392,6 +395,10 @@ fn bind_claim(claim: &BindClaim) -> io::Result<Socket> {
         socket.listen(1)?;
     }
     Ok(socket)
+}
+
+const fn reuse_address_for_probe(transport: ListenerTransport) -> bool {
+    cfg!(unix) && matches!(transport, ListenerTransport::Tcp)
 }
 
 fn is_bind_conflict(error: &io::Error) -> bool {


### PR DESCRIPTION
## Why

When Clash is closed, its listening socket is released, but established TCP connections may remain in kernel states such as `FIN_WAIT_2` or `TIME_WAIT`. Their lifetime depends on the peer and the operating system timers, so a graceful shutdown cannot guarantee immediate port reuse.

The mixed-port probe used stricter bind semantics than a new Unix TCP listener. When Clash was closed and quickly launched again, a stale TCP state could make the probe report a false conflict, causing the existing fallback to select and persist the next port. Repeated close-and-relaunch cycles reproduced this behavior and eventually moved the proxy to port 7903.

Waiting for a graceful Clash shutdown alone is not a reliable fix: the application cannot force the peer to finish the TCP shutdown or make the kernel discard these states immediately.

## What changed

- Unix TCP probes set `SO_REUSEADDR` before the existing `bind + listen` check.
- `SO_REUSEPORT` is not enabled.
- Windows TCP probes keep `SO_REUSEADDR` disabled and use `SO_EXCLUSIVEADDRUSE`.
- UDP probes keep address reuse disabled on every platform.

## Safety model

- A live TCP listener still owns the address. Without `SO_REUSEPORT`, the probe still performs `bind + listen` and fails with `EADDRINUSE` or `WSAEADDRINUSE`, so genuine conflicts continue to use the existing fallback.
- Old connections are not transferred to the new Mihomo process. They remain independent kernel connection states and close or time out separately; the new listener accepts only new connection attempts.
- Windows keeps exclusive binding because its `SO_REUSEADDR` semantics differ from Unix. UDP probing remains non-reusable because UDP has no TCP-style shutdown states to recover from.

## Verification

Before (Mac M5 Air): closing Clash and quickly launching it again repeatedly caused the core port to increment automatically.
<img width="1280" height="736" alt="image" src="https://github.com/user-attachments/assets/3542af87-b640-4c8b-9bde-dc7574a7cde9" />
After (Mac M5 Air): closing Clash and quickly launching it again repeatedly kept the configured core port unchanged.
<img width="1280" height="736" alt="image" src="https://github.com/user-attachments/assets/7b7b263f-1970-4767-8df7-8912f8956c6f" />

| Environment | Original probe | Modified probe | Safety boundary |
| --- | --- | --- | --- |
| Ubuntu 24.04.4 / Linux 6.8 KVM | `FIN_WAIT_2` present; failed with errno 98 | Reused the configured port with `bind + listen` | Live TCP and occupied UDP remained unavailable |
| Mac M5 Air | Closing and quickly relaunching Clash repeatedly incremented the core port | Closing and quickly relaunching Clash repeatedly kept the configured port | New proxy connections worked normally |
| Windows | Closing and quickly relaunching Clash did not reproduce the port-increment bug | Not applicable | No issue observed in the test |

The screenshots in the test record show the user-visible Mac M5 Air symptom before and after the patch. Local Ubuntu KVM socket checks verify the port-ownership boundary: stale TCP state can be reused, but active TCP listeners and occupied UDP ports remain unavailable.

The following repository checks passed locally:

- `cargo fmt --check`
- `cargo clippy-all`

## Scope

The production commit only changes `src-tauri/src/core/listener.rs`. It does not change mixed-port fallback or persistence, core shutdown behavior, UDP behavior, or proxy traffic handling.
