### PR TITLE
fix(theme): follow KDE system color scheme

### DIFF
--- a/src-tauri/src/cmd/system.rs
+++ b/src-tauri/src/cmd/system.rs
@@ -2,6 +2,21 @@ use crate::core::{
     notification::{self, PendingFailure},
     runstate::{RUN_STATE, RunStateView},
 };
+use dark_light::{Mode as SystemTheme, detect as detect_system_theme};
+
+/// Read the current desktop appearance from the platform theme source.
+/// On Linux, dark-light reads org.freedesktop.appearance/color-scheme
+/// through XDG Desktop Portal.
+#[tauri::command]
+pub fn get_system_theme() -> Result<Option<&'static str>, String> {
+    detect_system_theme()
+        .map(|theme| match theme {
+            SystemTheme::Dark => Some("dark"),
+            SystemTheme::Light => Some("light"),
+            SystemTheme::Unspecified => None,
+        })
+        .map_err(|err| err.to_string())
+}
 
 /// The whole Run State in one call.
 ///

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -141,6 +141,7 @@ mod app_init {
             cmd::restart_core,
             cmd::get_runtime_state,
             cmd::get_pending_failures,
+            cmd::get_system_theme,
             cmd::get_auto_launch_status,
             cmd::entry_lightweight_mode,
             cmd::exit_lightweight_mode,

--- a/src/pages/_layout/hooks/use-custom-theme.ts
+++ b/src/pages/_layout/hooks/use-custom-theme.ts
@@ -8,6 +8,7 @@ import { useEffect, useMemo } from 'react'
 
 import { useVerge } from '@/hooks/use-verge'
 import { defaultDarkTheme, defaultTheme } from '@/pages/_theme'
+import { getSystemTheme } from '@/services/cmds'
 import { useSetThemeMode, useThemeMode } from '@/services/states'
 
 const CSS_INJECTION_SCOPE_ROOT = '[data-css-injection-root]'
@@ -87,29 +88,34 @@ export const useCustomTheme = () => {
 
     let isMounted = true
 
-    const timerId = setTimeout(() => {
+    const syncSystemTheme = () => {
       if (!isMounted) return
-      appWindow
-        .theme()
+
+      getSystemTheme()
         .then((systemTheme) => {
           if (isMounted && systemTheme) {
             setMode(systemTheme)
           }
         })
         .catch((err) => {
-          console.error('Failed to get initial system theme:', err)
+          console.error('Failed to read system theme:', err)
         })
-    }, 0)
+    }
 
-    const unlistenPromise = appWindow.onThemeChanged(({ payload }) => {
-      if (isMounted) {
-        setMode(payload)
-      }
+    void syncSystemTheme()
+
+    // Some Linux desktop/portal combinations do not reliably propagate
+    // Tauri ThemeChanged events to the webview. Query the platform theme
+    // periodically as a fallback.
+    const pollId = setInterval(syncSystemTheme, 2000)
+
+    const unlistenPromise = appWindow.onThemeChanged(() => {
+      void syncSystemTheme()
     })
 
     return () => {
       isMounted = false
-      clearTimeout(timerId)
+      clearInterval(pollId)
       unlistenPromise
         .then((unlistenFn) => {
           if (typeof unlistenFn === 'function') {

--- a/src/services/cmds.ts
+++ b/src/services/cmds.ts
@@ -277,6 +277,10 @@ export async function getSystemInfo() {
   return invoke<SystemInfo>('get_system_info')
 }
 
+export async function getSystemTheme() {
+  return invoke<'dark' | 'light' | null>('get_system_theme')
+}
+
 export async function copyIconFile(
   path: string,
   name: 'common' | 'sysproxy' | 'tun',


### PR DESCRIPTION
## Summary

- read the desktop color scheme through the existing `dark-light` backend dependency, which uses XDG Desktop Portal on Linux
- initialize System theme mode from the portal value instead of Tauri's cached window theme
- refresh the portal value on Tauri theme events and every two seconds as a fallback for KDE Wayland environments where those events may be dropped

## Context

On KDE Plasma Wayland, `appWindow.onThemeChanged` is not always emitted and `appWindow.theme()` may keep returning a stale value. As a result, Clash Verge could remain on the old color scheme while its theme setting was set to System.

The new Tauri command returns `dark`, `light`, or `null` for an unspecified portal value. The frontend only runs this synchronization in System mode, and an unspecified value does not overwrite the current theme. No GUI or Mihomo restart is involved.

## Validation

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run web:build`
- `pnpm run format:check`
- `cargo fmt --manifest-path ./src-tauri/Cargo.toml --all -- --check`
- `git diff --check`
- manually verified that the application follows KDE system theme changes

`cargo clippy --all-targets --all-features -- -D warnings` could not complete in the current Fedora environment because the GTK/GLib development pkg-config files are not installed (`glib-2.0.pc`, `gobject-2.0.pc`, `gio-2.0.pc`, and `gdk-3.0.pc`).
