### PR TITLE
fix(windows): unbounded memory growth after render process termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "smartstring",
+ "sysinfo",
  "sysproxy",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -141,6 +141,9 @@ deelevate = { workspace = true }
 runas = "=1.2.0"
 winreg = "0.56.0"
 windows = { version = "0.62.2", features = ["Win32_Globalization"] }
+# 渲染进程存活探测需要按 --type=renderer 识别 WebView2 子进程, 用到 cmd()/parent()。
+# 已在依赖树中(经 tauri 等传递引入), 此处仅显式声明以便直接使用。
+sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2.5.1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -459,8 +459,11 @@ pub fn run() {
                 event_handlers::handle_window_close(&event);
             }
             tauri::WindowEvent::Focused(focused) => {
-                // 兜底：原生取消最小化只触发 Focused、不走 activate_window（macOS）
-                #[cfg(target_os = "macos")]
+                // 兜底：原生取消最小化只触发 Focused、不走 activate_window。
+                // macOS 与 Windows 都有这条路径——Windows 上从任务栏恢复最小化时，
+                // 应用自己的 activate_window 不会被调用，待重载标记没人取走，
+                // 页面会一直停在渲染进程死亡时的空白状态。
+                #[cfg(any(target_os = "macos", windows))]
                 if focused {
                     crate::utils::resolve::window::reload_main_window_if_needed();
                 }

--- a/src-tauri/src/utils/resolve/mod.rs
+++ b/src-tauri/src/utils/resolve/mod.rs
@@ -54,6 +54,14 @@ pub fn resolve_setup_async() {
         init_startup_script().await;
         let config_initialized = init_verge_config_before_window().await;
         init_window().await;
+
+        // Windows：渲染进程存活探测。
+        // macOS 走 wry 的 on_web_content_process_terminate 回调（见 lib.rs），
+        // 但该回调属于 wry 的 WebViewBuilderExtDarwin，Windows 上不存在等价项，
+        // 因此改由存活探测触发同一套恢复逻辑。窗口建好后再启动。
+        #[cfg(windows)]
+        window::start_renderer_liveness_watchdog();
+
         init_resources().await;
         if let Err(e) = init::init_dns_config().await {
             logging!(warn, Type::Setup, "DNS config initialization failed: {}", e);

--- a/src-tauri/src/utils/resolve/window.rs
+++ b/src-tauri/src/utils/resolve/window.rs
@@ -4,10 +4,8 @@ use tauri::webview::PageLoadEvent;
 use tauri::{Theme, WebviewWindow};
 
 use crate::{config::Config, core::handle, utils::resolve::window_script::build_window_initial_script};
-use clash_verge_logging::{Type, logging_error};
-// logging 仅在 macOS 的渲染进程恢复逻辑中使用
-#[cfg(target_os = "macos")]
 use clash_verge_logging::logging;
+use clash_verge_logging::{Type, logging_error};
 
 const DARK_BACKGROUND_COLOR: Color = Color(46, 48, 61, 255); // #2E303D
 const LIGHT_BACKGROUND_COLOR: Color = Color(245, 245, 245, 255); // #F5F5F5
@@ -113,7 +111,6 @@ pub async fn build_new_window() -> Result<WebviewWindow, String> {
             logging_error!(Type::Window, window.set_background_color(Some(background_color)));
             restore_default_size_if_needed(&window);
             // 全新窗口的页面即为最新状态，丢弃旧窗口遗留的待重载标记，避免多余 reload
-            #[cfg(target_os = "macos")]
             take_webview_needs_reload();
             Ok(window)
         }
@@ -121,19 +118,213 @@ pub async fn build_new_window() -> Result<WebviewWindow, String> {
     }
 }
 
-/// 渲染进程死亡、页面待重载标记（macOS）
+/// 渲染进程死亡、页面待重载标记
 ///
-/// 渲染进程在窗口不可见时被系统终止后置位，由下次激活窗口的路径取走并执行 reload。
-#[cfg(target_os = "macos")]
+/// 渲染进程在窗口不可见时被终止后置位，由下次激活窗口的路径取走并执行 reload。
+///
+/// 注：本标记与下方的恢复逻辑原本仅在 macOS 编译。Windows 上 WebView2 的渲染进程
+/// 同样会在内存压力下被系统终止，且症状完全一致（白屏 + 孤儿 WS 订阅持续向
+/// `ChannelDataIpcQueue` 写入导致主进程内存无限增长），故解除平台限制。
 static WEBVIEW_NEEDS_RELOAD: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// 取出并清除"页面待重载"标记
 ///
 /// # Returns
-/// * `bool` - 渲染进程是否曾在窗口不可见时被系统终止、页面需要 reload
-#[cfg(target_os = "macos")]
+/// * `bool` - 渲染进程是否曾在窗口不可见时被终止、页面需要 reload
 pub fn take_webview_needs_reload() -> bool {
     WEBVIEW_NEEDS_RELOAD.swap(false, std::sync::atomic::Ordering::SeqCst)
+}
+
+/// 重新置位"页面待重载"标记
+///
+/// 取走标记之后 reload 失败时必须调用，否则待重载状态就此丢失、后续激活不再重试。
+///
+/// 实测（Windows）：渲染进程在窗口不可见时死亡后，`reload()` 会返回
+/// `runtime error: failed to send message to the webview`（`show()` / `set_focus()`
+/// 同样失败）。此时若不还原标记，页面会永久停在空白状态直到应用重启。
+pub fn mark_webview_needs_reload() {
+    WEBVIEW_NEEDS_RELOAD.store(true, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// 渲染进程死亡后的公共恢复动作：清理孤儿 WS 订阅，必要时置位待重载标记。
+///
+/// 拆出来是因为触发源分平台：macOS 由 wry 的 `on_web_content_process_terminate`
+/// 回调触发；Windows 无该回调（wry 中它属于 `WebViewBuilderExtDarwin`），改由
+/// `start_renderer_liveness_watchdog` 的存活探测触发。**恢复动作本身平台无关。**
+///
+/// # Arguments
+/// * `reload_now` - 窗口当前是否可见。可见则立即 reload 恢复页面；不可见则只置标记，
+///   等用户下次打开窗口时再 reload（系统正是因内存压力才杀掉不可见窗口的渲染进程，
+///   立即重建既浪费内存也可能形成"系统杀→拉起→再杀"的循环）
+/// * `reload` - reload 用的回调，在 WS 清理完成之后执行
+fn recover_from_render_process_death<F>(reload_now: bool, reload: F)
+where
+    F: FnOnce() + Send + 'static,
+{
+    if !reload_now {
+        WEBVIEW_NEEDS_RELOAD.store(true, std::sync::atomic::Ordering::SeqCst);
+        logging!(info, Type::Window, "窗口不可见，页面将在下次打开窗口时重载");
+    }
+
+    // 清理全部 Mihomo WS 订阅，阻断 ChannelDataIpcQueue 泄漏（托盘速率任务约 1s 后自重连）。
+    // reload 必须与清理同任务、排在其后，否则清理可能误清重载后新页面的订阅（竞态）。
+    crate::process::AsyncHandler::spawn(move || async move {
+        if let Err(err) = handle::Handle::mihomo().await.clear_all_ws_connections().await {
+            logging!(warn, Type::Window, "清理 Mihomo WebSocket 连接失败: {err}");
+        } else {
+            logging!(info, Type::Window, "已清理全部 Mihomo WebSocket 连接");
+        }
+        if reload_now {
+            reload();
+        }
+    });
+}
+
+/// Windows：渲染进程存活探测（wry 在 Windows 上没有 `on_web_content_process_terminate`）
+///
+/// wry 的 `with_on_web_content_process_terminate_handler` 定义在
+/// `#[cfg(any(target_os = "macos", target_os = "ios"))] pub trait WebViewBuilderExtDarwin`，
+/// `WebViewBuilderExtWindows` 中没有等价项，因此 Windows 无法注册该回调。
+///
+/// 判据：本进程名下是否还存在 `--type=renderer` 的 WebView2 子进程。
+///
+/// 渲染进程被终止后，`msedgewebview2.exe` 的 browser / gpu-process / utility /
+/// crashpad-handler 兄弟进程都还在，唯独少了 renderer，且 **WebView2 不会重建它**。
+///
+/// 为什么不用 IPC 探测：曾尝试以 `window.eval("void 0")` 是否成功作为判据，
+/// 依据是渲染进程死亡后 `show()` / `set_focus()` 会返回
+/// `runtime error: failed to send message to the webview`。实测该推断不成立——
+/// 渲染进程已死时窗口操作仍可能成功（日志中出现过 `窗口激活成功`），
+/// `eval` 同样不失败，探测永远不会触发。
+///
+/// 为什么不用 WebView2 的 `ICoreWebView2::add_ProcessFailed`：那是语义最准确的方案，
+/// 但需要引入 `webview2-com` 直接依赖并与 wry 的版本保持一致；本判据无新增依赖，
+/// 且实测可靠。若 wry 日后在 `WebViewBuilderExtWindows` 补上等价回调，应改用回调。
+#[cfg(windows)]
+fn renderer_process_count() -> Option<usize> {
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
+
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing().with_cmd(sysinfo::UpdateKind::Always),
+    );
+
+    let self_pid = sysinfo::Pid::from_u32(std::process::id());
+    let mut renderers = 0usize;
+    let mut any_webview_child = false;
+    // 是否至少读到过一个非空命令行。若一个都读不到（权限/平台差异），
+    // renderers 会恒为 0 而看起来像"渲染进程死了"——那是仪器问题，不是故障事实。
+    let mut any_cmd_readable = false;
+
+    for proc_ in sys.processes().values() {
+        if !proc_
+            .name()
+            .to_string_lossy()
+            .eq_ignore_ascii_case("msedgewebview2.exe")
+        {
+            continue;
+        }
+        // 沿父链确认属于本进程（WebView2 子进程可能挂在 browser 进程下，非直接子进程）
+        let mut cur = proc_.parent();
+        let mut is_ours = false;
+        for _ in 0..12 {
+            let Some(p) = cur else { break };
+            if p == self_pid {
+                is_ours = true;
+                break;
+            }
+            cur = sys.process(p).and_then(|x| x.parent());
+        }
+        if !is_ours {
+            continue;
+        }
+        any_webview_child = true;
+        let cmd = proc_.cmd();
+        if !cmd.is_empty() {
+            any_cmd_readable = true;
+        }
+        if cmd.iter().any(|a| a.to_string_lossy().contains("--type=renderer")) {
+            renderers += 1;
+        }
+    }
+
+    // ⛔「没量到」不能当成「渲染进程死了」——两种都返回 None 让上层不动作：
+    //   1. 一个 WebView2 子进程都找不到：更像是没枚举到（真实的渲染进程死亡会留下
+    //      browser / gpu-process / utility / crashpad-handler 兄弟进程）
+    //   2. 找到了子进程却一个命令行都读不到：判据依赖命令行里的 --type=renderer，
+    //      读不到时 renderers 恒为 0，会伪装成"渲染进程已死"并每轮误触发恢复。
+    //      这比不触发更糟，故必须显式区分。
+    if !any_webview_child || !any_cmd_readable {
+        return None;
+    }
+    Some(renderers)
+}
+
+/// Windows：渲染进程存活探测（wry 在 Windows 上没有 `on_web_content_process_terminate`）
+///
+/// wry 的 `with_on_web_content_process_terminate_handler` 定义在
+/// `#[cfg(any(target_os = "macos", target_os = "ios"))] pub trait WebViewBuilderExtDarwin`，
+/// `WebViewBuilderExtWindows` 中没有等价项，因此 Windows 无法注册该回调。
+/// 改由周期性检查渲染进程是否存在来触发同一套恢复逻辑，判据见 `renderer_process_count`。
+///
+/// 连续两次判定为 0 才动作，避开窗口重建等瞬时状态。
+#[cfg(windows)]
+pub fn start_renderer_liveness_watchdog() {
+    use std::time::Duration;
+
+    const PROBE_INTERVAL: Duration = Duration::from_secs(10);
+    /// 连续多少次测到 0 才判定渲染进程已死。1 次会在窗口重建的瞬间误判。
+    const REQUIRED_CONSECUTIVE_FAILURES: u32 = 2;
+
+    crate::process::AsyncHandler::spawn(|| async move {
+        let mut consecutive_failures: u32 = 0;
+        // 已恢复过、且此后一直没再见到活的渲染进程。
+        // 窗口不可见时渲染进程不会被拉起（这正是上游的设计：等用户下次打开再 reload），
+        // 若不上闩，本循环会每 20s 重复清一次 WS，把托盘速率订阅也一并反复掐断。
+        let mut recovered_awaiting_renderer = false;
+        loop {
+            tokio::time::sleep(PROBE_INTERVAL).await;
+            if handle::Handle::global().is_exiting() {
+                break;
+            }
+            let Some(window) = crate::utils::window_manager::WindowManager::get_main_window() else {
+                consecutive_failures = 0;
+                continue;
+            };
+            // None = 没枚举到，不是故障事实，不推进计数
+            match renderer_process_count() {
+                None => continue,
+                Some(n) if n >= 1 => {
+                    consecutive_failures = 0;
+                    recovered_awaiting_renderer = false; // 渲染进程回来了，重新布防
+                    continue;
+                }
+                Some(_) => {}
+            }
+            if recovered_awaiting_renderer {
+                continue;
+            }
+            consecutive_failures += 1;
+            if consecutive_failures < REQUIRED_CONSECUTIVE_FAILURES {
+                continue;
+            }
+            consecutive_failures = 0;
+            recovered_awaiting_renderer = true;
+
+            logging!(
+                warn,
+                Type::Window,
+                "WebView 渲染进程已终止（连续两次未检测到 renderer 子进程），开始恢复"
+            );
+            let is_user_visible = window.is_visible().unwrap_or(false) && !window.is_minimized().unwrap_or(false);
+            let reload_target = window.clone();
+            recover_from_render_process_death(is_user_visible, move || {
+                logging_error!(Type::Window, reload_target.reload());
+            });
+        }
+    });
 }
 
 /// WebView 渲染进程被系统终止后的恢复处理（macOS）
@@ -175,41 +366,28 @@ pub fn on_web_content_process_terminated(webview: &tauri::Webview) {
     let is_main_window = webview.label() == "main";
     let reload_now = is_user_visible || !is_main_window;
 
-    if !reload_now {
-        // 主窗口不可见：置标记，延迟到下次 activate_window / reload_main_window_if_needed 再 reload
-        WEBVIEW_NEEDS_RELOAD.store(true, std::sync::atomic::Ordering::SeqCst);
-        logging!(info, Type::Window, "窗口不可见，页面将在下次打开窗口时重载");
-    }
-
-    // 清理全部 Mihomo WS 订阅，阻断 ChannelDataIpcQueue 泄漏（托盘速率任务约 1s 后自重连）。
-    // reload 必须与清理同任务、排在其后，否则清理可能误清重载后新页面的订阅（竞态）。
     let webview = webview.clone();
-    crate::process::AsyncHandler::spawn(move || async move {
-        if let Err(err) = handle::Handle::mihomo().await.clear_all_ws_connections().await {
-            logging!(warn, Type::Window, "清理 Mihomo WebSocket 连接失败: {err}");
-        } else {
-            logging!(info, Type::Window, "已清理全部 Mihomo WebSocket 连接");
-        }
-        if reload_now {
-            logging_error!(Type::Window, webview.reload());
-        }
+    recover_from_render_process_death(reload_now, move || {
+        logging_error!(Type::Window, webview.reload());
     });
 }
 
-/// 消费待重载标记并 reload 主窗口（macOS）。
+/// 消费待重载标记并 reload 主窗口。
 /// 兜底原生取消最小化（Dock 缩略图/调度中心/窗口菜单）只触发 Focused(true)、不走
 /// activate_window 的情况。与 activate_window 共用 swap 标记，先取先得、不重复 reload。
-#[cfg(target_os = "macos")]
 pub fn reload_main_window_if_needed() {
     if !take_webview_needs_reload() {
         return;
     }
     let Some(window) = crate::utils::window_manager::WindowManager::get_main_window() else {
+        // 拿不到窗口不是"已重载"，标记要还回去
+        mark_webview_needs_reload();
         return;
     };
     logging!(info, Type::Window, "渲染进程曾被系统终止，窗口聚焦后重载页面");
     if let Err(e) = window.reload() {
-        logging!(warn, Type::Window, "重载页面失败: {e}");
+        logging!(warn, Type::Window, "重载页面失败，保留待重载标记以便下次重试: {e}");
+        mark_webview_needs_reload();
     }
 }
 

--- a/src-tauri/src/utils/window_manager.rs
+++ b/src-tauri/src/utils/window_manager.rs
@@ -230,12 +230,16 @@ impl WindowManager {
         // 内容就绪再显示，避免白屏闪烁。reload 成功才 defer，失败则走下方直接显示。
         #[allow(unused_mut)]
         let mut defer_show_to_page_load = false;
-        #[cfg(target_os = "macos")]
         if crate::utils::resolve::window::take_webview_needs_reload() {
             logging!(info, Type::Window, "渲染进程曾被系统终止，激活窗口前重载页面");
             match window.reload() {
                 Ok(()) => defer_show_to_page_load = true,
-                Err(e) => logging!(warn, Type::Window, "重载页面失败，退回直接显示: {}", e),
+                Err(e) => {
+                    // 标记已被 take 走，reload 又失败——不还回去的话待重载状态就此丢失，
+                    // 后续再激活也不会重试，页面会一直空白到应用重启。
+                    logging!(warn, Type::Window, "重载页面失败，保留待重载标记并退回直接显示: {}", e);
+                    crate::utils::resolve::window::mark_webview_needs_reload();
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #7760

## Problem

On Windows, once the WebView2 render process is terminated, the private memory of
`clash-verge.exe` grows without bound until the process is OOM-killed or the user
restarts it. Measured at 5–28 MB/min, which reaches tens of GB in a day.

The key point is that **WebView2 does not recreate the renderer**. The
`msedgewebview2.exe` siblings (browser / gpu-process / utility / crashpad-handler)
are all still there — only the renderer is gone.

As a result the frontend JS state is lost, `ws_disconnect` is never called, and the
orphaned Mihomo WS subscriptions keep pushing full `/connections` snapshots (well
over 1 KB) into tauri's `ChannelDataIpcQueue`. **With no live page consuming them,
the queue grows in ~16 MB chunks forever.**

The rate is proportional to the number of active connections (measured at roughly
`active_connections × 450 bytes/sec`), so heavy users are hit hardest.

## Why macOS is not affected

#7410 already fixed this, but the whole path sits behind 7
`#[cfg(target_os = "macos")]` sites (6 in `resolve/window.rs`, 1 in
`window_manager.rs`):

```rust
// resolve/window.rs
#[cfg(target_os = "macos")] use clash_verge_logging::logging;
#[cfg(target_os = "macos")] static WEBVIEW_NEEDS_RELOAD: AtomicBool = ...;
#[cfg(target_os = "macos")] pub fn take_webview_needs_reload() -> bool { ... }
#[cfg(target_os = "macos")] pub fn on_web_content_process_terminated(...) { ... }
#[cfg(target_os = "macos")] pub fn reload_main_window_if_needed() { ... }
#[cfg(target_os = "macos")] take_webview_needs_reload();   // inside build_new_window

// window_manager.rs::activate_window
#[cfg(target_os = "macos")]
if crate::utils::resolve::window::take_webview_needs_reload() { ... }
```

The `WindowEvent::Focused` fallback in `lib.rs` is macOS-only as well.

**The recovery action itself — clearing orphaned WS subscriptions and reloading the
page when needed — is platform independent.** What is genuinely macOS-only is the
*trigger*: wry's callback is declared as

```rust
#[cfg(any(target_os = "macos", target_os = "ios"))]
pub trait WebViewBuilderExtDarwin { ... }
```

and `WebViewBuilderExtWindows` has no equivalent, so Windows cannot register it.

## What this PR does

1. **Un-gates the recovery logic**, extracting the shared action into
   `recover_from_render_process_death()` so the macOS callback and the Windows probe
   drive the same code path. `on_web_content_process_terminated` (the macOS callback
   entry point) stays macOS-only.
2. **Adds a liveness probe on Windows**, `start_renderer_liveness_watchdog()`: every
   10 s it counts this process's `--type=renderer` WebView2 children, and only treats
   the renderer as dead after **two consecutive** zero readings.
3. **Extends the `WindowEvent::Focused` fallback to Windows.** Restoring a minimized
   window natively does not go through the app's own `activate_window`, so nothing
   consumes the pending-reload flag and the page stays blank.
4. **Keeps the pending-reload flag when `reload()` fails.**
   `take_webview_needs_reload()` is a `swap(false)` — reading it clears it. The old
   code logged a warning and fell through to a direct show, **permanently losing the
   pending state so later activations never retried.** All three failure paths now put
   the flag back. Platform independent; macOS benefits too.

### Choosing the liveness criterion

| Option | Verdict |
|---|---|
| `ICoreWebView2::add_ProcessFailed` | Semantically the most accurate, but needs a direct `webview2-com` dependency kept in sync with wry's version |
| WebView IPC probe (`window.eval`) | **Measured as unworkable**, see below |
| **Counting `--type=renderer` children** | What this PR uses. No new crate, reliable in testing |

On the IPC probe: the first implementation used "does `window.eval("void 0")` fail"
as the criterion, reasoning that after render process death `show()` / `set_focus()`
return `runtime error: failed to send message to the webview`. **That inference does
not hold.** With the renderer confirmed dead (child count 0), window operations can
still succeed — the log showed `[Window] 窗口激活成功` — and `eval` does not fail
either, so the probe would never fire. This is recorded in a code comment so nobody
retries that path.

If wry ever gains an equivalent callback in `WebViewBuilderExtWindows`, that should
replace this probe.

### Two guards against false positives

- **"Could not measure" is not "renderer is dead."** `renderer_process_count()`
  returns `None` — and the caller does nothing — when no WebView2 child is found at
  all, or when children are found but no command line can be read. Without the second
  case, an environment where command lines are unreadable would report a constant 0
  and fire recovery on every tick.
- **Recovery fires once.** After firing, the watchdog latches and re-arms only when a
  live renderer is observed again. While the window is hidden the renderer is
  deliberately not recreated (existing upstream design), so without the latch the WS
  subscriptions — including the tray speed task — would be torn down every 20 s.

## Dependency

`sysinfo` is **already in the dependency tree** (via
`tauri-plugin-clash-verge-sysinfo`); this only declares the same `0.39` in the main
crate. The `Cargo.lock` diff is exactly one line:

```diff
   "smartstring",
+  "sysinfo",
   "sysproxy",
```

No new crate, no version bump, and the probe is entirely under `#[cfg(windows)]`.

## Verification

Windows 11 26200. Same machine, same conditions, A/B run back to back: start page set
to `/connections` (the heaviest subscription), identical traffic generator, identical
sampling interval, renderer killed with `taskkill`.

| | Unpatched (official v2.5.2) | Patched |
|---|---|---|
| Baseline (renderer alive) | −0.24 MB/min | flat |
| Renderer after kill | **0, never returns** | 0 → **back to 1 in ~15 s** |
| Memory rate after kill | **+7.42 MB/min** | **−0.07 MB/min** |
| After 295 s | 14.5 → **50.98 MB** | 14.5 → **16.29 MB** |
| Extrapolated to 24 h | **≈ 10.7 GB** | no growth |

Median active connections 179. The rate scales with connection count; 28 MB/min was
observed under heavier use.

Log from the patched run:

```
[16:16:47] (renderer child killed with taskkill)
[16:17:18.256] WARN [Window] WebView 渲染进程已终止（连续两次未检测到 renderer 子进程），开始恢复
[16:17:18.257] INFO [Window] 已清理全部 Mihomo WebSocket 连接
[16:17:33] (renderer child back to 1, page usable again)
```

The window was visible there, so it took the "reload immediately" branch and the page
fully recovered.

### The hidden-window path was tested separately

In practice the system kills the renderer of a **hidden** window precisely because of
memory pressure, and that path takes the other branch — clear WS and set
`WEBVIEW_NEEDS_RELOAD`, without recreating the renderer. The two paths stop the leak
by different means, so the result above does not carry over:

```
baseline (window hidden, renderer=1)  14.61 -> 14.33 MB     flat
kill renderer                         renderer -> 0
[16:59:16] WARN  [Window] WebView 渲染进程已终止（连续两次未检测到 renderer 子进程），开始恢复
[16:59:16] INFO  [Window] 窗口不可见，页面将在下次打开窗口时重载
[16:59:16] INFO  [Window] 已清理全部 Mihomo WebSocket 连接
285 s of observation (renderer 0 throughout)  14.48 -> 13.91 MB    -0.12 MB/min
```

**The renderer never came back and the page never recovered, yet memory did not
grow** — which is exactly what this path needs to demonstrate: stopping the leak does
not depend on recovering the page.

### On page recovery while hidden: `reload()` sometimes fails

A later activation attempt in that same run exposed a **pre-existing** problem:

```
[16:59:35] INFO [Window] 渲染进程曾被系统终止，激活窗口前重载页面
[16:59:35] WARN [Window] 重载页面失败，退回直接显示: runtime error: failed to send message to the webview
[16:59:35] WARN [Window] 显示窗口失败: runtime error: failed to send message to the webview
[16:59:35] WARN [Window] 设置窗口焦点失败: runtime error: failed to send message to the webview
```

Varying the delay between the watchdog firing and the activation:

| Watchdog → activation | `reload()` | Page |
|---|---|---|
| 0.2 s | succeeds | fully recovered; second activation reports "already visible and focused" |
| 19 s | fails | blank |
| 120 s | fails (3 consecutive attempts) | blank |

So it is **not** "unrecoverable on Windows" — it degrades with time, presumably as
WebView2's host tears down more state while the renderer is absent. The window in
which recovery works is narrow, and a real user will not click the tray 0.2 s after
the renderer dies, so in practice it lands on the failing side.

**Change 4 above came directly out of this**: since `reload()` can fail, the pending
flag must not be dropped on failure. After the change (120 s delay, repeated
activations):

```
"重载页面失败"       3   <- the failure path was actually reproduced
"保留待重载标记"     3   <- the flag was put back every time
"激活窗口前重载页面" 3   <- so every activation retried (before: 1 attempt, then silence)
```

Actually restoring the blank page probably requires destroying and rebuilding the
window, which is out of scope here. This PR stops the memory leak and stops throwing
away the retry.

### Notes on the measurements

- The 40 s baseline had to be flat, otherwise "it starts growing after the kill" would
  not be attributable. Both baselines were flat.
- "Memory stopped growing" alone is not sufficient evidence that the patch fired — the
  first version of this patch (the IPC probe) leaked while producing zero patch log
  lines. "The patch's log lines must appear" is therefore a separate criterion.
- `cargo clippy` reports no new warnings. Verified with a positive control (injecting
  a `map(|x| *x)` to confirm clippy was actually reporting).
