### PR TITLE
fix: add input ref and focus search fields on toggle

### DIFF
--- a/src/components/base/base-search-box.tsx
+++ b/src/components/base/base-search-box.tsx
@@ -27,6 +27,7 @@ export type SearchState = {
 type SearchOptionState = Omit<SearchState, 'text'>
 
 type SearchProps = {
+  inputRef?: React.RefObject<HTMLInputElement | null>
   value?: string
   defaultValue?: string
   autoFocus?: boolean
@@ -73,6 +74,7 @@ const useControllableState = <T,>(options: {
 }
 
 export const BaseSearchBox = ({
+  inputRef,
   value,
   defaultValue,
   autoFocus,
@@ -200,6 +202,7 @@ export const BaseSearchBox = ({
   return (
     <Tooltip title={effectiveErrorMessage || ''} placement="bottom-start">
       <StyledTextField
+        inputRef={inputRef}
         autoComplete="new-password"
         hiddenLabel
         fullWidth

--- a/src/components/proxy/proxy-group-tools.tsx
+++ b/src/components/proxy/proxy-group-tools.tsx
@@ -11,7 +11,7 @@ import WifiTetheringOffRounded from '@mui/icons-material/WifiTetheringOffRounded
 import WifiTetheringRounded from '@mui/icons-material/WifiTetheringRounded'
 import { Box, IconButton, type SxProps, TextField } from '@mui/material'
 import { useDebounceFn } from 'ahooks'
-import { memo, useEffect } from 'react'
+import { memo, useEffect, useRef } from 'react'
 import { flushSync } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
@@ -62,6 +62,8 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
     verge?.default_latency_test?.trim() ||
     'http://cp.cloudflare.com/generate_204'
 
+  const inputRef = useRef<HTMLInputElement>(null)
+
   useEffect(() => {
     delayManager.setUrl(groupName, testUrl?.trim() || url || defaultLatencyUrl)
   }, [groupName, testUrl, defaultLatencyUrl, url])
@@ -102,7 +104,7 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
       {textState === 'filter' && (
         <Box sx={{ flex: '1 1 auto' }}>
           <BaseSearchBox
-            autoFocus
+            inputRef={inputRef}
             defaultValue={filterText}
             matchCase={filterMatchCase}
             matchWholeWord={filterMatchWholeWord}
@@ -118,6 +120,7 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
 
       {textState === 'url' && (
         <TextField
+          inputRef={inputRef}
           autoComplete="new-password"
           hiddenLabel
           autoSave="off"
@@ -205,6 +208,7 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
           onHeadState({
             textState: textState === 'url' ? null : 'url',
           })
+          setTimeout(() => inputRef.current?.focus(), 0)
         }}
       >
         {textState === 'url' ? (
@@ -249,6 +253,7 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
             // eslint-disable-next-line @eslint-react/dom-no-flush-sync
             flushSync(() => onHeadState({ open: true }))
           onHeadState({ textState: textState === 'filter' ? null : 'filter' })
+          setTimeout(() => inputRef.current?.focus(), 0)
         }}
       >
         {textState === 'filter' ? (

--- a/src/components/proxy/proxy-group-tools.tsx
+++ b/src/components/proxy/proxy-group-tools.tsx
@@ -208,7 +208,7 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
           onHeadState({
             textState: textState === 'url' ? null : 'url',
           })
-          setTimeout(() => inputRef.current?.focus(), 0)
+          setTimeout(() => inputRef.current?.focus())
         }}
       >
         {textState === 'url' ? (
@@ -253,7 +253,7 @@ export const ProxyGroupTools = memo(function ProxyGroupTools(props: Props) {
             // eslint-disable-next-line @eslint-react/dom-no-flush-sync
             flushSync(() => onHeadState({ open: true }))
           onHeadState({ textState: textState === 'filter' ? null : 'filter' })
-          setTimeout(() => inputRef.current?.focus(), 0)
+          setTimeout(() => inputRef.current?.focus())
         }}
       >
         {textState === 'filter' ? (


### PR DESCRIPTION
代理组工具的输入框使用 `autoFocus` 属性时，每次数据刷新重新渲染时，代理列表页面都会自动滚动至上一个获得焦点的输入框并重新聚焦，导致用户滚动位置丢失，交互体验不佳

此 PR 移除了 `autoFocus` 的自动聚焦行为，改为手动调用 `focus()` 方法来精确控制输入框的聚焦逻辑