### PR TITLE
fix(linux): disable WebKit DMA-BUF renderer on virtual GPUs

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,7 +252,7 @@ pub fn run() -> std::process::ExitCode {
     }
 
     #[cfg(target_os = "linux")]
-    utils::linux::workarounds::apply_nvidia_dmabuf_renderer_workaround();
+    utils::linux::workarounds::apply_gpu_dmabuf_renderer_workaround();
     #[cfg(target_os = "linux")]
     utils::linux::workarounds::apply_wayland_webkit_fix();
 

--- a/src-tauri/src/utils/linux/workarounds.rs
+++ b/src-tauri/src/utils/linux/workarounds.rs
@@ -6,19 +6,23 @@
 use clash_verge_logging::{Type, logging};
 use std::{env, fs, path::Path, process::Command};
 
-pub fn apply_nvidia_dmabuf_renderer_workaround() {
+/// WebKitGTK's DMA-BUF renderer fails to paint the webview (blank window) on
+/// GPUs whose EGL implementation falls back to software rendering, such as the
+/// NVIDIA proprietary driver and virtual GPUs (VMware, VirtualBox, QEMU…).
+/// Disabling it forces a compatible rendering path.
+pub fn apply_gpu_dmabuf_renderer_workaround() {
     if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_some() {
         return;
     }
 
-    if has_nvidia_gpu() {
+    if has_unreliable_gpu() {
         unsafe {
             std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
         logging!(
             info,
             Type::Setup,
-            "Detected NVIDIA GPU, set WEBKIT_DISABLE_DMABUF_RENDERER=1"
+            "Detected GPU with unreliable DMA-BUF rendering, set WEBKIT_DISABLE_DMABUF_RENDERER=1"
         );
     }
 }
@@ -44,6 +48,45 @@ pub fn apply_wayland_webkit_fix() {
             env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
     }
+}
+
+/// Environments where the DMA-BUF renderer is known to leave a blank webview.
+fn has_unreliable_gpu() -> bool {
+    if has_nvidia_gpu() {
+        return true;
+    }
+
+    const VIRTUAL_GPU_VENDORS: &[&str] = &[
+        "0x15ad", // VMware SVGA
+        "0x80ee", // VirtualBox
+        "0x1af4", // Red Hat virtio-gpu
+        "0x1b36", // Red Hat QXL
+        "0x1234", // QEMU stdvga / bochs
+        "0x1414", // Microsoft Hyper-V
+    ];
+
+    let Ok(entries) = fs::read_dir("/sys/class/drm") else {
+        return false;
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("card") || name.contains('-') {
+            continue;
+        }
+
+        let vendor_path = entry.path().join("device/vendor");
+        let Ok(vendor) = fs::read_to_string(vendor_path) else {
+            continue;
+        };
+        let vendor = vendor.trim().to_ascii_lowercase();
+        if VIRTUAL_GPU_VENDORS.contains(&vendor.as_str()) {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn has_nvidia_gpu() -> bool {


### PR DESCRIPTION
## Summary
WebKitGTK's DMA-BUF renderer fails to repaint the webview (blank window) on GPUs
whose EGL implementation falls back to software rendering. The existing
workaround only covered NVIDIA; this extends it to common virtual GPUs
(VMware/VirtualBox/QEMU/Hyper-V) so the app is usable in VMs out of the box.

## Root cause
On a VMware VM, `glxinfo` reports SVGA3D for GLX but EGL falls back to llvmpipe.
WebKit never repaints past the initial loading overlay, leaving a solid-color
window with a clean app log (no frontend error).

## Changes
- `src-tauri/src/utils/linux/workarounds.rs`: rename
  `apply_nvidia_dmabuf_renderer_workaround` → `apply_gpu_dmabuf_renderer_workaround`,
  add `has_unreliable_gpu()` which detects NVIDIA **or** virtual GPU DRM vendors
  (`0x15ad` VMware, `0x80ee` VirtualBox, `0x1af4` virtio-gpu, `0x1b36` QXL,
  `0x1234` QEMU, `0x1414` Hyper-V) and sets `WEBKIT_DISABLE_DMABUF_RENDERER=1`.
- `src-tauri/src/lib.rs`: update the call site.

## Verification
- Blank window before: webview stuck on the solid `#2E303D` loading overlay.
- After: full UI renders (verified on a VMware VM, Linux Mint 22.3 / WebKitGTK 2.50).

## Test plan
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy-all`