### PR TITLE
chore(deps): revert dependency rust to v1.95.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
       "packageManager": "pnpm"
     },
     "ghcr.io/devcontainers/features/rust:1": {
-      "version": "1.96",
+      "version": "1.95.0",
       "profile": "default"
     },
     "ghcr.io/devcontainers/features/git:1": {},

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -254,7 +254,7 @@ jobs:
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: '1.97.1'
+          toolchain: '1.95.0'
           targets: ${{ matrix.target }}
 
       - name: Add Rust Target

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: '1.97.1'
+          toolchain: '1.95.0'
           targets: ${{ matrix.target }}
 
       - name: Add Rust Target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: '1.97.1'
+          toolchain: '1.95.0'
           targets: ${{ matrix.target }}
 
       - name: Add Rust Target
@@ -308,7 +308,7 @@ jobs:
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: '1.97.1'
+          toolchain: '1.95.0'
           targets: ${{ matrix.target }}
 
       - name: Add Rust Target
@@ -443,7 +443,7 @@ jobs:
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: '1.97.1'
+          toolchain: '1.95.0'
           targets: ${{ matrix.target }}
 
       - name: Add Rust Target


### PR DESCRIPTION
根据 [`rust-toolchain.toml`](https://github.com/clash-verge-rev/clash-verge-rev/blob/dev/rust-toolchain.toml) ，此项目的 Rust 工具链版本被锁定为 `v1.95.0` 。为了保障 Dev Containers 和 GitHub Workflows 中使用的 Rust Toolchain 版本与预定义一致，统一执行回退。

<div align="center">

|     涉及项目     |             文件路径              | 原始版本 | 目标版本 |
| :--------------: | :-------------------------------: | :------: | :------: |
| GitHub Workflows | `.github/workflows/autobuild.yml` | `1.97.1` | `1.95.0` |
| GitHub Workflows | `.github/workflows/release.yml`   | `1.97.1` | `1.95.0` |
|  Dev Containers  | `.devcontainer/devcontainer.json` |  `1.96`  | `1.95.0` |

</div>

> 此 Pull Request 由 VSCode 内置本地 Agent 使用 Gemini 3.6 Flash 辅助