### PR TITLE
fix: reset fake-ip-range6: "2001:2::0/64" as default on Tun Mode

### DIFF
--- a/src-tauri/src/enhance/mod.rs
+++ b/src-tauri/src/enhance/mod.rs
@@ -662,7 +662,7 @@ fn ensure_fake_ip_range6(dns: &mut Mapping) {
         .unwrap_or(true);
 
     if ipv6_enabled && is_fake_ip && range6_missing {
-        dns.insert(Value::from("fake-ip-range6"), Value::from("fdfe:dcba:9876::1/64"));
+        dns.insert(Value::from("fake-ip-range6"), Value::from("2001:2::0/64"));
     }
 }
 
@@ -790,7 +790,7 @@ mod fake_ip_tests {
         map
     }
 
-    const RANGE6: &str = "fdfe:dcba:9876::1/64";
+    const RANGE6: &str = "2001:2::0/64";
 
     #[test]
     fn an_ipv6_fake_ip_setup_missing_its_range_gets_one() {
@@ -942,7 +942,7 @@ mod use_tun_tests {
         assert_eq!(dns.get(Value::from("ipv6")), Some(&Value::from(true)));
         assert_eq!(
             dns.get(Value::from("fake-ip-range6")),
-            Some(&Value::from("fdfe:dcba:9876::1/64"))
+            Some(&Value::from("2001:2::0/64"))
         );
 
         let without_ipv6 = use_tun(Mapping::new(), true);

--- a/src-tauri/src/enhance/tun.rs
+++ b/src-tauri/src/enhance/tun.rs
@@ -44,7 +44,7 @@ pub fn use_tun(mut config: Mapping, enable: bool) -> Mapping {
             }
 
             if ipv6_val && !dns_val.contains_key(Value::from("fake-ip-range6")) {
-                revise!(dns_val, "fake-ip-range6", "2001:2::0/48");
+                revise!(dns_val, "fake-ip-range6", "2001:2::0/64");
             }
 
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/enhance/tun.rs
+++ b/src-tauri/src/enhance/tun.rs
@@ -44,7 +44,7 @@ pub fn use_tun(mut config: Mapping, enable: bool) -> Mapping {
             }
 
             if ipv6_val && !dns_val.contains_key(Value::from("fake-ip-range6")) {
-                revise!(dns_val, "fake-ip-range6", "fdfe:dcba:9876::1/64");
+                revise!(dns_val, "fake-ip-range6", "2001:2::0/48");
             }
 
             #[cfg(target_os = "macos")]


### PR DESCRIPTION
- Resolve #7564 

> 整个 2001:2::/48 被 RFC 5180（IPv6 基准测试方法论）保留，专用于网络设备性能基准测试/benchmarking，不应被用于真实公网主机的编址。IANA 特殊用途地址注册表里也把它列为 Benchmarking（2001:2::/48 — Benchmarking — RFC 5180）。

认为不影响个人主机.

可能需要商议.