### PR TITLE
fix(security): restrict external URL opening to HTTPS scheme

### DIFF
--- a/src-tauri/capabilities/migrated.json
+++ b/src-tauri/capabilities/migrated.json
@@ -64,7 +64,6 @@
     "core:window:allow-set-minimizable",
     "core:webview:allow-print",
     "shell:allow-execute",
-    "shell:allow-open",
     "shell:allow-kill",
     "shell:allow-spawn",
     "shell:allow-stdin-write",

--- a/src-tauri/src/cmd/app.rs
+++ b/src-tauri/src/cmd/app.rs
@@ -25,7 +25,11 @@ pub async fn open_logs_dir() -> CmdResult<()> {
 
 #[tauri::command]
 pub fn open_web_url(url: String) -> CmdResult<()> {
-    open::that(url.as_str()).stringify_err()
+    let parsed_url = reqwest::Url::parse(url.as_str()).map_err(|e| format!("invalid url: {e}"))?;
+    if parsed_url.scheme() != "https" || !parsed_url.has_host() {
+        anyhow::bail!("only https protocol is allowed");
+    }
+    open::that(parsed_url.as_str()).stringify_err()
 }
 
 #[tauri::command]

--- a/src-tauri/src/config/prfitem.rs
+++ b/src-tauri/src/config/prfitem.rs
@@ -339,7 +339,10 @@ impl PrfItem {
         let home = match header.get("profile-web-page-url") {
             Some(value) => {
                 let str_value = value.to_str().unwrap_or("");
-                Some(str_value.into())
+                match reqwest::Url::parse(str_value) {
+                    Ok(parsed_url) if parsed_url.scheme() == "https" && parsed_url.has_host() => Some(str_value.into()),
+                    _ => None,
+                }
             }
             None => None,
         };

--- a/src/components/profile/profile-item.tsx
+++ b/src/components/profile/profile-item.tsx
@@ -18,7 +18,6 @@ import {
   MenuItem,
   Typography,
 } from '@mui/material'
-import { open } from '@tauri-apps/plugin-shell'
 import { useLockFn } from 'ahooks'
 import dayjs from 'dayjs'
 import {
@@ -38,6 +37,7 @@ import { RulesEditorViewer } from '@/components/profile/rules-editor-viewer'
 import { useEditorDocument } from '@/hooks/use-editor-document'
 import {
   getNextUpdateTime,
+  openWebUrl,
   readProfileFile,
   saveProfileFile,
   updateProfile,
@@ -316,7 +316,9 @@ const ProfileItemBase = (props: ProfileItemProps) => {
 
   const onOpenHome = () => {
     setAnchorEl(null)
-    open(itemData.home ?? '')
+    if (itemData.home) {
+      openWebUrl(itemData.home)
+    }
   }
 
   const onEditInfo = () => {

--- a/src/components/setting/mods/update-viewer.tsx
+++ b/src/components/setting/mods/update-viewer.tsx
@@ -1,5 +1,4 @@
 import { alpha, Box, Button, LinearProgress } from '@mui/material'
-import { open as openUrl } from '@tauri-apps/plugin-shell'
 import type { DownloadEvent } from '@tauri-apps/plugin-updater'
 import { useLockFn } from 'ahooks'
 import type { Ref } from 'react'
@@ -14,9 +13,9 @@ import {
 import { useTranslation } from 'react-i18next'
 import type { Options as ReactMarkdownOptions } from 'react-markdown'
 
-import { BaseDialog, DialogRef } from '@/components/base'
+import { BaseDialog, type DialogRef } from '@/components/base'
 import { useUpdate } from '@/hooks/use-update'
-import { restartApp } from '@/services/cmds'
+import { openWebUrl, restartApp } from '@/services/cmds'
 import { showNotice } from '@/services/notice-service'
 import { useSetUpdateState, useUpdateState } from '@/services/states'
 
@@ -276,7 +275,7 @@ export function UpdateViewer({ ref }: { ref?: Ref<DialogRef> }) {
             size="small"
             sx={{ whiteSpace: 'nowrap' }}
             onClick={() => {
-              openUrl(
+              openWebUrl(
                 `https://github.com/clash-verge-rev/clash-verge-rev/releases/tag/v${updateInfo?.version}`,
               )
             }}

--- a/src/services/cmds.ts
+++ b/src/services/cmds.ts
@@ -243,6 +243,10 @@ export async function openLogsDir() {
 
 export const openWebUrl = async (url: string) => {
   try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'https:' || !parsed.host) {
+      throw new Error('Only HTTPS protocol is allowed')
+    }
     await invoke('open_web_url', { url })
   } catch (err: any) {
     showNotice.error(err)


### PR DESCRIPTION
- 移除 Tauri 权限 `shell:allow-open`
- 优化 URL 处理的约束并让 URL 验证逻辑更严格
  - 只有 HTTPS 协议且具备有效主机名的 URL 被允许使用
  - 使用 `reqwest::Url` 作为 Rust 后端的 URL 格式验证器
  - 使用 Nodejs 内置 `URL` 作为前端 URL 格式验证器

> [!NOTE]
> 
> 此 Pull Request 由 [VSCode 内置本地 Agent](https://code.visualstudio.com/docs/agents/overview?agent-surface=chat-view) 调用 Gemini 3.7 Flash ，辅以 [CodeGraph](https://colbymchenry.github.io/codegraph/) 实现

- Resolve #7800 