### PR TITLE
fix: don't let stale TUN session suppression veto an enabled, capable TUN (#7821)

### DIFF
--- a/src-tauri/src/enhance/mod.rs
+++ b/src-tauri/src/enhance/mod.rs
@@ -131,8 +131,7 @@ async fn get_config_values() -> ConfigValues {
         // the user is admin) the capability overrides it. Fixes #7821 where the
         // panel switch flipped `enable_tun_mode` but the kernel kept `tun.enable`
         // false because `continue_with_sidecar` had suppressed the session.
-        enable_tun_mode.unwrap_or(false)
-            && (!Config::tun_suppressed_for_session() || RUN_STATE.state().tun_capable()),
+        enable_tun_mode.unwrap_or(false) && (!Config::tun_suppressed_for_session() || RUN_STATE.state().tun_capable()),
         enable_builtin_enhanced.unwrap_or(true),
         verge_socks_enabled.unwrap_or(false),
         verge_http_enabled.unwrap_or(false),

--- a/src-tauri/src/enhance/mod.rs
+++ b/src-tauri/src/enhance/mod.rs
@@ -17,6 +17,7 @@ use crate::utils::dirs;
 use crate::{
     config::{Config, IProfiles, IVerge, PrfItem},
     constants,
+    core::runstate::RUN_STATE,
     utils::tmpl,
 };
 use anyhow::{Context as _, Result};
@@ -124,7 +125,14 @@ async fn get_config_values() -> ConfigValues {
 
     let (clash_core, enable_tun, enable_builtin, socks_enabled, http_enabled, enable_dns_settings) = (
         Some(verge_arc.get_valid_clash_core()),
-        enable_tun_mode.unwrap_or(false) && !Config::tun_suppressed_for_session(),
+        // A stale session TUN suppression must not veto an explicitly requested
+        // TUN when the current run state can actually support it. The suppression
+        // only means "this session cannot do TUN"; once the Service is ready (or
+        // the user is admin) the capability overrides it. Fixes #7821 where the
+        // panel switch flipped `enable_tun_mode` but the kernel kept `tun.enable`
+        // false because `continue_with_sidecar` had suppressed the session.
+        enable_tun_mode.unwrap_or(false)
+            && (!Config::tun_suppressed_for_session() || RUN_STATE.state().tun_capable()),
         enable_builtin_enhanced.unwrap_or(true),
         verge_socks_enabled.unwrap_or(false),
         verge_http_enabled.unwrap_or(false),


### PR DESCRIPTION
## Summary

Fixes #7821 — on macOS, toggling the TUN switch in the panel flips `enable_tun_mode` but the kernel keeps `tun.enable = false`, so traffic is never routed through TUN even though the UI shows it as enabled.

## Root cause

The runtime core config's `tun.enable` is decided in `enhance/mod.rs::get_config_values`:

```rust
enable_tun = enable_tun_mode.unwrap_or(false) && !Config::tun_suppressed_for_session();
```

The `tun_suppressed_for_session()` flag is set on macOS by `continue_with_sidecar` (`core/manager/lifecycle.rs:329`) when the app decides to run the core as a Sidecar (non-Service). Its only meaning is "this session cannot do TUN".

The bug is that the flag is **never cleared** once the Service actually becomes ready — the running core ends up as `root` (`verge-mihomo` owner = root, `clash-verge-service` running), and a manual `PATCH /configs {"tun":{"enable":true}}` immediately brings up `utun` and routes traffic correctly. So the session is fully TUN-capable, yet the stale suppression keeps `enable_tun` false, making the panel switch a no-op at the kernel.

(For contrast, Linux already works because `determine_update_flags` adds `RESTART_CORE` for `tun_mode == Some(true)` at `feat/config.rs:144`, forcing a regenerate+restart; macOS/Windows lack that line.)

## Fix

Override the suppression with the actual run-state capability:

```rust
enable_tun_mode.unwrap_or(false)
    && (!Config::tun_suppressed_for_session() || RUN_STATE.state().tun_capable()),
```

`tun_capable()` already encodes exactly "this session can do TUN" (`is_admin || service_usable()`). So when the Service is ready (or the user is admin), the suppression is legitimately overridden and the generated config emits `tun.enable = true`. When the session genuinely cannot do TUN (true Sidecar with no admin/Service), suppression still blocks TUN as intended.

## Notes

- I could not compile/run this locally (no Rust toolchain + no macOS code signing, and Service Mode requires a signed privileged helper), so this is reviewed-by-reasoning rather than end-to-end tested. A maintainer build/CI check would be appreciated.
- The reported manual workaround (`tun-on` / `tun-off` via `PATCH /configs`) remains valid until this ships.
