### PR TITLE
fix: Rewrite delay test logic

### DIFF
--- a/src-tauri/src/feat/clash.rs
+++ b/src-tauri/src/feat/clash.rs
@@ -5,23 +5,12 @@ use crate::{
     process::AsyncHandler,
     utils,
 };
-use bytes::BytesMut;
 use clash_verge_logging::{Type, logging};
-use once_cell::sync::Lazy;
+use reqwest::{Client, Proxy};
 use serde_yaml_ng::{Mapping, Value};
 use smartstring::alias::String;
-use std::sync::Arc;
-
-#[allow(clippy::expect_used)]
-static TLS_CONFIG: Lazy<Arc<rustls::ClientConfig>> = Lazy::new(|| {
-    let root_store = rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    let config = rustls::ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
-        .with_safe_default_protocol_versions()
-        .expect("Failed to set TLS versions")
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
-    Arc::new(config)
-});
+use std::time::Duration;
+use tokio::time::Instant;
 
 pub async fn restart_clash_core() {
     match CoreManager::global().restart_core().await {
@@ -116,70 +105,23 @@ pub async fn change_clash_mode(mode: String) -> Result<(), String> {
 }
 
 /// Test delay to a URL through proxy.
-/// HTTPS: measures TLS handshake time. HTTP: measures HEAD round-trip time.
 pub async fn test_delay(url: String) -> anyhow::Result<u32> {
-    use std::sync::Arc;
-    use std::time::Duration;
-    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
-    use tokio::net::TcpStream;
-    use tokio::time::Instant;
+    let proxy_port = MixedPort::effective().await;
+    let proxy = Proxy::all(format!("http://127.0.0.1:{proxy_port}"))?;
 
-    let parsed = tauri::Url::parse(&url)?;
-    let is_https = parsed.scheme() == "https";
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| anyhow::anyhow!("Invalid URL: no host"))?
-        .to_string();
-    let port = parsed.port().unwrap_or(if is_https { 443 } else { 80 });
+    let client = Client::builder()
+        .proxy(proxy)
+        .timeout(Duration::from_secs(10))
+        .danger_accept_invalid_certs(true)
+        .build()?;
 
-    let verge = Config::verge().await.latest_arc();
-    let proxy_enabled = verge.enable_system_proxy.unwrap_or(false) || verge.enable_tun_mode.unwrap_or(false);
-    let proxy_port = if proxy_enabled {
-        Some(MixedPort::desired().await)
-    } else {
-        None
-    };
-
-    tokio::time::timeout(Duration::from_secs(10), async {
-        let start = Instant::now();
-        let mut buf = BytesMut::with_capacity(1024);
-
-        if is_https {
-            let stream = match proxy_port {
-                Some(pp) => {
-                    let mut s = TcpStream::connect(format!("127.0.0.1:{pp}")).await?;
-                    s.write_all(format!("CONNECT {host}:{port} HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n").as_bytes())
-                        .await?;
-                    s.read_buf(&mut buf).await?;
-                    if !buf.windows(3).any(|w| w == b"200") {
-                        return Err(anyhow::anyhow!("Proxy CONNECT failed"));
-                    }
-                    s
-                }
-                None => TcpStream::connect(format!("{host}:{port}")).await?,
-            };
-            let connector = tokio_rustls::TlsConnector::from(Arc::clone(&TLS_CONFIG));
-            let server_name = rustls::pki_types::ServerName::try_from(host.as_str())
-                .map_err(|_| anyhow::anyhow!("Invalid DNS name: {host}"))?
-                .to_owned();
-            connector.connect(server_name, stream).await?;
-        } else {
-            let (mut stream, req) = match proxy_port {
-                Some(pp) => (
-                    TcpStream::connect(format!("127.0.0.1:{pp}")).await?,
-                    format!("HEAD {url} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n"),
-                ),
-                None => (
-                    TcpStream::connect(format!("{host}:{port}")).await?,
-                    format!("HEAD / HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n"),
-                ),
-            };
-            stream.write_all(req.as_bytes()).await?;
-            let _ = stream.read(&mut buf).await?;
+    let start = Instant::now();
+    let resp = client.head(url.as_str()).send().await;
+    match resp {
+        Ok(_) => Ok((start.elapsed().as_millis() as u32).max(1)),
+        Err(_) => {
+            client.get(url.as_str()).send().await?;
+            Ok((start.elapsed().as_millis() as u32).max(1))
         }
-
-        Ok((start.elapsed().as_millis() as u32).max(1))
-    })
-    .await
-    .unwrap_or(Ok(10000u32))
+    }
 }


### PR DESCRIPTION
## 概述

重写延迟测试逻辑

- Resolve #7775 

## 细节

- 使用 `app_lib::config::mixed_port::MixedPort` 获取 Mihomo 内核的混合端口号
- 不论系统代理或虚拟网卡模式是否在 Clash Verge Rev 中启用， **始终** 途经 Mihomo 内核进行延迟测试
- 使用 Rust `reqwest` 库进行延迟测试，替代原有的手动 TCP 通信构建
  - ℹ️ 这可能与 原有的实现细节[^1] 存在出入，引入「基准测试变更」
  - HTTP 与 HTTPS 统一使用 `reqwest` 发送 `HEAD` 请求进行测试
  - 对于少数由 CDN / WAF / Anti-DDoS 等服务保护、可能针对性不处理 `HEAD` 请求的测试端点，回退为发送 `GET` 请求[^2]

[^1]: HTTPS 通过手动构造 TCP `CONNECT` 握手，HTTP 通过手动构造 `HEAD` 请求并接收响应
[^2]: 因回退发生的全新请求会被一并计入先前的测试过程， `HEAD` 请求失败后不停表清零，延迟结果值实为 `HEAD` 失败＋ `GET` 重试的总时长

> [!NOTE]
> 
> 此 Pull Request 由 VSCode 内置 Agent Host 接入 Gemini 3.7 Flash (medium) ，配合 CodeGraph 自动实现