### PR TITLE
fix: preserve page filters during navigation

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,6 +22,7 @@ import {
 import { swrConfig } from './services/query-client'
 import {
   LoadingCacheProvider,
+  PageSearchStateProvider,
   ThemeModeProvider,
   UpdateStateProvider,
 } from './services/states'
@@ -45,6 +46,7 @@ const initializeApp = (initialThemeMode: 'light' | 'dark') => {
     <ThemeModeProvider key="theme" initialState={initialThemeMode} />,
     <LoadingCacheProvider key="loading" />,
     <UpdateStateProvider key="update" />,
+    <PageSearchStateProvider key="page-search" />,
   ]
 
   const root = createRoot(container)

--- a/src/pages/connections.tsx
+++ b/src/pages/connections.tsx
@@ -24,7 +24,6 @@ import {
   BasePage,
   BaseSearchBox,
   BaseStyledSelect,
-  type SearchState,
   VirtualList,
 } from '@/components/base'
 import {
@@ -41,6 +40,7 @@ import { useConnectionData } from '@/hooks/use-connection-data'
 import { useConnectionSetting } from '@/hooks/use-connection-setting'
 import { useTrafficData } from '@/hooks/use-traffic-data'
 import { useVisibility } from '@/hooks/use-visibility'
+import { usePageSearchState } from '@/services/states'
 import parseTraffic from '@/utils/parse-traffic'
 
 type OrderFunc = (list: IConnectionsItem[]) => IConnectionsItem[]
@@ -82,10 +82,12 @@ const EMPTY_CONNECTIONS: IConnectionsItem[] = []
 const ConnectionsPage = () => {
   const { t } = useTranslation()
   const pageVisible = useVisibility()
-  const [match, setMatch] = useState<(input: string) => boolean>(
-    () => () => true,
-  )
-  const [hasSearch, setHasSearch] = useState(false)
+  const {
+    matcher: match,
+    searchState,
+    setSearchState,
+  } = usePageSearchState('connections')
+  const hasSearch = searchState.text.length > 0
   const [curOrderOpt, setCurOrderOpt] = useState<OrderKey>('default')
   const [connectionsType, setConnectionsType] = useState<'active' | 'closed'>(
     'active',
@@ -154,13 +156,6 @@ const ConnectionsPage = () => {
 
   const onCloseAll = useLockFn(closeAllConnections)
 
-  const handleSearch = useCallback(
-    (match: (content: string) => boolean, state: SearchState) => {
-      setMatch(() => match)
-      setHasSearch(state.text.length > 0)
-    },
-    [],
-  )
   const hasTableData = filterConn.length > 0
 
   return (
@@ -268,7 +263,11 @@ const ConnectionsPage = () => {
             },
           }}
         >
-          <BaseSearchBox onSearch={handleSearch} />
+          <BaseSearchBox
+            value={searchState.text}
+            searchState={searchState}
+            onSearch={(_, state) => setSearchState(state)}
+          />
         </Box>
         {isTableLayout && hasTableData && (
           <Tooltip title={t('connections.components.columnManager.title')}>

--- a/src/pages/logs.tsx
+++ b/src/pages/logs.tsx
@@ -4,7 +4,7 @@ import {
   SwapVertRounded,
 } from '@mui/icons-material'
 import { Box, Button, IconButton, MenuItem } from '@mui/material'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -12,13 +12,13 @@ import {
   BasePage,
   BaseSearchBox,
   BaseStyledSelect,
-  type SearchState,
   VirtualList,
   type VirtualListHandle,
 } from '@/components/base'
 import LogItem from '@/components/log/log-item'
 import { useClashLog } from '@/hooks/use-clash-log'
 import { useLogData } from '@/hooks/use-log-data'
+import { usePageSearchState } from '@/services/states'
 
 const LogPage = () => {
   const { t } = useTranslation()
@@ -28,8 +28,11 @@ const LogPage = () => {
   const logOrder = clashLog.logOrder ?? 'asc'
   const isDescending = logOrder === 'desc'
 
-  const [match, setMatch] = useState(() => (_: string) => true)
-  const [searchState, setSearchState] = useState<SearchState>()
+  const {
+    matcher: match,
+    searchState,
+    setSearchState,
+  } = usePageSearchState('logs')
   const {
     response: { data: logData },
     refreshGetClashLog,
@@ -174,10 +177,9 @@ const LogPage = () => {
           <MenuItem value="err">{t('shared.filters.logLevels.error')}</MenuItem>
         </BaseStyledSelect>
         <BaseSearchBox
-          onSearch={(matcher, state) => {
-            setMatch(() => matcher)
-            setSearchState(state)
-          }}
+          value={searchState.text}
+          searchState={searchState}
+          onSearch={(_, state) => setSearchState(state)}
         />
       </Box>
 

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -14,12 +14,17 @@ import { ProviderButton } from '@/components/rule/provider-button'
 import RuleItem from '@/components/rule/rule-item'
 import { useVisibility } from '@/hooks/use-visibility'
 import { useAppRefreshers, useRulesData } from '@/providers/app-data-context'
+import { usePageSearchState } from '@/services/states'
 
 const RulesPage = () => {
   const { t } = useTranslation()
   const { rules = [] } = useRulesData()
   const { refreshRules, refreshRuleProviders } = useAppRefreshers()
-  const [match, setMatch] = useState(() => (_: string) => true)
+  const {
+    matcher: match,
+    searchState,
+    setSearchState,
+  } = usePageSearchState('rules')
   const virtuosoRef = useRef<VirtualListHandle>(null)
   const [showScrollTop, setShowScrollTop] = useState(false)
   const pageVisible = useVisibility()
@@ -79,7 +84,11 @@ const RulesPage = () => {
           alignItems: 'center',
         }}
       >
-        <BaseSearchBox onSearch={(match) => setMatch(() => match)} />
+        <BaseSearchBox
+          value={searchState.text}
+          searchState={searchState}
+          onSearch={(_, state) => setSearchState(state)}
+        />
       </Box>
 
       {filteredRules && filteredRules.length > 0 ? (

--- a/src/services/states.test.ts
+++ b/src/services/states.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest'
+
+import type { SearchState } from '@/components/base'
+
+import {
+  compilePageSearchMatcher,
+  createDefaultPageSearchStates,
+  updatePageSearchState,
+} from './states'
+
+const searchState = (text: string): SearchState => ({
+  text,
+  matchCase: false,
+  matchWholeWord: false,
+  useRegularExpression: false,
+})
+
+describe('page search session state', () => {
+  test('keeps each page search independent', () => {
+    const initial = createDefaultPageSearchStates()
+    const withConnections = updatePageSearchState(
+      initial,
+      'connections',
+      searchState('github.com'),
+    )
+    const withRules = updatePageSearchState(
+      withConnections,
+      'rules',
+      searchState('MATCH'),
+    )
+
+    expect(withRules.connections.text).toBe('github.com')
+    expect(withRules.rules.text).toBe('MATCH')
+    expect(withRules.logs.text).toBe('')
+    expect(initial).toEqual(createDefaultPageSearchStates())
+  })
+
+  test('derives the restored matcher from the saved options', () => {
+    const matcher = compilePageSearchMatcher({
+      text: '^GitHub$',
+      matchCase: true,
+      matchWholeWord: false,
+      useRegularExpression: true,
+    })
+
+    expect(matcher('GitHub')).toBe(true)
+    expect(matcher('github')).toBe(false)
+  })
+
+  test('clearing one page restores unfiltered results only for that page', () => {
+    const populated = updatePageSearchState(
+      updatePageSearchState(
+        createDefaultPageSearchStates(),
+        'connections',
+        searchState('example.com'),
+      ),
+      'logs',
+      searchState('warning'),
+    )
+    const cleared = updatePageSearchState(
+      populated,
+      'connections',
+      searchState(''),
+    )
+
+    expect(compilePageSearchMatcher(cleared.connections)('anything')).toBe(true)
+    expect(cleared.logs.text).toBe('warning')
+  })
+
+  test('starts a new app session with fresh page states', () => {
+    const firstSession = createDefaultPageSearchStates()
+    const secondSession = createDefaultPageSearchStates()
+
+    firstSession.connections.text = 'changed outside React'
+
+    expect(secondSession.connections.text).toBe('')
+    expect(secondSession.connections).not.toBe(firstSession.connections)
+  })
+})

--- a/src/services/states.ts
+++ b/src/services/states.ts
@@ -1,4 +1,55 @@
 import { createContextState } from 'foxact/create-context-state'
+import { useCallback, useMemo } from 'react'
+
+import type { SearchState } from '@/components/base'
+import { compileStringMatcher } from '@/utils/search-matcher'
+
+export type PageSearchKey = 'connections' | 'rules' | 'logs'
+export type PageSearchStates = Record<PageSearchKey, SearchState>
+
+const createDefaultSearchState = (): SearchState => ({
+  text: '',
+  matchCase: false,
+  matchWholeWord: false,
+  useRegularExpression: false,
+})
+
+export const createDefaultPageSearchStates = (): PageSearchStates => ({
+  connections: createDefaultSearchState(),
+  rules: createDefaultSearchState(),
+  logs: createDefaultSearchState(),
+})
+
+export const updatePageSearchState = (
+  states: PageSearchStates,
+  page: PageSearchKey,
+  searchState: SearchState,
+): PageSearchStates => ({ ...states, [page]: searchState })
+
+export const compilePageSearchMatcher = (searchState: SearchState) =>
+  compileStringMatcher(searchState.text, searchState).matcher
+
+const [PageSearchStateProvider, usePageSearchStates, useSetPageSearchStates] =
+  createContextState<PageSearchStates>(createDefaultPageSearchStates())
+
+const usePageSearchState = (page: PageSearchKey) => {
+  const searchState = usePageSearchStates()[page]
+  const setPageSearchStates = useSetPageSearchStates()
+  const matcher = useMemo(
+    () => compilePageSearchMatcher(searchState),
+    [searchState],
+  )
+  const setSearchState = useCallback(
+    (nextSearchState: SearchState) => {
+      setPageSearchStates((states) =>
+        updatePageSearchState(states, page, nextSearchState),
+      )
+    },
+    [page, setPageSearchStates],
+  )
+
+  return { matcher, searchState, setSearchState }
+}
 
 const [ThemeModeProvider, useThemeMode, useSetThemeMode] = createContextState<
   'light' | 'dark'
@@ -22,4 +73,6 @@ export {
   UpdateStateProvider,
   useUpdateState,
   useSetUpdateState,
+  PageSearchStateProvider,
+  usePageSearchState,
 }


### PR DESCRIPTION
## Summary

- keep Connections, Rules, and Logs search text and matching options across route navigation
- scope the state to the current app session instead of persisting it across restarts
- isolate each page search state and rebuild its matcher when the page remounts
- add regression coverage for page isolation, restored matcher options, clearing, and fresh sessions

## Verification

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip:check`
- `pnpm web:build`

Fixes #7788