### PR TITLE
chore(gitattributes): Lock end of line style for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 .github/workflows/*.lock.yml linguist-generated=true
 Changelog.md merge=union
+*.sh text eol=lf
+*.bash text eol=lf


### PR DESCRIPTION
项目中的 `.sh` 和 `.bash` 文件主要是给 Unix/Linux 环境使用的，对于在 Windows 上使用 Git Bash 或类似环境的用户，可能会由于默认或额外配置的 `core.autocrlf=true` 导致相关文件在检出时自动切换为 CRLF 模式。意外的 CR 会给 Shell 运行环境引入不必要的非预期错误。

配置 `.gitattributes` ，将此类文件统一锁定为 LF 模式。

> [!NOTE]
> 
> 使用 VSCode Copilot Chat ，接入 Gemini 3.7 Flash ，配合 CodeGraph 生成