### PR TITLE
refactor: simplify side menu layout and drag-and-drop logic

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -213,6 +213,25 @@ const Layout = () => {
     )
   }
 
+  // Navigation menu items
+  const menuItems = menuOrder.map((path, index) => {
+    const item = navItemMap.get(path)
+    if (!item) return null
+
+    return menuUnlocked ? (
+      <SortableNavMenuItem
+        key={item.path}
+        index={index}
+        item={item}
+        label={t(item.label)}
+      />
+    ) : (
+      <LayoutItem key={item.path} to={item.path} icon={item.icon}>
+        {t(item.label)}
+      </LayoutItem>
+    )
+  })
+
   return (
     <ThemeProvider theme={theme}>
       {/* 左侧底部窗口控制按钮 */}
@@ -318,43 +337,19 @@ const Layout = () => {
               </Box>
             )}
 
-            {menuUnlocked ? (
-              <List className="the-menu" onContextMenu={handleMenuContextMenu}>
+            {/* Navigation menu */}
+            <List className="the-menu" onContextMenu={handleMenuContextMenu}>
+              {menuUnlocked ? (
                 <DragDropProvider
                   sensors={[PointerSensor, KeyboardSensor]}
                   onDragEnd={handleMenuDragEnd}
                 >
-                  {menuOrder.map((path) => {
-                    const item = navItemMap.get(path)
-                    if (!item) {
-                      return null
-                    }
-                    return (
-                      <SortableNavMenuItem
-                        key={item.path}
-                        item={item}
-                        label={t(item.label)}
-                        index={menuOrder.indexOf(path)}
-                      />
-                    )
-                  })}
+                  {menuItems}
                 </DragDropProvider>
-              </List>
-            ) : (
-              <List className="the-menu" onContextMenu={handleMenuContextMenu}>
-                {menuOrder.map((path) => {
-                  const item = navItemMap.get(path)
-                  if (!item) {
-                    return null
-                  }
-                  return (
-                    <LayoutItem key={item.path} to={item.path} icon={item.icon}>
-                      {t(item.label)}
-                    </LayoutItem>
-                  )
-                })}
-              </List>
-            )}
+              ) : (
+                menuItems
+              )}
+            </List>
 
             <Menu
               open={Boolean(menuContextPosition)}

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -47,35 +47,12 @@ import { navItems } from './_navigation'
 import 'dayjs/locale/ru'
 import 'dayjs/locale/zh-cn'
 
-type NavItem = (typeof navItems)[number]
-
 type MenuContextPosition = { top: number; left: number }
-
-interface SortableNavMenuItemProps {
-  item: NavItem
-  label: string
-  index: number
-}
-
-const SortableNavMenuItem = ({
-  item,
-  label,
-  index,
-}: SortableNavMenuItemProps) => {
-  return (
-    <SortableItem id={item.path} index={index}>
-      {(sortable) => (
-        <LayoutItem to={item.path} icon={item.icon} sortable={sortable}>
-          {label}
-        </LayoutItem>
-      )}
-    </SortableItem>
-  )
-}
 
 dayjs.extend(relativeTime)
 
 const OS = getSystem()
+const SENSORS = [PointerSensor, KeyboardSensor]
 
 const Layout = () => {
   const mode = useThemeMode()
@@ -214,21 +191,23 @@ const Layout = () => {
   }
 
   // Navigation menu items
-  const menuItems = menuOrder.map((path, index) => {
+  const navMenuItems = menuOrder.map((path, index) => {
     const item = navItemMap.get(path)
     if (!item) return null
 
-    return menuUnlocked ? (
-      <SortableNavMenuItem
+    return (
+      <SortableItem
         key={item.path}
+        id={item.path}
         index={index}
-        item={item}
-        label={t(item.label)}
-      />
-    ) : (
-      <LayoutItem key={item.path} to={item.path} icon={item.icon}>
-        {t(item.label)}
-      </LayoutItem>
+        disabled={!menuUnlocked}
+      >
+        {(sortable) => (
+          <LayoutItem to={item.path} icon={item.icon} sortable={sortable}>
+            {t(item.label)}
+          </LayoutItem>
+        )}
+      </SortableItem>
     )
   })
 
@@ -339,16 +318,9 @@ const Layout = () => {
 
             {/* Navigation menu */}
             <List className="the-menu" onContextMenu={handleMenuContextMenu}>
-              {menuUnlocked ? (
-                <DragDropProvider
-                  sensors={[PointerSensor, KeyboardSensor]}
-                  onDragEnd={handleMenuDragEnd}
-                >
-                  {menuItems}
-                </DragDropProvider>
-              ) : (
-                menuItems
-              )}
+              <DragDropProvider sensors={SENSORS} onDragEnd={handleMenuDragEnd}>
+                {navMenuItems}
+              </DragDropProvider>
             </List>
 
             <Menu


### PR DESCRIPTION
### Summary
Simplified side navigation rendering by removing duplicate `<List>` and `.map()` blocks for locked and unlocked menu states. Also eliminated an $O(n^2)$ `menuOrder.indexOf(path)` lookup inside the map iteration.

### Changes
- Wrapped `<List>` container around conditional `DragDropProvider` logic instead of duplicating the whole tree.
- Consolidated menu mapping into a single `navMenuItems` array using `map((path, index) => ...)`.