### PR TITLE
fix: shutdown blocked on Windows

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,8 +19,8 @@ default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
 verge-dev = ["clash_verge_logger/color", "clash_verge_service_ipc/development-channel"]
 dev-sidecar = ["verge-dev"]
-tauri-dev = []
-tokio-trace = ["console-subscriber"]
+tauri-dev = ["dep:tauri-plugin-devtools"]
+tokio-trace = ["dep:console-subscriber"]
 clippy = ["tauri/test"]
 tracing = []
 
@@ -94,7 +94,7 @@ tokio-stream = "0.1.19"
 backon = { version = "1.6.0", features = ["tokio-sleep"] }
 tauri-plugin-http = "2.5.9"
 console-subscriber = { version = "0.5.0", optional = true }
-tauri-plugin-devtools = { version = "2.1.0" }
+tauri-plugin-devtools = { version = "2.1.0", optional = true }
 tauri-plugin-mihomo = { git = "https://github.com/clash-verge-rev/tauri-plugin-mihomo", branch = "main" }
 clash_verge_logger = { git = "https://github.com/clash-verge-rev/clash-verge-logger" }
 async-trait = "0.1.92"


### PR DESCRIPTION
Closes: #7549
Closes: #5963
Closes: #7755
Closes: #7841

## 问题

主窗口打开时 Windows 关机被「此程序正在阻止关机」卡住，进程无法退出；窗口收进托盘时正常

## 根因

`tauri-plugin-devtools` 无条件声明 `tauri = { features = ["tracing"] }`，且 `src-tauri/Cargo.toml` 无条件依赖它。Cargo feature 合并导致 **release 构建也全局开启了 `tauri-runtime-wry/tracing`**，即使插件从未注册（`lib.rs:66` 仅在 `debug_assertions && tauri-dev` 下注册）

启用 `tracing` 后，`tauri-runtime-wry` 的 `eval_script` 变为阻塞式主线程往返（`send_user_message` 后 `rx.recv()` 等主线程处理完 `EvaluateScript`），而默认实现仅 `PostMessage` 非阻塞

关机死锁链：`WM_ENDSESSION` → 主线程 `block_on(clean_session_ending_best_effort())` 不再泵消息 → 停止 core 时前端 WebSocket 断连，`tauri-plugin-mihomo` websocket reader 任务在 error/close 路径通过 `on_message` 发送消息到前端时，走的是阻塞版 `webview.eval` 等主线程处理 → 主线程等清理 future（需空闲 tokio worker），互相等待 → 进程永不退出

## 修改

`src-tauri/Cargo.toml` 将 tauri-plugin-devtools 改为 optional，仅随 `tauri-dev` 启用

release 构建不再引入 tauri-plugin-devtools，从而不强制开启 `tauri/tracing`，`webview.eval` 恢复非阻塞实现，死锁链从根上消除，语义与 `lib.rs` 中插件注册的 `cfg(feature = "tauri-dev")` 一致
