### PR TITLE
fix(proxy): preserve active proxy chains across profile refreshes

### DIFF
--- a/src-tauri/src/config/config.rs
+++ b/src-tauri/src/config/config.rs
@@ -220,12 +220,17 @@ impl Config {
         }
 
         Self::runtime().await.edit_draft(|d| {
-            *d = IRuntime {
+            let mut next = IRuntime {
                 config: Some(config),
                 exists_keys,
                 chain_logs: logs,
-            }
-        });
+                profile_uid: profiles.current.clone(),
+                ..IRuntime::default()
+            };
+            next.inherit_proxy_chain(d)?;
+            *d = next;
+            Ok::<(), anyhow::Error>(())
+        })?;
 
         Ok(())
     }

--- a/src-tauri/src/config/runtime.rs
+++ b/src-tauri/src/config/runtime.rs
@@ -9,6 +9,9 @@ const PATCH_CONFIG_INNER: [&str; 5] = ["allow-lan", "ipv6", "log-level", "unifie
 #[derive(Default, Clone)]
 pub struct IRuntime {
     pub config: Option<Mapping>,
+    pub(crate) profile_uid: Option<String>,
+    // Session-only user intent, separate from the configuration rebuilt by profile updates.
+    pub(crate) active_proxy_chain: Option<Value>,
     // Keys seen in the profile pipeline, including merge and script output.
     pub exists_keys: HashSet<String>,
     // TODO 或许可以用 FixMap 来存储以提升效率
@@ -16,6 +19,31 @@ pub struct IRuntime {
 }
 
 impl IRuntime {
+    /// Restores the user chain before a regenerated config is validated and loaded.
+    pub(crate) fn inherit_proxy_chain(&mut self, previous: &Self) -> anyhow::Result<()> {
+        if self.profile_uid != previous.profile_uid {
+            return Ok(());
+        }
+        let Some(chain) = previous.active_proxy_chain.as_ref() else {
+            // Do not touch dialer-proxy links supplied by the profile itself.
+            return Ok(());
+        };
+        if let Some(names) = chain.as_sequence() {
+            let proxies = self.config.as_ref().and_then(|config| config.get("proxies"));
+            for name in names {
+                anyhow::ensure!(
+                    proxies
+                        .and_then(Value::as_sequence)
+                        .is_some_and(|proxies| { proxies.iter().any(|proxy| proxy.get("name") == Some(name)) }),
+                    "Cannot preserve active proxy chain: node {:?} is missing from the refreshed profile",
+                    name.as_str()
+                );
+            }
+        }
+        self.update_proxy_chain_config(Some(chain.clone()));
+        Ok(())
+    }
+
     #[inline]
     pub fn patch_config(&mut self, patch: &Mapping) {
         let config = if let Some(config) = self.config.as_mut() {
@@ -58,6 +86,10 @@ impl IRuntime {
             return;
         };
 
+        self.active_proxy_chain = proxy_chain_config
+            .clone()
+            .filter(|value| value.as_sequence().is_some_and(|nodes| nodes.len() >= 2));
+
         if let Some(Value::Sequence(proxies)) = config.get_mut("proxies") {
             proxies.iter_mut().for_each(|proxy| {
                 if let Some(proxy) = proxy.as_mapping_mut()
@@ -81,5 +113,133 @@ impl IRuntime {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IRuntime;
+    use anyhow::{Context as _, Result};
+    use clash_verge_draft::Draft;
+    use serde_yaml_ng::Value;
+
+    fn runtime(profile: &str, port: u16) -> Result<IRuntime> {
+        Ok(IRuntime {
+            config: Some(serde_yaml_ng::from_str(&format!(
+                "proxies:\n  - {{name: entry, port: {port}}}\n  - {{name: middle}}\n  - {{name: exit}}\n"
+            ))?),
+            profile_uid: Some(profile.into()),
+            ..IRuntime::default()
+        })
+    }
+
+    fn chain() -> Value {
+        Value::Sequence(vec!["entry".into(), "middle".into(), "exit".into()])
+    }
+
+    fn proxies(runtime: &IRuntime) -> Result<&Vec<Value>> {
+        runtime
+            .config
+            .as_ref()
+            .and_then(|config| config.get("proxies"))
+            .and_then(Value::as_sequence)
+            .context("test config must contain proxies")
+    }
+
+    #[test]
+    fn refresh_preserves_chain_and_uses_new_node_configuration() -> Result<()> {
+        let mut current = runtime("a", 1000)?;
+        current.update_proxy_chain_config(Some(chain()));
+
+        for port in 1001..1004 {
+            let mut refreshed = runtime("a", port)?;
+            refreshed.inherit_proxy_chain(&current)?;
+            let nodes = proxies(&refreshed)?;
+            assert_eq!(nodes[0]["port"], Value::from(port));
+            assert!(nodes[0].get("dialer-proxy").is_none());
+            assert_eq!(nodes[1]["dialer-proxy"], Value::from("entry"));
+            assert_eq!(nodes[2]["dialer-proxy"], Value::from("middle"));
+            assert_eq!(refreshed.active_proxy_chain, Some(chain()));
+            current = refreshed;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn refresh_without_user_chain_preserves_profile_dialers() -> Result<()> {
+        let current = runtime("a", 1000)?;
+        let mut refreshed = runtime("a", 2000)?;
+        refreshed.config = Some(serde_yaml_ng::from_str(
+            "proxies:\n  - {name: entry}\n  - {name: exit, dialer-proxy: entry}\n",
+        )?);
+        let expected = refreshed.config.clone();
+        refreshed.inherit_proxy_chain(&current)?;
+        assert_eq!(refreshed.config, expected);
+        assert!(refreshed.active_proxy_chain.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn manual_disconnect_is_not_restored_on_refresh() -> Result<()> {
+        let mut current = runtime("a", 1000)?;
+        current.update_proxy_chain_config(Some(chain()));
+        current.update_proxy_chain_config(None);
+        assert!(current.active_proxy_chain.is_none());
+        assert!(proxies(&current)?.iter().all(|node| node.get("dialer-proxy").is_none()));
+
+        let mut refreshed = runtime("a", 2000)?;
+        refreshed.inherit_proxy_chain(&current)?;
+        assert!(refreshed.active_proxy_chain.is_none());
+        assert!(
+            proxies(&refreshed)?
+                .iter()
+                .all(|node| node.get("dialer-proxy").is_none())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn switching_profiles_does_not_inherit_the_previous_chain() -> Result<()> {
+        let mut current = runtime("a", 1000)?;
+        current.update_proxy_chain_config(Some(chain()));
+        let mut other = runtime("b", 2000)?;
+        let expected = other.config.clone();
+        other.inherit_proxy_chain(&current)?;
+        assert_eq!(other.config, expected);
+        assert!(other.active_proxy_chain.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn missing_chain_node_rejects_refresh_without_partial_links() -> Result<()> {
+        let mut current = runtime("a", 1000)?;
+        current.update_proxy_chain_config(Some(chain()));
+        let mut refreshed = runtime("a", 2000)?;
+        refreshed.config = Some(serde_yaml_ng::from_str(
+            "proxies:\n  - {name: entry}\n  - {name: exit}\n",
+        )?);
+        let expected = refreshed.config.clone();
+        let error = refreshed
+            .inherit_proxy_chain(&current)
+            .err()
+            .context("missing middle node must reject refresh")?;
+        assert!(error.to_string().contains("middle"));
+        assert_eq!(refreshed.config, expected);
+        assert!(refreshed.active_proxy_chain.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn failed_runtime_update_rolls_back_chain_intent() -> Result<()> {
+        let mut current = runtime("a", 1000)?;
+        current.update_proxy_chain_config(Some(chain()));
+        let draft = Draft::new(current);
+        draft.edit_draft(|runtime| runtime.update_proxy_chain_config(None));
+        draft.discard();
+        let mut refreshed = runtime("a", 2000)?;
+        refreshed.inherit_proxy_chain(&draft.latest_arc())?;
+        assert_eq!(refreshed.active_proxy_chain, Some(chain()));
+        assert_eq!(proxies(&refreshed)?[2]["dialer-proxy"], Value::from("middle"));
+        Ok(())
     }
 }

--- a/src-tauri/src/core/manager/config.rs
+++ b/src-tauri/src/core/manager/config.rs
@@ -138,6 +138,7 @@ impl CoreManager {
                 config: Some(clash_config.to_owned()),
                 exists_keys: HashSet::new(),
                 chain_logs: Default::default(),
+                ..IRuntime::default()
             }
         });
 


### PR DESCRIPTION
## Summary

Preserve an explicitly connected proxy chain when the active profile is regenerated, including subscription refreshes.

Currently, connecting a chain only writes `dialer-proxy` into `IRuntime.config`. `Config::generate_with_profiles` replaces that runtime with fresh enhanced profile output, so the links disappear even though the user never disconnected the chain. Traffic selecting the exit node can then use it directly.

## Changes

- Keep the active manual chain and its profile UID as session-only runtime state.
- Reapply that chain to the freshly generated nodes before core validation/loading, retaining updated node settings.
- Clear the intent on manual disconnect; do not carry it across profile switches.
- Leave profile-provided `dialer-proxy` settings alone when no manual chain is active.
- Reject a same-profile refresh if a chain member is missing, using the existing runtime transaction to retain the previous configuration instead of silently applying a partial/single-node route.

This does not add cross-restart persistence, change group selection/rules, or guarantee uninterrupted sockets during a core reload. Existing explicit chain-toggle behavior is unchanged. In particular, this is separate from #7537 (preserving extension-owned links during a toggle) and #7670 (restoring the selected group after page navigation).

## Reproduction / manual verification

1. Select a profile and connect a two-node chain in the proxy page.
2. Refresh that same subscription without pressing Disconnect.
3. Check the generated runtime: the exit node should still have `dialer-proxy` pointing to the entry node, while refreshed node settings are used.
4. Repeat the refresh, then manually disconnect and refresh again: the manual chain must not return.
5. Switch to a different profile: the previous profile's manual chain must not be injected.

## Field validation

A macOS arm64 A/B build was also tested against a real two-node chain and a profile containing many VLESS/AnyTLS nodes:

- The selected exit node carried the expected `dialer-proxy` link to the entry node.
- In three isolated rounds, the exit node failed when dialed directly and succeeded when reached through the preserved entry node.
- Broad batch-delay timeouts also affected nodes without `dialer-proxy` and reproduced in another Mihomo GUI, so that behavior is separate from this runtime-chain preservation change.

The PR therefore remains scoped to retaining explicit chain intent across same-profile regeneration; it does not alter delay-test concurrency, retry behavior, or test URLs.

## Automated coverage

Six regression tests cover repeated regeneration with updated node settings, profile-owned links without a manual chain, explicit disconnect, profile switching, a missing chain member, and rollback of a failed runtime update.

Verified on macOS arm64 with Rust 1.98.1 after rebasing onto the latest `dev`:

- `cargo test -p clash-verge --features clippy config::runtime::tests --locked`: 6 passed.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy --locked --all-targets --all-features -- -D warnings` (from `src-tauri`, equivalent to `cargo clippy-all`): passed.
- `git diff --check`: passed.

Only backend Rust files are changed; no frontend or generated/binary artifacts are included.

