### PR TITLE
fix(clippy): Restrict 2 imports to macOS only

### DIFF
--- a/src-tauri/src/core/proxy_control.rs
+++ b/src-tauri/src/core/proxy_control.rs
@@ -1081,6 +1081,9 @@ mod tests {
     use super::{SystemProxyStateUnknown, is_reportable_given, rollback_failure};
 
     #[cfg(target_os = "macos")]
+    use super::service_apply_result;
+
+    #[cfg(target_os = "macos")]
     #[test]
     fn an_enable_the_os_never_received_is_never_reported_as_applied() {
         let requested = MacosProxyConfig::Global {

--- a/src-tauri/src/core/proxy_control.rs
+++ b/src-tauri/src/core/proxy_control.rs
@@ -1078,7 +1078,7 @@ mod tests {
         assert_eq!(refusal_classification(None), SysproxyFailure::PrivilegeRequired);
     }
 
-    use super::{SystemProxyStateUnknown, is_reportable_given, rollback_failure, service_apply_result};
+    use super::{SystemProxyStateUnknown, is_reportable_given, rollback_failure};
 
     #[cfg(target_os = "macos")]
     #[test]

--- a/src-tauri/src/core/sysopt.rs
+++ b/src-tauri/src/core/sysopt.rs
@@ -574,7 +574,7 @@ mod tests {
         AuthoritativeState, BYPASS_SEPARATOR, DEFAULT_BYPASS, OsProxyState, ProxyApplyStep, SystemProxyStateUnknown,
         authoritative_state, authoritative_state_from, classify_os_proxy_state, disable_both,
         disable_until_the_last_write_is_ours, first_failure, format_bypass, proxy_apply_steps,
-        recover_from_failed_write, skip_without_network_service, target_is_already_in_place,
+        recover_from_failed_write, target_is_already_in_place,
     };
     use parking_lot::Mutex;
     use std::collections::VecDeque;

--- a/src-tauri/src/core/sysopt.rs
+++ b/src-tauri/src/core/sysopt.rs
@@ -581,6 +581,9 @@ mod tests {
     use sysproxy::{Autoproxy, Sysproxy};
 
     #[cfg(target_os = "macos")]
+    use super::skip_without_network_service;
+
+    #[cfg(target_os = "macos")]
     #[test]
     fn a_machine_with_no_network_service_has_nothing_to_turn_off() {
         for missing in [


### PR DESCRIPTION
按照 Clippy 的建议，拆分2处标识符导入，将导入以条件编译限定为 macOS 专属：

<div align="center">

|                  标识符路径                   |             导入名             |
| :-------------------------------------------: | :----------------------------: |
| `src-tauri\src\core\proxy_control.rs:1081:81` |     `service_apply_result`     |
|     `src-tauri\src\core\sysopt.rs:577:36`     | `skip_without_network_service` |

</div>

<details><summary>Windows 本地日志</summary><p>

```log
23:26:09 D:\...\clash-verge-rev [dev ≡] 0ms pwsh
$ git ci   # 自定义 Git Alias
...... (frontend-check 部分正常，以下 lint-clippy 开始报错)
warning: clash-verge@2.5.4: Skipping tauri_build during Clippy
note: did not finalize incremental compilation session directory `\\?\D:\Repository\clash-verge-rev\target\debug\incremental\clash_verge_limiter-00zgc9ab0dlot\s-hlya6gk5jh-0ub0ydw-working`: 拒绝访问。 (os error 5)
  |
  = help: the next build will not be able to reuse work from this compilation

note: did not finalize incremental compilation session directory `\\?\D:\Repository\clash-verge-rev\target\debug\incremental\app_lib-3tgq770nwodkj\s-hlya6gzfqy-0ug4agy-working`: 拒绝访问。 (os error 5)
  |
  = help: the next build will not be able to reuse work from this compilation

    Checking clash-verge v2.5.4 (D:\Repository\clash-verge-rev\src-tauri)
error: unused import: `service_apply_result`
    --> src-tauri\src\core\proxy_control.rs:1081:81
     |
1081 |     use super::{SystemProxyStateUnknown, is_reportable_given, rollback_failure, service_apply_result};
     |                                                                                 ^^^^^^^^^^^^^^^^^^^^
     |
     = note: `-D unused-imports` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(unused_imports)]`

error: unused import: `skip_without_network_service`
   --> src-tauri\src\core\sysopt.rs:577:36
    |
577 |         recover_from_failed_write, skip_without_network_service, target_is_already_in_place,
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: clash-verge@2.5.4: Skipping tauri_build during Clippy
error: could not compile `clash-verge` (lib test) due to 2 previous errors
```

</p></details>

- 参见 [Windows Logs](https://github.com/clash-verge-rev/clash-verge-rev/actions/runs/33754241601/job/100644678550?pr=7230#step:11:1385)
- 参见 [Linux Logs](https://github.com/clash-verge-rev/clash-verge-rev/actions/runs/33754241601/job/100644678619?pr=7230#step:11:1452)
- 参见 [macOS Logs](https://github.com/clash-verge-rev/clash-verge-rev/actions/runs/33775051212/job/100714541169#step:11:1403)