### PR TITLE
fix(tun): preserve explicitly disabled DNS IPv6

### DIFF
--- a/src-tauri/src/enhance/tun.rs
+++ b/src-tauri/src/enhance/tun.rs
@@ -25,6 +25,9 @@ pub fn use_tun(mut config: Mapping, enable: bool) -> Mapping {
         });
         let ipv6_key = Value::from("ipv6");
         let ipv6_val = config.get(&ipv6_key).and_then(|v| v.as_bool()).unwrap_or(false);
+        // Accepting IPv6 connections does not require returning AAAA DNS answers.
+        // Preserve an explicit DNS opt-out, while still honoring the core switch.
+        let dns_ipv6 = ipv6_val && dns_val.get(&ipv6_key).and_then(Value::as_bool).unwrap_or(true);
 
         let current_mode = dns_val
             .get(Value::from("enhanced-mode"))
@@ -33,7 +36,7 @@ pub fn use_tun(mut config: Mapping, enable: bool) -> Mapping {
 
         if current_mode == "fake-ip" || !dns_val.contains_key(Value::from("enhanced-mode")) {
             revise!(dns_val, "enable", true);
-            revise!(dns_val, "ipv6", ipv6_val);
+            revise!(dns_val, "ipv6", dns_ipv6);
 
             if !dns_val.contains_key(Value::from("enhanced-mode")) {
                 revise!(dns_val, "enhanced-mode", "fake-ip");
@@ -43,7 +46,7 @@ pub fn use_tun(mut config: Mapping, enable: bool) -> Mapping {
                 revise!(dns_val, "fake-ip-range", "198.18.0.1/16");
             }
 
-            if ipv6_val && !dns_val.contains_key(Value::from("fake-ip-range6")) {
+            if dns_ipv6 && !dns_val.contains_key(Value::from("fake-ip-range6")) {
                 revise!(dns_val, "fake-ip-range6", "2001:2::0/64");
             }
 
@@ -68,4 +71,53 @@ pub fn use_tun(mut config: Mapping, enable: bool) -> Mapping {
     revise!(config, "tun", tun_val);
 
     config
+}
+
+#[cfg(test)]
+mod tests {
+    use super::use_tun;
+    use serde_yaml_ng::{Mapping, Value};
+
+    #[tokio::test]
+    async fn explicit_dns_ipv6_opt_out_survives_tun_regeneration() -> anyhow::Result<()> {
+        for mode in ["", "  enhanced-mode: fake-ip\n"] {
+            let input =
+                format!("ipv6: true\ndns:\n  ipv6: false\n  nameserver: [223.5.5.5]\n{mode}tun:\n  stack: mixed\n");
+            let config: Mapping = serde_yaml_ng::from_str(&input)?;
+            let enabled = use_tun(config, true);
+            for result in [&enabled, &use_tun(use_tun(enabled.clone(), false), true)] {
+                assert_eq!(result.get("ipv6"), Some(&Value::from(true)));
+                assert_eq!(result["dns"]["ipv6"], Value::from(false));
+                assert!(result["dns"].get("fake-ip-range6").is_none());
+                assert_eq!(result["dns"]["nameserver"][0], Value::from("223.5.5.5"));
+                assert_eq!(result["tun"]["enable"], Value::from(true));
+                assert_eq!(result["tun"]["stack"], Value::from("mixed"));
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dns_ipv6_still_defaults_to_and_is_limited_by_the_core_switch() -> anyhow::Result<()> {
+        for (input, expected) in [
+            ("ipv6: true", true),
+            ("ipv6: true\ndns: {ipv6: true}", true),
+            ("ipv6: false\ndns: {ipv6: true}", false),
+            ("dns: {ipv6: true}", false),
+        ] {
+            let result = use_tun(serde_yaml_ng::from_str(input)?, true);
+            assert_eq!(result["dns"]["ipv6"], Value::from(expected), "{input}");
+            assert_eq!(result["dns"].get("fake-ip-range6").is_some(), expected, "{input}");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn explicit_dns_ipv6_opt_out_preserves_an_existing_range() -> anyhow::Result<()> {
+        let config = serde_yaml_ng::from_str("ipv6: true\ndns: {ipv6: false, fake-ip-range6: '2001:2::/64'}")?;
+        let result = use_tun(config, true);
+        assert_eq!(result["dns"]["ipv6"], Value::from(false));
+        assert_eq!(result["dns"]["fake-ip-range6"], Value::from("2001:2::/64"));
+        Ok(())
+    }
 }


### PR DESCRIPTION
When TUN is enabled with the core's `ipv6: true` and a profile's explicit `dns.ipv6: false`, `use_tun` currently replaces the DNS opt-out with `true`. Regenerating the config or toggling TUN therefore changes the requested DNS behavior.

The core's acceptance of IPv6 destinations and DNS AAAA answers are separate settings. A client can connect to an IPv6 literal while the local DNS resolver continues to return only IPv4 answers. This combination is useful for clients such as DingTalk that can supply their own IPv6 destinations.

This change preserves an explicit `dns.ipv6: false` during TUN enhancement. When DNS IPv6 is unspecified, it still follows the core switch; disabling core IPv6 still disables DNS IPv6. A default IPv6 fake-IP range is added only when DNS IPv6 is actually enabled, and existing ranges are retained. The app-owned top-level IPv6 setting, manual override precedence, redir-host behavior, and DNS overwrite page are unchanged.

Reproduction: set core IPv6 on in Settings, use `dns: { ipv6: false, enhanced-mode: fake-ip }` in a profile with DNS Overwrite off, then enable TUN. Before this patch the generated DNS setting is `true`; after it remains `false`, including after TUN off/on.

Validation on Windows:

- `cargo fmt --all -- --check`
- `cargo clippy-all`
- `cargo test -p clash-verge --lib --features clippy enhance:: -- --test-threads=1`: 47 passed.
- The three new regression tests compiled against the original `tun.rs` produce two failures and one pass; all three pass against the changed source.

This does not automatically enable a user's disabled core IPv6 setting, and it does not claim to fix every DingTalk login failure. The companion local repair uses the app-owned setting plus a DNS merge override for currently installed versions; it is not part of this PR.
