### PR TITLE
fix(proxy-group): prevent PASS-RULE from being filtered out

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 修复 i18n 清理脚本因导入方式错误而无法运行的问题
 修复 Linux 桌面环境下主题切换时应用外观不跟随的问题
 修复 Gemini 测试正确性
+修复代理组节点 `PASS-RULE` 被过滤丢失的问题
 
 <details>
 <summary><strong> ✨ 新增功能 </strong></summary>

--- a/src-tauri/src/enhance/mod.rs
+++ b/src-tauri/src/enhance/mod.rs
@@ -562,7 +562,8 @@ async fn apply_builtin_scripts(mut config: Mapping, clash_core: Option<String>, 
 }
 
 fn cleanup_proxy_groups(mut config: Mapping) -> Mapping {
-    const BUILTIN_POLICIES: &[&str] = &["DIRECT", "REJECT", "REJECT-DROP", "PASS"];
+    // built-in proxies docs: https://wiki.metacubex.one/config/proxies/built-in
+    const BUILTIN_POLICIES: &[&str] = &["DIRECT", "REJECT", "REJECT-DROP", "PASS", "PASS-RULE"];
 
     let proxy_names = config
         .get("proxies")


### PR DESCRIPTION
Closes: #7774 

built-in proxies docs: https://wiki.metacubex.one/config/proxies/built-in

默认内置代理节点添加 `PASS-RULE`，避免过滤丢失该代理节点