### PR TITLE
refactor: extract sidebar context menu into standalone component

### DIFF
--- a/src/components/layout/layout-sidebar.tsx
+++ b/src/components/layout/layout-sidebar.tsx
@@ -1,5 +1,5 @@
 import { DragDropProvider, KeyboardSensor, PointerSensor } from '@dnd-kit/react'
-import { Box, List, Menu, MenuItem, SvgIcon } from '@mui/material'
+import { Box, List, SvgIcon } from '@mui/material'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -14,6 +14,7 @@ import { SortableItem } from '../base'
 
 import { LayoutItem } from './layout-item'
 import { LayoutTraffic } from './layout-traffic'
+import { SidebarContextMenu } from './sidebar-context-menu'
 import { UpdateButton } from './update-button'
 
 type MenuContextPosition = { top: number; left: number }
@@ -176,46 +177,16 @@ export const LayoutSidebar = (props: LayoutSidebarProps) => {
       </List>
 
       {/* Context menu */}
-      <Menu
-        open={Boolean(menuContextPosition)}
+      <SidebarContextMenu
+        position={menuContextPosition}
         onClose={handleMenuContextClose}
-        anchorReference="anchorPosition"
-        anchorPosition={
-          menuContextPosition
-            ? {
-                top: menuContextPosition.top,
-                left: menuContextPosition.left,
-              }
-            : undefined
-        }
-        transitionDuration={200}
-        slotProps={{
-          list: {
-            sx: { py: 0.5 },
-          },
-        }}
-      >
-        <MenuItem onClick={handleToggleNavCollapsed} dense>
-          {isCollapsed
-            ? t('layout.components.navigation.menu.expandNavBar')
-            : t('layout.components.navigation.menu.collapseNavBar')}
-        </MenuItem>
-        <MenuItem
-          onClick={menuUnlocked ? handleLockMenu : handleUnlockMenu}
-          dense
-        >
-          {menuUnlocked
-            ? t('layout.components.navigation.menu.lock')
-            : t('layout.components.navigation.menu.unlock')}
-        </MenuItem>
-        <MenuItem
-          onClick={handleResetMenuOrder}
-          dense
-          disabled={isDefaultOrder}
-        >
-          {t('layout.components.navigation.menu.restoreDefaultOrder')}
-        </MenuItem>
-      </Menu>
+        isSidebarCollapsed={isCollapsed}
+        onToggleSidebar={handleToggleNavCollapsed}
+        isMenuOrderUnlocked={menuUnlocked}
+        isMenuOrderDefault={isDefaultOrder}
+        onToggleMenuLock={menuUnlocked ? handleLockMenu : handleUnlockMenu}
+        onResetMenuOrder={handleResetMenuOrder}
+      />
 
       {/* Traffic */}
       <div className="the-traffic">

--- a/src/components/layout/sidebar-context-menu.tsx
+++ b/src/components/layout/sidebar-context-menu.tsx
@@ -1,0 +1,83 @@
+import { Menu, MenuItem } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+
+interface ContextMenuItem {
+  key: string
+  label: string
+  onClick: () => void
+  disabled?: boolean
+}
+
+interface SidebarContextMenuProps {
+  // Menu visibility/position
+  position: { top: number; left: number } | null
+  onClose: () => void
+
+  // Sidebar controls
+  isSidebarCollapsed: boolean
+  onToggleSidebar: () => void
+
+  // Navigation order controls
+  isMenuOrderUnlocked: boolean
+  isMenuOrderDefault: boolean
+  onToggleMenuLock: () => void
+  onResetMenuOrder: () => void
+}
+
+/**
+ * Context menu for sidebar actions.
+ */
+export const SidebarContextMenu = (props: SidebarContextMenuProps) => {
+  const {
+    position,
+    onClose,
+    isSidebarCollapsed,
+    onToggleSidebar,
+    isMenuOrderUnlocked,
+    isMenuOrderDefault,
+    onToggleMenuLock,
+    onResetMenuOrder,
+  } = props
+
+  const { t } = useTranslation()
+
+  const menuItems: ContextMenuItem[] = [
+    {
+      key: 'toggle-sidebar',
+      label: isSidebarCollapsed
+        ? t('layout.components.navigation.menu.expandNavBar')
+        : t('layout.components.navigation.menu.collapseNavBar'),
+      onClick: onToggleSidebar,
+    },
+    {
+      key: 'toggle-menu-lock',
+      label: isMenuOrderUnlocked
+        ? t('layout.components.navigation.menu.lock')
+        : t('layout.components.navigation.menu.unlock'),
+      onClick: onToggleMenuLock,
+    },
+    {
+      key: 'reset-menu-order',
+      label: t('layout.components.navigation.menu.restoreDefaultOrder'),
+      onClick: onResetMenuOrder,
+      disabled: isMenuOrderDefault,
+    },
+  ]
+
+  return (
+    <Menu
+      open={Boolean(position)}
+      onClose={onClose}
+      anchorReference="anchorPosition"
+      anchorPosition={position ?? undefined}
+      transitionDuration={200}
+      slotProps={{ list: { sx: { py: 0.5 } } }}
+    >
+      {menuItems.map(({ key, label, onClick, disabled }) => (
+        <MenuItem key={key} onClick={onClick} disabled={disabled} dense>
+          {label}
+        </MenuItem>
+      ))}
+    </Menu>
+  )
+}


### PR DESCRIPTION
### Summary
Decomposed `LayoutSidebar` to simplify navigation state logic and improve layout maintainability.

### Changes
- **Extracted `SidebarContextMenu`**: Isolated context menu UI and reduced `LayoutSidebar` complexity
- **Data-Driven Menu Rendering**: Replaced imperative JSX with declarative item configuration
- **Standardized Component API**: Grouped explicit state flags for cleaner prop passing and state control