### PR TITLE
fix(proxy): verify runtime links before showing a connected chain

### DIFF
--- a/src/components/proxy/proxy-chain-model.test.ts
+++ b/src/components/proxy/proxy-chain-model.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest'
+
+import { isProxyChainConnected } from './proxy-chain-model'
+
+const chain = [{ name: 'entry' }, { name: 'exit' }]
+const connected = [{ name: 'entry' }, { name: 'exit', 'dialer-proxy': 'entry' }]
+
+test('selecting the exit does not connect a chain whose runtime links were lost', () => {
+  expect(isProxyChainConnected(chain, 'exit', connected)).toBe(true)
+  expect(isProxyChainConnected(chain, 'exit', chain)).toBe(false)
+  expect(isProxyChainConnected(chain, 'exit', undefined)).toBe(false)
+  expect(isProxyChainConnected(chain, 'entry', connected)).toBe(false)
+  expect(isProxyChainConnected(chain, undefined, connected)).toBe(false)
+})
+
+test('editing the entry or an intermediate hop requires reconnecting the chain', () => {
+  const edited = [{ name: 'other-entry' }, { name: 'exit' }]
+  expect(isProxyChainConnected(edited, 'exit', connected)).toBe(false)
+
+  const threeHops = [{ name: 'entry' }, { name: 'middle' }, { name: 'exit' }]
+  const runtime = [
+    { name: 'entry' },
+    { name: 'middle', 'dialer-proxy': 'entry' },
+    { name: 'exit', 'dialer-proxy': 'middle' },
+  ]
+  expect(isProxyChainConnected(threeHops, 'exit', runtime)).toBe(true)
+  runtime[1]['dialer-proxy'] = undefined
+  expect(isProxyChainConnected(threeHops, 'exit', runtime)).toBe(false)
+  expect(isProxyChainConnected([{ name: 'exit' }], 'exit', connected)).toBe(
+    false,
+  )
+})

--- a/src/components/proxy/proxy-chain-model.ts
+++ b/src/components/proxy/proxy-chain-model.ts
@@ -14,6 +14,34 @@ export interface ProxyChainItem {
   delay?: number
 }
 
+export const isProxyChainConnected = (
+  items: readonly Pick<ProxyChainItem, 'name'>[],
+  selectedExit: string | undefined,
+  runtimeProxies: unknown,
+): boolean => {
+  if (
+    items.length < 2 ||
+    selectedExit !== items.at(-1)?.name ||
+    !Array.isArray(runtimeProxies)
+  ) {
+    return false
+  }
+
+  return items
+    .slice(1)
+    .every((item, index) =>
+      runtimeProxies.some(
+        (proxy: unknown) =>
+          typeof proxy === 'object' &&
+          proxy !== null &&
+          'name' in proxy &&
+          proxy.name === item.name &&
+          'dialer-proxy' in proxy &&
+          proxy['dialer-proxy'] === items[index].name,
+      ),
+    )
+}
+
 export const rebindProxyChainItems = (
   items: readonly ProxyChainItem[],
   candidates: readonly ProxyNodeView[],

--- a/src/components/proxy/proxy-chain.tsx
+++ b/src/components/proxy/proxy-chain.tsx
@@ -51,7 +51,11 @@ import {
 } from '@/types/proxy-view'
 import { debugLog } from '@/utils/debug'
 
-import { rebindProxyChainItems, type ProxyChainItem } from './proxy-chain-model'
+import {
+  isProxyChainConnected,
+  rebindProxyChainItems,
+  type ProxyChainItem,
+} from './proxy-chain-model'
 
 const chainPointerSensor = PointerSensor.configure({
   activationConstraints: () => undefined,
@@ -336,7 +340,8 @@ export const ProxyChain = ({
   const chainWarning = t('proxies.page.chain.warning')
   const { proxyView } = useProxiesData()
   const { refreshProxy } = useAppRefreshers()
-  const { data: runtimeConfig } = useRuntimeConfig(true)
+  const { data: runtimeConfig, refetch: refreshRuntimeConfig } =
+    useRuntimeConfig(true)
   const [isConnecting, setIsConnecting] = useState(false)
   const recordSelection = useRecordSelection()
   const markUnsavedChanges = useCallback(() => {
@@ -370,30 +375,17 @@ export const ProxyChain = ({
   )
 
   const isConnected = useMemo(() => {
-    if (!proxyView || currentProxyChain.length === 0) {
-      return false
-    }
+    const selectedExit =
+      mode === 'global'
+        ? proxyView?.global?.now
+        : proxyView?.groups.find((group) => group.name === selectedGroup)?.now
 
-    const lastNode = currentProxyChain[currentProxyChain.length - 1]
-    if (localStorage.getItem('proxy-chain-exit-node') === lastNode.name) {
-      return true
-    }
-    if (currentProxyChain.length < 2) return false
-
-    if (mode === 'global') {
-      return proxyView.global?.now === lastNode.name
-    }
-
-    if (!selectedGroup) {
-      return false
-    }
-
-    const proxyChainGroup = proxyView.groups.find(
-      (group) => group.name === selectedGroup,
+    return isProxyChainConnected(
+      currentProxyChain,
+      selectedExit,
+      (runtimeConfig as RuntimeConfigWithProxySequence | null)?.proxies,
     )
-
-    return proxyChainGroup?.now === lastNode.name
-  }, [proxyView, currentProxyChain, mode, selectedGroup])
+  }, [proxyView, currentProxyChain, mode, selectedGroup, runtimeConfig])
 
   // 监听链的变化，但排除从配置加载的情况
   const chainLengthRef = useRef(currentProxyChain.length)
@@ -472,7 +464,7 @@ export const ProxyChain = ({
         localStorage.removeItem('proxy-chain-items')
 
         await closeAllConnections()
-        await refreshProxy()
+        await Promise.all([refreshProxy(), refreshRuntimeConfig()])
 
         onUpdateChain([])
       } catch (error) {
@@ -524,7 +516,7 @@ export const ProxyChain = ({
       localStorage.setItem('proxy-chain-exit-node', lastNode.name)
 
       // 刷新代理信息以更新连接状态
-      refreshProxy()
+      await Promise.all([refreshProxy(), refreshRuntimeConfig()])
       debugLog('Successfully connected to proxy chain')
     } catch (error) {
       console.error('Failed to connect to proxy chain:', error)
@@ -537,6 +529,7 @@ export const ProxyChain = ({
     isConnected,
     t,
     refreshProxy,
+    refreshRuntimeConfig,
     mode,
     proxyView,
     selectedGroup,


### PR DESCRIPTION
## Problem

The proxy-chain page can show Disconnect while the displayed chain is not applied. For example, select `exit` in a proxy group, then arrange `entry -> exit` without connecting it: the existing predicate accepts the selected exit even when `exit` has no `dialer-proxy`. A cached exit name can also report a connection after the runtime links disappear, or after changing the entry while keeping the same exit.

This addresses the misleading connected state associated with #6646 and #7012. It does not resolve the separate lifecycle problem that removes runtime chains; #7856 proposes preserving them across profile refreshes.

## Approach

Require both the selected exit and every adjacent `dialer-proxy` relationship to match the displayed chain in the runtime configuration. Use the runtime-config query already loaded by the page, and refresh it alongside proxy selections after connecting or disconnecting. Cached exit metadata is no longer evidence that a chain is connected.

Two focused regression tests cover losing the runtime links while the exit stays selected, and editing an entry or intermediate hop while retaining the exit. Valid two-hop and three-hop chains remain connected. These cases distinguish an applied chain from the selection-only condition that caused the false positive.

## Scope

Changes are limited to the chain status predicate, its refresh points, and its regression tests. This checks applied configuration, not node reachability, and adds no persistence or dependency changes.

Validation: all 12 tests pass with `pnpm test`; `pnpm typecheck`, `pnpm lint`, `pnpm web:build`, formatting of the three changed files, and `git diff --cached --check` pass. Native application packaging and interactive testing of a rebuilt desktop app were not performed.

Assisted by: GPT-6
