### PR TITLE
chore(devcontainers): Pin `pnpm` version for Nodejs feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:2": {
       "version": "24.21.0",
-      "packageManager": "pnpm"
+      "pnpmVersion": "12.3.3"
     },
     "ghcr.io/devcontainers/features/rust:1": {
       "version": "1.98.1",


### PR DESCRIPTION
## Problem

When initializing the development environment of this repository in _GitHub Codespaces_ or local _Dev Containers_, latest stable version (currently `v12.3.4`) of `pnpm` will be installed globally. 

This will cause errors when running some of scripts pre-defined in `package.json`, complained as "version conflicts". In GitHub Codespaces, this issue have to be handled manually - by reinstalling `pnpm` to the exact version defined in `package.json` (currently `v12.3.3`). 

## Approach

According to [feature docs](https://github.com/devcontainers/features/blob/main/src/node/README.md) of Nodejs, there's an implicit property `pnpmVersion` which defaults to `latest`. 

Explicitly specify that property to exactly match `packageManager` defined in `package.json` would be the best solution. 

## Scope

- Explicitly specify `pnpmVersion` for node feature

-----

## Approach

According to [commit history](https://github.com/devcontainers/features/commits/main/src/node/README.md) of feature docs, property `packageManager` was never be mentioned. This is a useless and even incorrect property. 

## Scope

- Remove `packageManager` as documentation never mentioned it